### PR TITLE
Changed Minimum Water Check

### DIFF
--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/algae/GregtechMTE_AlgaePondBase.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/algae/GregtechMTE_AlgaePondBase.java
@@ -269,7 +269,7 @@ public class GregtechMTE_AlgaePondBase extends GregtechMeta_MultiBlockBase<Gregt
 			}
 		}
 
-		boolean isValidWater = tAmount >= 60;
+		boolean isValidWater = tAmount >= 49;
 
 		if (isValidWater) {
 			Logger.INFO("Filled structure.");


### PR DESCRIPTION
- Changed the minimum amount of water blocks needed to run the multi, since it only renders one layer of water now instead of two.

Algae Farm didn't run before, it does now. Water change was probably due to StructureLib change.