### PR TITLE
fix nitric acid dupe

### DIFF
--- a/src/Java/gtPlusPlus/core/recipe/RECIPES_GREGTECH.java
+++ b/src/Java/gtPlusPlus/core/recipe/RECIPES_GREGTECH.java
@@ -131,15 +131,15 @@ public class RECIPES_GREGTECH {
 						CI.getPinkCatalyst(0),
 				},
 				new FluidStack[] {
-						FluidUtils.getFluidStack(GenericChem.Nitrogen_Dioxide, 3000),
-						FluidUtils.getAir(7000)
+						FluidUtils.getFluidStack(GenericChem.Nitrogen_Dioxide, 4000),
+						FluidUtils.getAir(4000),
+						FluidUtils.getWater(2000),
 				},
 				new ItemStack[] {
 
 				},
 				new FluidStack[] {
-						FluidUtils.getFluidStack("nitricacid", 4000),	
-						FluidUtils.getWater(2000),				
+						FluidUtils.getFluidStack("nitricacid", 4000),
 				},
 				10 * 20,
 				480,


### PR DESCRIPTION
the corret reaction equation should be 
`4*NO2 + O2 + 2*H2O === 4*HNO3`
instead of
`3*NO2 + O2 === 4*HNO3 + 2*H2O` which will lead to nitric acid dupe.