### PR TITLE
Tree Growth Simulator balancing + structurelib

### DIFF
--- a/src/Java/gtPlusPlus/core/handler/COMPAT_HANDLER.java
+++ b/src/Java/gtPlusPlus/core/handler/COMPAT_HANDLER.java
@@ -118,7 +118,7 @@ public class COMPAT_HANDLER {
 			Gregtech4Content.run();
 			GregtechIndustrialFuelRefinery.run();
 			GregtechTreeFarmerTE.run();
-			//GregtechIndustrialTreeFarm.run();
+			GregtechIndustrialTreeFarm.run();
 			GregtechIndustrialSifter.run();
 			GregtechSimpleWasher.run();
 			GregtechRTG.run();

--- a/src/Java/gtPlusPlus/core/recipe/RECIPES_Machines.java
+++ b/src/Java/gtPlusPlus/core/recipe/RECIPES_Machines.java
@@ -1116,22 +1116,22 @@ public class RECIPES_Machines {
 
 			if (CORE.ConfigSwitches.enableMultiblock_TreeFarmer){
 				//Industrial Tree Farmer
-				/*RECIPE_TreeFarmController = GregtechItemList.Industrial_TreeFarm.get(1);*/
+				RECIPE_TreeFarmController = GregtechItemList.Industrial_TreeFarm.get(1);
 				RECIPE_TreeFarmFrame = GregtechItemList.Casing_PLACEHOLDER_TreeFarmer.get(Casing_Amount);
 				//Industrial Tree Farm Controller
 				if (!GTNH) {
-					/*RecipeUtils.addShapedGregtechRecipe(
+					RecipeUtils.addShapedGregtechRecipe(
 							"plateEglinSteel", "rotorEglinSteel", "plateEglinSteel",
 							"cableGt02Steel", "pipeMediumSteel", "cableGt02Steel",
 							"plateEglinSteel", CI.machineCasing_MV, "plateEglinSteel",
-							RECIPE_TreeFarmController);*/
+							RECIPE_TreeFarmController);
 				}
 				else {
-					/*RecipeUtils.addShapedGregtechRecipe(
+					RecipeUtils.addShapedGregtechRecipe(
 							"plateEglinSteel", "rotorEglinSteel", "plateEglinSteel",
 							"cableGt02Silver", "pipeMediumStainlessSteel", "cableGt02Silver",
 							"plateEglinSteel", CI.machineCasing_HV, "plateEglinSteel",
-							RECIPE_TreeFarmController);*/
+							RECIPE_TreeFarmController);
 				}
 				//Industrial Tree Farm Frame
 				RecipeUtils.addShapedGregtechRecipe(

--- a/src/Java/gtPlusPlus/xmod/gregtech/api/enums/GregtechItemList.java
+++ b/src/Java/gtPlusPlus/xmod/gregtech/api/enums/GregtechItemList.java
@@ -266,7 +266,7 @@ public enum GregtechItemList implements GregtechItemContainer {
 
 
 	//Tree Farm
-	/*Industrial_TreeFarm, */
+	Industrial_TreeFarm,
 	TreeFarmer_Structural,
 	Casing_PLACEHOLDER_TreeFarmer,
 

--- a/src/Java/gtPlusPlus/xmod/gregtech/api/gui/CONTAINER_TreeFarmer.java
+++ b/src/Java/gtPlusPlus/xmod/gregtech/api/gui/CONTAINER_TreeFarmer.java
@@ -1,4 +1,4 @@
-/*
+
 package gtPlusPlus.xmod.gregtech.api.gui;
 
 import java.util.List;
@@ -68,4 +68,4 @@ public class CONTAINER_TreeFarmer extends GT_ContainerMetaTile_Machine {
 		}
 	}
 
-}*/
+}

--- a/src/Java/gtPlusPlus/xmod/gregtech/api/gui/GUI_TreeFarmer.java
+++ b/src/Java/gtPlusPlus/xmod/gregtech/api/gui/GUI_TreeFarmer.java
@@ -1,4 +1,4 @@
-/*
+
 package gtPlusPlus.xmod.gregtech.api.gui;
 
 
@@ -44,4 +44,3 @@ public class GUI_TreeFarmer extends GT_GUIContainerMetaTile_Machine {
 		this.drawTexturedModalRect(x, y, 0, 0, this.xSize, this.ySize);
 	}
 }
-*/

--- a/src/Java/gtPlusPlus/xmod/gregtech/common/helpers/TreeFarmHelper.java
+++ b/src/Java/gtPlusPlus/xmod/gregtech/common/helpers/TreeFarmHelper.java
@@ -202,7 +202,7 @@ public class TreeFarmHelper {
 									)){
 
 						if (!testBlock.getUnlocalizedName().toLowerCase().contains("air") || !testBlock.getUnlocalizedName().toLowerCase().contains("pumpkin")) {
-							Logger.WARNING("5:"+testBlock.getUnlocalizedName());
+							//Logger.WARNING("5:"+testBlock.getUnlocalizedName());
 						} else {
 							aBaseMetaTileEntity.getWorld().setBlock(aBaseMetaTileEntity.getXCoord()+xDir+i, aBaseMetaTileEntity.getYCoord()+h, aBaseMetaTileEntity.getZCoord()+zDir+j, Blocks.bookshelf);
 						}
@@ -222,14 +222,14 @@ public class TreeFarmHelper {
 							){
 
 						if (!testBlock.getUnlocalizedName().toLowerCase().contains("air") || !testBlock.getUnlocalizedName().toLowerCase().contains("pumpkin")) {
-							Logger.WARNING("0:"+testBlock.getUnlocalizedName());
+							//Logger.WARNING("0:"+testBlock.getUnlocalizedName());
 						} else {
 							aBaseMetaTileEntity.getWorld().setBlock(aBaseMetaTileEntity.getXCoord()+xDir+i, aBaseMetaTileEntity.getYCoord()+h, aBaseMetaTileEntity.getZCoord()+zDir+j, Blocks.melon_block);
 						}
 
 
 						if (isLeaves(testBlock) || isWoodLog(testBlock)){
-							Logger.WARNING("1:"+testBlock.getUnlocalizedName());
+							//Logger.WARNING("1:"+testBlock.getUnlocalizedName());
 							int posiX, posiY, posiZ;
 							posiX = aBaseMetaTileEntity.getXCoord()+xDir+i;
 							posiY = aBaseMetaTileEntity.getYCoord()+h;
@@ -440,10 +440,10 @@ public class TreeFarmHelper {
 	public static boolean isSapling(final Block log){
 		if (log != null){
 			if (OrePrefixes.sapling.contains(new ItemStack(log, 1))){
-				Logger.WARNING(""+log.getLocalizedName());
+				//Logger.WARNING(""+log.getLocalizedName());
 			}
 			if (log.getLocalizedName().toLowerCase().contains("sapling")){
-				Logger.WARNING(""+log.getLocalizedName());
+				//Logger.WARNING(""+log.getLocalizedName());
 				return true;
 			}
 		}

--- a/src/Java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/GregtechMetaTileEntityTreeFarm.java
+++ b/src/Java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/GregtechMetaTileEntityTreeFarm.java
@@ -305,32 +305,31 @@ if (executor == null || mTreeData == null) {
 			ItemStack invItem = this.mInventory[1];
 			if (isCorrectMachinePart(invItem)) {
 				boolean didElectricDamage = false;
-				//Damage and discharge to the internal tool disabled for now
-//				if (EU.isElectricItem(invItem)) {
-//					if (EU.hasCharge(invItem)) {
-//						long tVoltage = getMaxInputVoltage();
-//						byte tTier = (byte) Math.max(1, GT_Utility.getTier(tVoltage));
-//						if (EU.getCharge(invItem) >= tVoltage) {
-//							if (EU.discharge(invItem, (int) tVoltage, -1)) {
-//								didElectricDamage = true;
-//							}
-//							else {
-//								this.getBaseMetaTileEntity().disableWorking();
-//							}
-//						}
-//					}
-//				}
+				if (EU.isElectricItem(invItem)) {
+					if (EU.hasCharge(invItem)) {
+						long tVoltage = getMaxInputVoltage();
+						byte tTier = (byte) Math.max(1, GT_Utility.getTier(tVoltage));
+						if (EU.getCharge(invItem) >= tVoltage) {
+							if (EU.discharge(invItem, (int) tVoltage, -1)) {
+								didElectricDamage = true;
+							}
+							else {
+								this.getBaseMetaTileEntity().disableWorking();
+							}
+						}
+					}
+				}
 
-//				if (!didElectricDamage && invItem.getItem() instanceof GT_MetaGenerated_Tool) {
-//					long aDmg = GT_MetaGenerated_Tool.getToolDamage(invItem);
-//					long aDmgMax = GT_MetaGenerated_Tool.getToolMaxDamage(invItem);
-//					if (aDmg < aDmgMax && GT_MetaGenerated_Tool.getPrimaryMaterial(invItem) != Materials._NULL) {
-//						GT_ModHandler.damageOrDechargeItem(invItem, 1, 0, null);
-//					}
-//					else if (aDmg >= aDmgMax) {
-//						this.mInventory[1] = null;
-//					}
-//				}
+				if (!didElectricDamage && invItem.getItem() instanceof GT_MetaGenerated_Tool) {
+					long aDmg = GT_MetaGenerated_Tool.getToolDamage(invItem);
+					long aDmgMax = GT_MetaGenerated_Tool.getToolMaxDamage(invItem);
+					if (aDmg < aDmgMax && GT_MetaGenerated_Tool.getPrimaryMaterial(invItem) != Materials._NULL) {
+						GT_ModHandler.damageOrDechargeItem(invItem, 1, 0, null);
+					}
+					else if (aDmg >= aDmgMax) {
+						this.mInventory[1] = null;
+					}
+				}
 			}
 		}
 	}

--- a/src/Java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/GregtechMetaTileEntityTreeFarm.java
+++ b/src/Java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/GregtechMetaTileEntityTreeFarm.java
@@ -1,8 +1,11 @@
 
 package gtPlusPlus.xmod.gregtech.common.tileentities.machines.multi.production;
 
+import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
 
+import com.gtnewhorizon.structurelib.structure.IStructureDefinition;
 import gregtech.api.enums.Materials;
 import gregtech.api.enums.TAE;
 import gregtech.api.enums.Textures;
@@ -12,6 +15,7 @@ import gregtech.api.interfaces.metatileentity.IMetaTileEntity;
 import gregtech.api.interfaces.tileentity.IGregTechTileEntity;
 import gregtech.api.items.GT_MetaGenerated_Tool;
 import gregtech.api.objects.GT_RenderedTexture;
+import gregtech.api.util.GT_Multiblock_Tooltip_Builder;
 import gregtech.api.util.GT_Recipe;
 import gregtech.api.util.GT_Utility;
 import gtPlusPlus.api.objects.Logger;
@@ -64,12 +68,12 @@ public class GregtechMetaTileEntityTreeFarm extends GregtechMeta_MultiBlockBase 
 
 if (executor == null || mTreeData == null) {
 			if (executor == null) {
-				executor = Executors.newScheduledThreadPool(10);				
+				executor = Executors.newScheduledThreadPool(10);
 			}
 			if (executor != null) {				
 				if (aThread == null) {
 					aThread = new ThreadFakeWorldGenerator();	
-					executor.scheduleAtFixedRate(aThread, 0, 1, TimeUnit.SECONDS);			
+					executor.scheduleAtFixedRate(aThread, 0, 1, TimeUnit.SECONDS);
 					while (aThread.mGenerator == null) {
 						if (aThread.mGenerator != null) {
 							break;
@@ -97,20 +101,29 @@ if (executor == null || mTreeData == null) {
 		return "Tree Farm";
 	}
 
-	public String[] getTooltip() {
-
+	@Override
+	protected GT_Multiblock_Tooltip_Builder createTooltip() {
 		if (mCasingName.toLowerCase().contains(".name")) {
 			mCasingName = ItemUtils.getLocalizedNameOfBlock(ModBlocks.blockCasings2Misc, 15);
 		}
-
-		return new String[]{
-				"Converts EU to Oak Logs",
-				"Speed: Very Fast | Eu Usage: 100% | Parallel: 1",				
-				"Requires a Saw, Buzz Saw or Chainsaw in GUI slot",
-				"Constructed exactly the same as a normal Vacuum Freezer",
-				"Use "+mCasingName+"s (10 at least!)",
-				"TAG_HIDE_HATCHES"
-		};
+		GT_Multiblock_Tooltip_Builder tt = new GT_Multiblock_Tooltip_Builder();
+		tt.addMachineType(getMachineType())
+				.addInfo("Converts EU to Oak Logs")
+				.addInfo("Eu Usage: 100% | Parallel: 1")
+				.addInfo("Requires a Saw or Chainsaw in GUI slot")
+				.addInfo("Constructed exactly the same as a normal Vacuum Freezer")
+				.addPollutionAmount(getPollutionPerTick(null) * 20)
+				.addSeparator()
+				.beginStructureBlock(3, 3, 3, true)
+				.addController("Front center")
+				.addCasingInfo(mCasingName, 10)
+				.addInputBus("Any casing", 1)
+				.addOutputBus("Any casing", 1)
+				.addEnergyHatch("Any casing", 1)
+				.addMaintenanceHatch("Any casing", 1)
+				.addMufflerHatch("Any casing", 1)
+				.toolTipFinisher("GT++");
+		return tt;
 	}
 
 	public ITexture[] getTexture(final IGregTechTileEntity aBaseMetaTileEntity, final byte aSide, final byte aFacing,
@@ -146,8 +159,13 @@ if (executor == null || mTreeData == null) {
 		//return true;
 	}
 
-	public boolean isFacingValid(final byte aFacing) {
-		return aFacing > 1;
+//	public boolean isFacingValid(final byte aFacing) {
+//		return aFacing > 1;
+//	}
+
+	@Override
+	public IStructureDefinition getStructureDefinition() {
+		return null;
 	}
 
 	public boolean checkRecipe(final ItemStack aStack) {
@@ -212,6 +230,11 @@ if (executor == null || mTreeData == null) {
 			return false;
 		}
 		//return this.checkRecipeGeneric(4, 100, 100);
+	}
+
+	@Override
+	public boolean checkMachine(IGregTechTileEntity iGregTechTileEntity, ItemStack itemStack) {
+		return false;
 	}
 
 	@Override
@@ -313,5 +336,10 @@ if (executor == null || mTreeData == null) {
 				}
 			}			
 		}		
+	}
+
+	@Override
+	public void construct(ItemStack stackSize, boolean hintsOnly) {
+
 	}
 }

--- a/src/Java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/GregtechMetaTileEntityTreeFarm.java
+++ b/src/Java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/GregtechMetaTileEntityTreeFarm.java
@@ -1,4 +1,4 @@
-/*
+
 package gtPlusPlus.xmod.gregtech.common.tileentities.machines.multi.production;
 
 import java.util.concurrent.ScheduledExecutorService;
@@ -48,10 +48,9 @@ public class GregtechMetaTileEntityTreeFarm extends GregtechMeta_MultiBlockBase 
 
 
 
-	*/
 /*
 	 * Static thread for Fake World Handling
-	 *//*
+	 */
 
 
 
@@ -63,8 +62,7 @@ public class GregtechMetaTileEntityTreeFarm extends GregtechMeta_MultiBlockBase 
 		CASING_TEXTURE_ID = TAE.getIndexFromPage(1, 15);
 		mCasingName = ItemUtils.getLocalizedNameOfBlock(ModBlocks.blockCasings2Misc, 15);
 
-		*/
-/*if (executor == null || mTreeData == null) {
+if (executor == null || mTreeData == null) {
 			if (executor == null) {
 				executor = Executors.newScheduledThreadPool(10);				
 			}
@@ -82,7 +80,7 @@ public class GregtechMetaTileEntityTreeFarm extends GregtechMeta_MultiBlockBase 
 					}
 				}
 			}			
-		}*//*
+		}
 
 
 
@@ -106,7 +104,6 @@ public class GregtechMetaTileEntityTreeFarm extends GregtechMeta_MultiBlockBase 
 		}
 
 		return new String[]{
-                "[WIP] Disabled",
 				"Converts EU to Oak Logs",
 				"Speed: Very Fast | Eu Usage: 100% | Parallel: 1",				
 				"Requires a Saw, Buzz Saw or Chainsaw in GUI slot",
@@ -155,9 +152,7 @@ public class GregtechMetaTileEntityTreeFarm extends GregtechMeta_MultiBlockBase 
 
 	public boolean checkRecipe(final ItemStack aStack) {
 
-		//Logger.WARNING("Trying to process virtual tree farming");
 		if (mTreeData != null) {
-			//Logger.WARNING("Tree Data is valid");
 
 			long tVoltage = getMaxInputVoltage();
 			byte tTier = (byte) Math.max(1, GT_Utility.getTier(tVoltage));
@@ -189,13 +184,11 @@ public class GregtechMetaTileEntityTreeFarm extends GregtechMeta_MultiBlockBase 
 			AutoMap<ItemStack> aOutputs = new AutoMap<ItemStack>();
 
 			try {
-				//Logger.WARNING("Output Chance - "+aChance+" | Valid number? "+(aChance < 1000));
 				if (aChance < 8) {
 					//1% Chance per Tick				
 					for (int u=0; u<(Math.max(4, (MathUtils.randInt((3*tTier), 100)*tTier*tTier)/14));u++) {
 						aOutputs = mTreeData.generateOutput(0);		
 						if (aOutputs.size() > 0) {
-							Logger.WARNING("Generated some Loot, adding it to the output busses");
 
 							ItemStack aLeaves = ItemUtils.getSimpleStack(Blocks.leaves);
 
@@ -204,7 +197,6 @@ public class GregtechMetaTileEntityTreeFarm extends GregtechMeta_MultiBlockBase 
 									this.addOutput(aOutputItemStack);
 								}
 							}
-							Logger.WARNING("Updating Slots");
 							this.updateSlots();
 						}	
 					}			
@@ -214,12 +206,9 @@ public class GregtechMetaTileEntityTreeFarm extends GregtechMeta_MultiBlockBase 
 			catch (Throwable t) {
 				t.printStackTrace();
 			}
-
-			//Logger.WARNING("Valid Recipe");
 			return true;
 		}
 		else {
-			//Logger.WARNING("Invalid Recipe");
 			return false;
 		}
 		//return this.checkRecipeGeneric(4, 100, 100);
@@ -253,7 +242,7 @@ public class GregtechMetaTileEntityTreeFarm extends GregtechMeta_MultiBlockBase 
 
 							if (!isValidBlockForStructure(tTileEntity, CASING_TEXTURE_ID, true, aBlock, aMeta,
 									ModBlocks.blockCasings2Misc, 15)) {
-								Logger.WARNING("Bad centrifuge casing");
+								//Logger.WARNING("Bad centrifuge casing");
 								return false;
 							}
 							++tAmount;
@@ -295,19 +284,19 @@ public class GregtechMetaTileEntityTreeFarm extends GregtechMeta_MultiBlockBase 
 						long tVoltage = getMaxInputVoltage();
 						byte tTier = (byte) Math.max(1, GT_Utility.getTier(tVoltage));						
 						if (EU.getCharge(invItem) >= tVoltage) {
-							Logger.WARNING("Can drain.");
+							//Logger.WARNING("Can drain.");
 							if (EU.discharge(invItem, (int) tVoltage, -1)) {
-								Logger.WARNING("Drained Power.");
+								//Logger.WARNING("Drained Power.");
 								didElectricDamage = true;
 							}
 							else {
-								Logger.WARNING("Failed when draining Power.");
+								//Logger.WARNING("Failed when draining Power.");
 								this.getBaseMetaTileEntity().disableWorking();
 							}
 						}							
 					}
 				}
-				Logger.WARNING("Drained Power? "+didElectricDamage);
+				//Logger.WARNING("Drained Power? "+didElectricDamage);
 
 
 
@@ -315,7 +304,7 @@ public class GregtechMetaTileEntityTreeFarm extends GregtechMeta_MultiBlockBase 
 					long aDmg = GT_MetaGenerated_Tool.getToolDamage(invItem);
 					long aDmgMax = GT_MetaGenerated_Tool.getToolMaxDamage(invItem);
 					if (aDmg < aDmgMax && GT_MetaGenerated_Tool.getPrimaryMaterial(invItem) != Materials._NULL) {
-						Logger.WARNING("dmg: "+aDmg+" | max: "+aDmgMax);
+						//Logger.WARNING("dmg: "+aDmg+" | max: "+aDmgMax);
 						GT_MetaGenerated_Tool.setToolDamage(invItem, aDmg+getDamageToComponent(invItem));							
 					}
 					else if (aDmg >= aDmgMax) {
@@ -325,4 +314,4 @@ public class GregtechMetaTileEntityTreeFarm extends GregtechMeta_MultiBlockBase 
 			}			
 		}		
 	}
-}*/
+}

--- a/src/Java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/GregtechMetaTileEntityTreeFarm.java
+++ b/src/Java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/GregtechMetaTileEntityTreeFarm.java
@@ -93,11 +93,6 @@ if (executor == null || mTreeData == null) {
 				}
 			}			
 		}
-
-
-
-
-
 	}
 
 	public IMetaTileEntity newMetaEntity(final IGregTechTileEntity aTileEntity) {
@@ -119,12 +114,11 @@ if (executor == null || mTreeData == null) {
 				.addInfo("Converts EU to Oak Logs")
 				.addInfo("Eu Usage: 100% | Parallel: 1")
 				.addInfo("Requires a Saw or Chainsaw in GUI slot")
-				.addInfo("Constructed exactly the same as a normal Vacuum Freezer")
 				.addPollutionAmount(getPollutionPerTick(null) * 20)
 				.addSeparator()
 				.beginStructureBlock(3, 3, 3, true)
 				.addController("Front center")
-				.addCasingInfo(mCasingName, 10)
+				.addCasingInfo("Sterile Farm Casing", 10)
 				.addInputBus("Any casing", 1)
 				.addOutputBus("Any casing", 1)
 				.addEnergyHatch("Any casing", 1)
@@ -257,8 +251,8 @@ if (executor == null || mTreeData == null) {
 			STRUCTURE_DEFINITION = StructureDefinition.<GregtechMetaTileEntityTreeFarm>builder()
 					.addShape(mName, transpose(new String[][]{
 							{"XXX", "CCC", "CCC"},
-							{"XXX", "C-C", "CCC"},
-							{"X~X", "CCC", "CCC"},
+							{"X~X", "C-C", "CCC"},
+							{"XXX", "CCC", "CCC"},
 					}))
 					.addElement(
 							'C',
@@ -269,7 +263,7 @@ if (executor == null || mTreeData == null) {
 									onElementPass(
 											x -> ++x.mCasing,
 											ofBlock(
-													ModBlocks.blockCasingsMisc, 0
+													ModBlocks.blockCasings2Misc, 0
 											)
 									)
 							)
@@ -277,7 +271,7 @@ if (executor == null || mTreeData == null) {
 					.addElement(
 							'X',
 							ofBlock(
-									ModBlocks.blockCasingsMisc, 0
+									ModBlocks.blockCasings2Misc, 0
 							)
 					)
 					.build();

--- a/src/Java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/GregtechMetaTileEntityTreeFarm.java
+++ b/src/Java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/GregtechMetaTileEntityTreeFarm.java
@@ -20,7 +20,6 @@ import gregtech.api.objects.GT_RenderedTexture;
 import gregtech.api.util.GT_Multiblock_Tooltip_Builder;
 import gregtech.api.util.GT_Recipe;
 import gregtech.api.util.GT_Utility;
-import gtPlusPlus.api.objects.Logger;
 import gtPlusPlus.api.objects.data.AutoMap;
 import gtPlusPlus.api.objects.minecraft.ThreadFakeWorldGenerator;
 import gtPlusPlus.core.block.ModBlocks;
@@ -31,11 +30,8 @@ import gtPlusPlus.xmod.gregtech.api.metatileentity.implementations.base.Gregtech
 import gtPlusPlus.xmod.gregtech.common.blocks.textures.TexturesGtBlock;
 import gtPlusPlus.xmod.gregtech.common.helpers.TreeFarmHelper;
 import gtPlusPlus.xmod.gregtech.common.helpers.treefarm.TreeGenerator;
-import gtPlusPlus.xmod.gregtech.common.tileentities.machines.multi.processing.GregtechMetaTileEntity_IndustrialSifter;
-import net.minecraft.block.Block;
 import net.minecraft.init.Blocks;
 import net.minecraft.item.ItemStack;
-import net.minecraftforge.common.util.ForgeDirection;
 
 import static com.gtnewhorizon.structurelib.structure.StructureUtility.*;
 import static gregtech.api.util.GT_StructureUtility.ofHatchAdder;
@@ -258,12 +254,12 @@ if (executor == null || mTreeData == null) {
 							'C',
 							ofChain(
 									ofHatchAdder(
-											GregtechMetaTileEntityTreeFarm::addTreeFarmList, getCasingTextureIndex(), 1
+											GregtechMetaTileEntityTreeFarm::addTreeFarmList, CASING_TEXTURE_ID, 1
 									),
 									onElementPass(
 											x -> ++x.mCasing,
 											ofBlock(
-													ModBlocks.blockCasings2Misc, 0
+													ModBlocks.blockCasings2Misc, 15
 											)
 									)
 							)
@@ -271,7 +267,7 @@ if (executor == null || mTreeData == null) {
 					.addElement(
 							'X',
 							ofBlock(
-									ModBlocks.blockCasings2Misc, 0
+									ModBlocks.blockCasings2Misc, 15
 							)
 					)
 					.build();
@@ -308,10 +304,6 @@ if (executor == null || mTreeData == null) {
 			}
 		}
 		return false;
-	}
-
-	public byte getCasingTextureIndex() {
-		return (byte) TAE.GTPP_INDEX(0);
 	}
 
 	public int getMaxEfficiency(final ItemStack aStack) {

--- a/src/Java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/GregtechMetaTileEntityTreeFarm.java
+++ b/src/Java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/GregtechMetaTileEntityTreeFarm.java
@@ -47,9 +47,9 @@ public class GregtechMetaTileEntityTreeFarm extends GregtechMeta_MultiBlockBase 
 	public static TreeGenerator mTreeData;
 	private int mCasing;
 	private IStructureDefinition<GregtechMetaTileEntityTreeFarm> STRUCTURE_DEFINITION = null;
-	
+
 	static {
-		mTreeData = new TreeGenerator();	
+		mTreeData = new TreeGenerator();
 	}
 
 	public GregtechMetaTileEntityTreeFarm(final int aID, final String aName, final String aNameRegional) {
@@ -58,10 +58,9 @@ public class GregtechMetaTileEntityTreeFarm extends GregtechMeta_MultiBlockBase 
 		mCasingName = ItemUtils.getLocalizedNameOfBlock(ModBlocks.blockCasings2Misc, 15);
 	}
 
-/*
+	/*
 	 * Static thread for Fake World Handling
 	 */
-
 
 
 	private static ScheduledExecutorService executor;
@@ -72,24 +71,24 @@ public class GregtechMetaTileEntityTreeFarm extends GregtechMeta_MultiBlockBase 
 		CASING_TEXTURE_ID = TAE.getIndexFromPage(1, 15);
 		mCasingName = ItemUtils.getLocalizedNameOfBlock(ModBlocks.blockCasings2Misc, 15);
 
-if (executor == null || mTreeData == null) {
+		if (executor == null || mTreeData == null) {
 			if (executor == null) {
 				executor = Executors.newScheduledThreadPool(10);
 			}
-			if (executor != null) {				
+			if (executor != null) {
 				if (aThread == null) {
-					aThread = new ThreadFakeWorldGenerator();	
+					aThread = new ThreadFakeWorldGenerator();
 					executor.scheduleAtFixedRate(aThread, 0, 1, TimeUnit.SECONDS);
 					while (aThread.mGenerator == null) {
 						if (aThread.mGenerator != null) {
 							break;
 						}
-					}		
+					}
 					if (aThread.mGenerator != null) {
 						mTreeData = aThread.mGenerator;
 					}
 				}
-			}			
+			}
 		}
 	}
 
@@ -127,7 +126,7 @@ if (executor == null || mTreeData == null) {
 	}
 
 	public ITexture[] getTexture(final IGregTechTileEntity aBaseMetaTileEntity, final byte aSide, final byte aFacing,
-			final byte aColorIndex, final boolean aActive, final boolean aRedstone) {
+								 final byte aColorIndex, final boolean aActive, final boolean aRedstone) {
 		if (aSide == aFacing) {
 			return new ITexture[]{Textures.BlockIcons.getCasingTextureForId(CASING_TEXTURE_ID),
 					new GT_RenderedTexture((IIconContainer) (aActive ? TexturesGtBlock.Overlay_Machine_Controller_Advanced_Active : TexturesGtBlock.Overlay_Machine_Controller_Advanced))};
@@ -150,7 +149,7 @@ if (executor == null || mTreeData == null) {
 		return "VacuumFreezer";
 	}
 
-	public GT_Recipe.GT_Recipe_Map getRecipeMap() {			
+	public GT_Recipe.GT_Recipe_Map getRecipeMap() {
 		return null;
 	}
 
@@ -192,15 +191,14 @@ if (executor == null || mTreeData == null) {
 			}
 
 
-
 			int aChance = MathUtils.randInt(0, 10);
 			AutoMap<ItemStack> aOutputs = new AutoMap<ItemStack>();
 
 			try {
 				if (aChance < 8) {
 					//1% Chance per Tick				
-					for (int u=0; u<(Math.max(4, (MathUtils.randInt((3*tTier), 100)*tTier*tTier)/14));u++) {
-						aOutputs = mTreeData.generateOutput(0);		
+					for (int u = 0; u < (Math.max(4, (MathUtils.randInt((3 * tTier), 100) * tTier * tTier) / 14)); u++) {
+						aOutputs = mTreeData.generateOutput(0);
 						if (aOutputs.size() > 0) {
 
 							ItemStack aLeaves = ItemUtils.getSimpleStack(Blocks.leaves);
@@ -211,17 +209,15 @@ if (executor == null || mTreeData == null) {
 								}
 							}
 							this.updateSlots();
-						}	
-					}			
+						}
+					}
 
-				}				
-			}
-			catch (Throwable t) {
+				}
+			} catch (Throwable t) {
 				t.printStackTrace();
 			}
 			return true;
-		}
-		else {
+		} else {
 			return false;
 		}
 		//return this.checkRecipeGeneric(4, 100, 100);
@@ -299,13 +295,24 @@ if (executor == null || mTreeData == null) {
 		ItemStack invItem = this.mInventory[1];
 		if (invItem == null) {
 			for (GT_MetaTileEntity_Hatch_InputBus mInputBus : this.mInputBusses) {
-				for (int i = 0; i < mInputBus.mInventory.length ; i++) {
+				for (int i = 0; i < mInputBus.mInventory.length; i++) {
 					ItemStack uStack = mInputBus.mInventory[i];
-					if(uStack != null && TreeFarmHelper.isCorrectPart(uStack)) {
+					if (uStack != null && TreeFarmHelper.isCorrectPart(uStack)) {
 						this.setGUIItemStack(uStack);
 						return true;
 					}
 				}
+			}
+		}
+		return false;
+	}
+
+	public boolean tryDamageTool(ItemStack invItem) {
+		if (invItem != null && invItem.getItem() instanceof GT_MetaGenerated_Tool) {
+			long aDmg = GT_MetaGenerated_Tool.getToolDamage(invItem);
+			long aDmgMax = GT_MetaGenerated_Tool.getToolMaxDamage(invItem);
+			if (aDmg < aDmgMax && GT_MetaGenerated_Tool.getPrimaryMaterial(invItem) != Materials._NULL) {
+				return GT_ModHandler.damageOrDechargeItem(invItem, 1, 0, null);
 			}
 		}
 		return false;
@@ -316,29 +323,22 @@ if (executor == null || mTreeData == null) {
 		super.onPostTick(aBaseMetaTileEntity, aTick);
 		replaceTool();
 		ItemStack invItem = this.mInventory[1];
-		if (invItem != null && aTick % 200 == 0 && this.getBaseMetaTileEntity().isServerSide()) {
-			if (isCorrectMachinePart(invItem)) {
-				boolean didElectricDamage = true;
-				if (EU.isElectricItem(invItem)) {
-					if (!GT_ModHandler.damageOrDechargeItem(invItem, 2, 0, null)) {
-						didElectricDamage = false;
-						addOutput(invItem);
-						this.mInventory[1] = null;
-						if(!replaceTool())
-							this.getBaseMetaTileEntity().disableWorking();
-					}
-				}
+		if (invItem != null && aTick % 200 == 0 && this.getBaseMetaTileEntity().isServerSide() && isCorrectMachinePart(invItem)) {
 
-				if (!didElectricDamage && invItem.getItem() instanceof GT_MetaGenerated_Tool) {
-					long aDmg = GT_MetaGenerated_Tool.getToolDamage(invItem);
-					long aDmgMax = GT_MetaGenerated_Tool.getToolMaxDamage(invItem);
-					if (aDmg < aDmgMax && GT_MetaGenerated_Tool.getPrimaryMaterial(invItem) != Materials._NULL) {
-						GT_ModHandler.damageOrDechargeItem(invItem, 1, 0, null);
+			if (!tryDamageTool(invItem)) {
+				if (!invItem.getItem().isDamageable()) { //item durability is <= 0
+					this.mInventory[1] = null;
+					if (!replaceTool()) {
+						this.getBaseMetaTileEntity().disableWorking();
 					}
-					else if (aDmg >= aDmgMax) {
-						this.mInventory[1] = null;
-						replaceTool();
+					tryDamageTool(invItem);
+				} else {
+					addOutput(invItem);
+					this.mInventory[1] = null;
+					if (!replaceTool()) {
+						this.getBaseMetaTileEntity().disableWorking();
 					}
+					tryDamageTool(invItem);
 				}
 			}
 		}

--- a/src/Java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/GregtechMetaTileEntityTreeFarm.java
+++ b/src/Java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/GregtechMetaTileEntityTreeFarm.java
@@ -154,12 +154,7 @@ public class GregtechMetaTileEntityTreeFarm extends GregtechMeta_MultiBlockBase 
 	}
 
 	public boolean checkRecipe(final ItemStack aStack) {
-	    
-	    if (true) {
-	        return false;
-	    }
-	    
-	    
+
 		//Logger.WARNING("Trying to process virtual tree farming");
 		if (mTreeData != null) {
 			//Logger.WARNING("Tree Data is valid");
@@ -197,7 +192,7 @@ public class GregtechMetaTileEntityTreeFarm extends GregtechMeta_MultiBlockBase 
 				//Logger.WARNING("Output Chance - "+aChance+" | Valid number? "+(aChance < 1000));
 				if (aChance < 8) {
 					//1% Chance per Tick				
-					for (int u=0; u<(Math.max(20, (MathUtils.randInt((3*tTier), 100)*tTier*tTier)/8));u++) {
+					for (int u=0; u<(Math.max(4, (MathUtils.randInt((3*tTier), 100)*tTier*tTier)/14));u++) {
 						aOutputs = mTreeData.generateOutput(0);		
 						if (aOutputs.size() > 0) {
 							Logger.WARNING("Generated some Loot, adding it to the output busses");

--- a/src/Java/gtPlusPlus/xmod/gregtech/registration/gregtech/GregtechIndustrialTreeFarm.java
+++ b/src/Java/gtPlusPlus/xmod/gregtech/registration/gregtech/GregtechIndustrialTreeFarm.java
@@ -1,4 +1,4 @@
-/*
+
 package gtPlusPlus.xmod.gregtech.registration.gregtech;
 
 import gtPlusPlus.api.objects.Logger;
@@ -25,4 +25,4 @@ public class GregtechIndustrialTreeFarm {
 						.getStackForm(1L));
 
 	}
-}*/
+}


### PR DESCRIPTION
Give an alternative source for wood by re-enabling the GT++ multiblock.
Other wood farms are a lot more laggy in comparison to the multiblock. Growing trees normally, especially with a world accelerator, can have a noticeable impact on the server.

I tried balancing it with the expected wood output of an enderio farm with spruce saplings and world accelerators.
![javaw_judcy4o5SM](https://user-images.githubusercontent.com/17811922/142736735-3d101fe8-cbab-4c1b-bca4-5f3f23df0862.png)

World accelerator was placed on top of the farming station. Test with HV was done without a capacitor and test with ZPM was done with octadic capacitor.

EIO farm output, 1 minute:
3 amp hv (hv world accelerator) 2500 wood
3 amp zpm (zpm world accelerator) 6400 wood

GT++ Tree Growth Simulator, 1 minute:
1 amp hv 950 wood
1 amp uv 6500 wood