### PR TITLE
fix chemplant not consuming catalyst

### DIFF
--- a/src/Java/gtPlusPlus/xmod/gregtech/api/metatileentity/implementations/nbthandlers/GT_MetaTileEntity_Hatch_NbtConsumable.java
+++ b/src/Java/gtPlusPlus/xmod/gregtech/api/metatileentity/implementations/nbthandlers/GT_MetaTileEntity_Hatch_NbtConsumable.java
@@ -128,7 +128,6 @@ public abstract class GT_MetaTileEntity_Hatch_NbtConsumable extends GT_MetaTileE
 				fillStacksIntoFirstSlots();
 			}
 		}
-		tryFillUsageSlots();
 	}
 
 	// Only moves items in the first four slots
@@ -142,7 +141,7 @@ public abstract class GT_MetaTileEntity_Hatch_NbtConsumable extends GT_MetaTileE
 		}                
 	}
 	
-	private final void tryFillUsageSlots() {
+	public final void tryFillUsageSlots() {
 		int aSlotSpace = (mInputslotCount - getContentUsageSlots().size());
 		if (aSlotSpace > 0) {
 			Logger.INFO("We have empty usage slots. "+aSlotSpace);

--- a/src/Java/gtPlusPlus/xmod/gregtech/api/metatileentity/implementations/nbthandlers/GT_MetaTileEntity_Hatch_NbtConsumable.java
+++ b/src/Java/gtPlusPlus/xmod/gregtech/api/metatileentity/implementations/nbthandlers/GT_MetaTileEntity_Hatch_NbtConsumable.java
@@ -40,13 +40,6 @@ public abstract class GT_MetaTileEntity_Hatch_NbtConsumable extends GT_MetaTileE
 		mAllowDuplicateUsageTypes = aAllowDuplicateTypes;
 	}
 
-	public GT_MetaTileEntity_Hatch_NbtConsumable(String aName, int aTier, int aInputSlots, String[] aDescription, boolean aAllowDuplicateTypes, ITexture[][][] aTextures) {
-		super(aName, aTier, aInputSlots*2, aDescription[0], aTextures);
-		mInputslotCount = getInputSlotCount();
-		mTotalSlotCount = getInputSlotCount()*2;
-		mAllowDuplicateUsageTypes = aAllowDuplicateTypes;
-	}
-
 	@Override
 	public abstract ITexture[] getTexturesActive(ITexture aBaseTexture);
 

--- a/src/Java/gtPlusPlus/xmod/gregtech/api/metatileentity/implementations/nbthandlers/GT_MetaTileEntity_Hatch_NbtConsumable.java
+++ b/src/Java/gtPlusPlus/xmod/gregtech/api/metatileentity/implementations/nbthandlers/GT_MetaTileEntity_Hatch_NbtConsumable.java
@@ -40,6 +40,13 @@ public abstract class GT_MetaTileEntity_Hatch_NbtConsumable extends GT_MetaTileE
 		mAllowDuplicateUsageTypes = aAllowDuplicateTypes;
 	}
 
+	public GT_MetaTileEntity_Hatch_NbtConsumable(String aName, int aTier, int aInputSlots, String[] aDescription, boolean aAllowDuplicateTypes, ITexture[][][] aTextures) {
+		super(aName, aTier, aInputSlots*2, aDescription, aTextures);
+		mInputslotCount = getInputSlotCount();
+		mTotalSlotCount = getInputSlotCount()*2;
+		mAllowDuplicateUsageTypes = aAllowDuplicateTypes;
+	}
+
 	@Override
 	public abstract ITexture[] getTexturesActive(ITexture aBaseTexture);
 

--- a/src/Java/gtPlusPlus/xmod/gregtech/api/metatileentity/implementations/nbthandlers/GT_MetaTileEntity_Hatch_NbtConsumable.java
+++ b/src/Java/gtPlusPlus/xmod/gregtech/api/metatileentity/implementations/nbthandlers/GT_MetaTileEntity_Hatch_NbtConsumable.java
@@ -128,6 +128,7 @@ public abstract class GT_MetaTileEntity_Hatch_NbtConsumable extends GT_MetaTileE
 				fillStacksIntoFirstSlots();
 			}
 		}
+		tryFillUsageSlots();
 	}
 
 	// Only moves items in the first four slots
@@ -141,7 +142,7 @@ public abstract class GT_MetaTileEntity_Hatch_NbtConsumable extends GT_MetaTileE
 		}                
 	}
 	
