### PR TITLE
Fix large semi-fluid generator

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -3,6 +3,6 @@ forge.version=10.13.4.1614-1.7.10
 ic2.version=2.2.817-experimental
 gt.version=5.09.37
 ae2.version=rv3-beta-22
-gtpp.version=1.7.11
+gtpp.version=1.7.12
 commit.hash=aa9f04218e5298414f900b9fe61131f7ed26b8f1
 structurelib.version=1.0.6

--- a/src/Java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/GregtechMetaTileEntity_LargeSemifluidGenerator.java
+++ b/src/Java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/GregtechMetaTileEntity_LargeSemifluidGenerator.java
@@ -115,7 +115,8 @@ public class GregtechMetaTileEntity_LargeSemifluidGenerator extends GregtechMeta
 				continue;
 			}
 
-			fuelConsumption = boostEu ? (4096 / aFuel.mSpecialValue) : (2048 / aFuel.mSpecialValue); //Calc fuel consumption
+			int newEUt = boostEu ? 4096 : 2048;
+			fuelConsumption = newEUt / aFuel.mSpecialValue; //Calc fuel consumption
 			FluidStack tLiquid = new FluidStack(hatchFluid.getFluid(), fuelConsumption);
 			if(depleteInput(tLiquid)) { //Deplete that amount
 				// We checked beforehand, so both of these depletions should succeed.
@@ -134,7 +135,7 @@ public class GregtechMetaTileEntity_LargeSemifluidGenerator extends GregtechMeta
 
 				fuelValue = aFuel.mSpecialValue;
 				fuelRemaining = hatchFluid.amount; //Record available fuel
-				this.mEUt = mEfficiency < 2000 ? 0 : 2048; //Output 0 if startup is less than 20%
+				this.mEUt = mEfficiency < 2000 ? 0 : newEUt; //Output 0 if startup is less than 20%
 				this.mProgresstime = 1;
 				this.mMaxProgresstime = 1;
 				this.mEfficiencyIncrease = 15;
@@ -286,7 +287,7 @@ public class GregtechMetaTileEntity_LargeSemifluidGenerator extends GregtechMeta
 	}
 
 	public int getMaxEfficiency(ItemStack aStack) {
-		return boostEu ? 20000 : 10000;
+		return boostEu ? 15000 : 10000;
 	}
 
 	@Override

--- a/src/Java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/GregtechMetaTileEntity_LargeSemifluidGenerator.java
+++ b/src/Java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/GregtechMetaTileEntity_LargeSemifluidGenerator.java
@@ -1,7 +1,6 @@
 package gtPlusPlus.xmod.gregtech.common.tileentities.machines.multi.production;
 
 import java.util.ArrayList;
-import java.util.Collection;
 
 import com.gtnewhorizon.structurelib.structure.IStructureDefinition;
 import com.gtnewhorizon.structurelib.structure.StructureDefinition;
@@ -16,7 +15,6 @@ import gregtech.api.metatileentity.implementations.*;
 import gregtech.api.objects.GT_RenderedTexture;
 import gregtech.api.util.GT_Multiblock_Tooltip_Builder;
 import gregtech.api.util.GT_Recipe;
-import gregtech.api.util.GT_Utility;
 import gregtech.api.util.GTPP_Recipe.GTPP_Recipe_Map;
 import gtPlusPlus.xmod.gregtech.api.metatileentity.implementations.base.GregtechMeta_MultiBlockBase;
 import net.minecraft.block.Block;
