### PR TITLE
fix consuming dust schematics in packagers

### DIFF
--- a/src/Java/gtPlusPlus/core/util/minecraft/ItemUtils.java
+++ b/src/Java/gtPlusPlus/core/util/minecraft/ItemUtils.java
@@ -451,7 +451,7 @@ public class ItemUtils {
 		final ItemStack smallDust = ItemUtils.getSimpleStack(output[1]);
 		final ItemStack tinyDust = ItemUtils.getSimpleStack(output[2]);
 
-		CORE.RA.addpackagerRecipe(ItemList.Schematic_Dust.get(1), smallDust, tinyDust, normalDust);
+		CORE.RA.addpackagerRecipe(ItemList.Schematic_Dust.get(0), smallDust, tinyDust, normalDust);
 		
 		if (ItemUtils.checkForInvalidItems(tinyDust) && ItemUtils.checkForInvalidItems(normalDust)) {
 			if (RecipeUtils.addShapedRecipe(


### PR DESCRIPTION
@Dream-Master please help tag GTNewHorizons/developers. Somehow it's not in the reviewers list on my end. Also please add discord webhooks for this repo thanks.

https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/8100

We need to figure out which commit we were using and cherrypick the few bugfix commits onto that one. GT++'s unreleased commits apparently contains more bugs than we anticipated.