-	public final void tryFillUsageSlots() {
+	private final void tryFillUsageSlots() {
 		int aSlotSpace = (mInputslotCount - getContentUsageSlots().size());
 		if (aSlotSpace > 0) {
 			Logger.INFO("We have empty usage slots. "+aSlotSpace);

--- a/src/Java/gtPlusPlus/xmod/gregtech/api/metatileentity/implementations/nbthandlers/GT_MetaTileEntity_Hatch_NbtConsumable.java
+++ b/src/Java/gtPlusPlus/xmod/gregtech/api/metatileentity/implementations/nbthandlers/GT_MetaTileEntity_Hatch_NbtConsumable.java
@@ -120,7 +120,8 @@ public abstract class GT_MetaTileEntity_Hatch_NbtConsumable extends GT_MetaTileE
 			if (i <= getSlotID_LastInput()) {
 				fillStacksIntoFirstSlots();
 			}
-		}            
+		}
+		tryFillUsageSlots();
 	}
 
 	// Only moves items in the first four slots

--- a/src/Java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/chemplant/GregtechMTE_ChemicalPlant.java
+++ b/src/Java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/chemplant/GregtechMTE_ChemicalPlant.java
@@ -766,7 +766,9 @@ public class GregtechMTE_ChemicalPlant extends GregtechMeta_MultiBlockBase {
 		this.mOutputItems = tOutputItems;
 		this.mOutputFluids = tOutputFluids;
 		updateSlots();
-		for (GT_MetaTileEntity_Hatch_Catalysts h : mCatalystBuses) h.updateSlots();
+		for (GT_MetaTileEntity_Hatch_Catalysts h : mCatalystBuses) {
+			h.updateSlots();
+		}
 
 		// Play sounds (GT++ addition - GT multiblocks play no sounds)
 		startProcess();

--- a/src/Java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/chemplant/GregtechMTE_ChemicalPlant.java
+++ b/src/Java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/chemplant/GregtechMTE_ChemicalPlant.java
@@ -768,6 +768,7 @@ public class GregtechMTE_ChemicalPlant extends GregtechMeta_MultiBlockBase {
 		updateSlots();
 		for (GT_MetaTileEntity_Hatch_Catalysts h : mCatalystBuses) {
 			h.updateSlots();
+			h.tryFillUsageSlots();
 		}
 
 		// Play sounds (GT++ addition - GT multiblocks play no sounds)

--- a/src/Java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/chemplant/GregtechMTE_ChemicalPlant.java
+++ b/src/Java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/chemplant/GregtechMTE_ChemicalPlant.java
@@ -768,7 +768,6 @@ public class GregtechMTE_ChemicalPlant extends GregtechMeta_MultiBlockBase {
 		updateSlots();
 		for (GT_MetaTileEntity_Hatch_Catalysts h : mCatalystBuses) {
 			h.updateSlots();
-			h.tryFillUsageSlots();
 		}
 
 		// Play sounds (GT++ addition - GT multiblocks play no sounds)

--- a/src/Java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/chemplant/GregtechMTE_ChemicalPlant.java
+++ b/src/Java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/chemplant/GregtechMTE_ChemicalPlant.java
@@ -766,6 +766,7 @@ public class GregtechMTE_ChemicalPlant extends GregtechMeta_MultiBlockBase {
 		this.mOutputItems = tOutputItems;
 		this.mOutputFluids = tOutputFluids;
 		updateSlots();
+		for (GT_MetaTileEntity_Hatch_Catalysts h : mCatalystBuses) h.updateSlots();
 
 		// Play sounds (GT++ addition - GT multiblocks play no sounds)
 		startProcess();
@@ -960,7 +961,7 @@ public class GregtechMTE_ChemicalPlant extends GregtechMeta_MultiBlockBase {
 				if (damage >= getMaxCatalystDurability()) {
 					log("consume catalyst");
 					addOutput(CI.getEmptyCatalyst(1));
-					aStack = null;
+					aStack.stackSize -= 1;
 				} 
 				else {
 					log("damaging catalyst");


### PR DESCRIPTION
fix GTNewHorizons/GT-New-Horizons-Modpack#6308

The catalyst was being set null but it wasn't being synced because updateSlots doesn't touch the Catalyst Hatch.

I couldn't figure out how to make it do that, so I iterate over the array (which will only ever have one item) and update the slots.

Considering this is the first line of Java I've ever written, it's probably horribly wrong. *but it works*

Also removed an errant duplication of code.