@@ -91,37 +89,36 @@ public class GregtechMetaTileEntity_LargeSemifluidGenerator extends GregtechMeta
 	@Override
 	public boolean checkRecipe(ItemStack aStack) {
 		ArrayList<FluidStack> tFluids = getStoredFluids();
-		Collection<GT_Recipe> tRecipeList = GTPP_Recipe_Map.sSemiFluidLiquidFuels.mRecipeList;
 
-		if(tFluids.size() > 0 && tRecipeList != null) { //Does input hatch have a semifluid fuel?
-			for (FluidStack hatchFluid1 : tFluids) { //Loops through hatches
-				for(GT_Recipe aFuel : tRecipeList) { //Loops through semifluid fuel recipes
-					FluidStack tLiquid;
-					if ((tLiquid = GT_Utility.getFluidForFilledItem(aFuel.getRepresentativeInput(0), true)) != null) { //Create fluidstack from current recipe
-						if (hatchFluid1.isFluidEqual(tLiquid)) { //Has a semifluid fluid
-							fuelConsumption = tLiquid.amount = boostEu ? (4096 / aFuel.mSpecialValue) : (2048 / aFuel.mSpecialValue); //Calc fuel consumption
-							if(depleteInput(tLiquid)) { //Deplete that amount
-								boostEu = depleteInput(Materials.Oxygen.getGas(4L));
-								if(tFluids.contains(Materials.Lubricant.getFluid(2L))) { //Has lubricant?
-									//Deplete Lubricant. 2000L should = 1 hour of runtime (if baseEU = 2048)
-									if(mRuntime % 72 == 0 || mRuntime == 0) {
-										depleteInput(Materials.Lubricant.getFluid(boostEu ? 2 : 1));
-									}
-								} 
-								else {
-									return false;
-								}
+		if(tFluids.size() > 0) { //Does input hatch have a semifluid fuel?
+			for (FluidStack hatchFluid : tFluids) { //Loops through hatches
+				GT_Recipe aFuel = GTPP_Recipe_Map.sSemiFluidLiquidFuels.findFuel(hatchFluid);
+				if (aFuel == null) {
+					// Not a valid semi-fluid fuel.
+					continue;
+				}
 
-								fuelValue = aFuel.mSpecialValue;
-								fuelRemaining = hatchFluid1.amount; //Record available fuel
-								this.mEUt = mEfficiency < 2000 ? 0 : 2048; //Output 0 if startup is less than 20%
-								this.mProgresstime = 1;
-								this.mMaxProgresstime = 1;
-								this.mEfficiencyIncrease = 15;
-								return true;
-							}
+				fuelConsumption = boostEu ? (4096 / aFuel.mSpecialValue) : (2048 / aFuel.mSpecialValue); //Calc fuel consumption
+				FluidStack tLiquid = new FluidStack(hatchFluid.getFluid(), fuelConsumption);
+				if(depleteInput(tLiquid)) { //Deplete that amount
+					boostEu = depleteInput(Materials.Oxygen.getGas(4L));
+					if(tFluids.contains(Materials.Lubricant.getFluid(2L))) { //Has lubricant?
+						//Deplete Lubricant. 2000L should = 1 hour of runtime (if baseEU = 2048)
+						if(mRuntime % 72 == 0 || mRuntime == 0) {
+							depleteInput(Materials.Lubricant.getFluid(boostEu ? 2 : 1));
 						}
 					}
+					else {
+						return false;
+					}
+
+					fuelValue = aFuel.mSpecialValue;
+					fuelRemaining = hatchFluid.amount; //Record available fuel
+					this.mEUt = mEfficiency < 2000 ? 0 : 2048; //Output 0 if startup is less than 20%
+					this.mProgresstime = 1;
+					this.mMaxProgresstime = 1;
+					this.mEfficiencyIncrease = 15;
+					return true;
 				}
 			}
 		}


### PR DESCRIPTION
The problem was that `checkRecipe()` was looking for recipes taking cells of fluid as input, but the semi-fluid recipe map only contains recipes that take fluid directly as input.

I also fixed the following bugs:
 * Lubricant check was after consumption of fuel and oxygen. This meant that a generator that was out of lubricant would consume (and waste) fuel and oxygen each time that it checked its recipe. I moved the check earlier so that fuel and oxygen should no longer be wasted.
 * The return value of lubricant consumption was not being checked. The presence of lubricant was checked, which guaranteed that at least `1L` of lubricant was present, but in the case where exactly `1L` of lubricant was present and the generator was oxygen-boosted, it would try to consume `2L` of lubricant each time, fail (leaving the `1L` unconsumed), and ignore the failure. This meant that the `1L` of lubricant would last forever. This has been fixed and the machine will now stop.
 * The max output EU/t and efficiency when boosted did not agree with the tooltip: the tooltip says 6144 EU/t at 150%, but the code actually gave 2048 EU/t base at 200%, which works out to 4096 EU/t actual output. Meanwhile, the amount of fuel consumed was doubled (compared to unboosted at 2048 EU/t), which gave an actual output of 4096 EU/t at 100% fuel efficiency. I've changed this to be 4096 EU/t base at 150% while consuming double the fuel (compared to unboosted at 2048 EU/t), which I believe should work out to an actual output of 6144 EU/t at 150% fuel efficiency, which is what the tooltip says.