### PR TITLE
Changed EBF faster recipes to not have circuit 1s

### DIFF
--- a/src/main/java/gtPlusPlus/xmod/gregtech/loaders/RecipeGen_BlastSmelterGT_GTNH.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/loaders/RecipeGen_BlastSmelterGT_GTNH.java
@@ -158,20 +158,40 @@ public class RecipeGen_BlastSmelterGT_GTNH {
 					}
 					//If this recipe is enabled and we have a valid molten fluidstack, let's try add this recipe.
 					if (enabled && isValid(inputs, outputs, inputsF, mMoltenStack)) {						
+						// Boolean to decide whether or not to create a new circuit later
+						boolean circuitFound = false;
+
 						//Build correct input stack
 						ArrayList<ItemStack> aTempList = new ArrayList<ItemStack>();
 						for (ItemStack aPossibleCircuit : inputs) {
 							if (!ItemUtils.isControlCircuit(aPossibleCircuit)) {
 								aTempList.add(aPossibleCircuit);
 							}
+							else {
+								aTempList.add(aPossibleCircuit);
+								circuitFound = true;
+							}
 						}
 						inputs = aTempList.toArray(new ItemStack[aTempList.size()]);						
-						ItemStack[] newInput = new ItemStack[inputs.length+1];						
-						int l = 1;
+						int inputLength = inputs.length;
+						// If no circuit was found, increase array length by 1 to add circuit at newInput[0]
+						if (!circuitFound) {
+							inputLength++;
+						}
+
+						ItemStack[] newInput = new ItemStack[inputLength];
+
+						int l = 0;
+						// If no circuit was found, add a circuit here
+						if (!circuitFound) {
+							l = 1;
+							newInput[0] = CI.getNumberedCircuit(inputs.length);
+						}
+
 						for (ItemStack y : inputs) {
 							newInput[l++] = y;
 						}
-						newInput[0] = CI.getNumberedCircuit(inputs.length);						
+
 						//Logger.MACHINE_INFO("[ABS] Generating ABS recipe for "+mMoltenStack.getLocalizedName()+".");
 						if (CORE.RA.addBlastSmelterRecipe(newInput, (inputsF.length > 0 ? inputsF[0] : null), mMoltenStack, 100, MathUtils.roundToClosestInt(time*0.8), voltage, special)) {
 							//Logger.MACHINE_INFO("[ABS] Success.");

--- a/src/main/java/gtPlusPlus/xmod/gregtech/loaders/RecipeGen_BlastSmelterGT_GTNH.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/loaders/RecipeGen_BlastSmelterGT_GTNH.java
@@ -163,15 +163,13 @@ public class RecipeGen_BlastSmelterGT_GTNH {
 
 						//Build correct input stack
 						ArrayList<ItemStack> aTempList = new ArrayList<ItemStack>();
-						for (ItemStack aPossibleCircuit : inputs) {
-							if (!ItemUtils.isControlCircuit(aPossibleCircuit)) {
-								aTempList.add(aPossibleCircuit);
-							}
-							else {
-								aTempList.add(aPossibleCircuit);
+						for (ItemStack recipeItem : inputs) {
+							if (ItemUtils.isControlCircuit(recipeItem)) {
 								circuitFound = true;
 							}
+							aTempList.add(recipeItem);
 						}
+
 						inputs = aTempList.toArray(new ItemStack[aTempList.size()]);						
 						int inputLength = inputs.length;
 						// If no circuit was found, increase array length by 1 to add circuit at newInput[0]


### PR DESCRIPTION
- Changed the ABS recipes taken from the EBF recipe map to ask for different circuits on the recipes that use a fluid input to reduce crafting time for specific dusts.

The ABS has some EBF recipes included in its recipe map, but the ones that use fluid inputs such as Oxygen to accelerate the crafting use the same circuit as the slower alternatives, circuit 1, and as such these recipes are never chosen by the ABS. With this change, the ABS uses the same circuit as the EBF for these, usually circuit 11, which allows the faster recipes to be used in the ABS.