### PR TITLE
Duplicate Calcium Chloride Changes

### DIFF
--- a/src/main/java/gtPlusPlus/xmod/gregtech/loaders/recipe/RecipeLoader_GlueLine.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/loaders/recipe/RecipeLoader_GlueLine.java
@@ -204,14 +204,27 @@ public class RecipeLoader_GlueLine {
                 MISC_MATERIALS.SODIUM_CYANIDE.getDust(1),
                 10 * 20);
 
-        GT_Values.RA.addChemicalRecipe(
-                CI.getNumberedCircuit(18),
-                ItemUtils.getSimpleStack(ModItems.dustCalciumCarbonate, 1),
-                Materials.SaltWater.getFluid(1000L),
-                FluidUtils.getWater(1000),
-                Materials.SodiumCarbonate.getDust(1),
-                MISC_MATERIALS.CALCIUM_CHLORIDE.getDust(1),
-                5 * 20);
+        if (LoadedMods.BartWorks) {
+            GT_Values.RA.addChemicalRecipe(
+                    CI.getNumberedCircuit(18),
+                    ItemUtils.getSimpleStack(ModItems.dustCalciumCarbonate, 1),
+                    Materials.SaltWater.getFluid(1000L),
+                    FluidUtils.getWater(1000),
+                    Materials.SodiumCarbonate.getDust(1),
+                    ItemUtils.getItemStackFromFQRN("bartworks:gt.bwMetaGenerateddust:63", 1),
+                    5 * 20);
+        }
+
+        else {
+            GT_Values.RA.addChemicalRecipe(
+                    CI.getNumberedCircuit(18),
+                    ItemUtils.getSimpleStack(ModItems.dustCalciumCarbonate, 1),
+                    Materials.SaltWater.getFluid(1000L),
+                    FluidUtils.getWater(1000),
+                    Materials.SodiumCarbonate.getDust(1),
+                    MISC_MATERIALS.CALCIUM_CHLORIDE.getDust(1),
+                    5 * 20);
+        }
 
         GT_Values.RA.addChemicalRecipe(
                 CI.getNumberedCircuit(19),
@@ -253,20 +266,22 @@ public class RecipeLoader_GlueLine {
     }
 
     private static void electrolyzerRecipes() {
-        GT_Values.RA.addElectrolyzerRecipe(
-                CI.getNumberedCircuit(1),
-                MISC_MATERIALS.CALCIUM_CHLORIDE.getDust(1),
-                null,
-                Materials.Chlorine.getFluid(2000), // Out
-                Materials.Calcium.getDust(1),
-                null,
-                null,
-                null,
-                null,
-                null,
-                new int[] {10000, 10000, 10000},
-                20 * 30,
-                120);
+        if (!LoadedMods.BartWorks) {
+            GT_Values.RA.addElectrolyzerRecipe(
+                    CI.getNumberedCircuit(1),
+                    MISC_MATERIALS.CALCIUM_CHLORIDE.getDust(3),
+                    null,
+                    Materials.Chlorine.getFluid(2000), // Out
+                    Materials.Calcium.getDust(1),
+                    null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    new int[]{10000, 10000, 10000},
+                    20 * 30,
+                    120);
+        }
     }
 
     private static void fluidHeaterRecipes() {


### PR DESCRIPTION
- Changed Sodium Carbonite recipe to use the Bartworks Calcium Chloride instead, if loaded. If it isn't loaded, the GT++ dust is used instead (at Alkalus's request of having this dust defined in GT++ as well);
- Removed duplicate electrolyzer recipe if BW is loaded. If it isn't, the recipe does load. Also adjusted the amount of inputs, 3 dusts instead of 1.

Alkalus requested that the Calcium Chloride dust, defined in GT++, is kept there, despite BW already having a dust for the same material. I made it so the duplicate GT++ recipes only load if BW isn't loaded. Awaiting further feedback.