### PR TITLE
Fix books localization

### DIFF
--- a/src/main/java/gtPlusPlus/core/handler/BookHandler.java
+++ b/src/main/java/gtPlusPlus/core/handler/BookHandler.java
@@ -13,6 +13,9 @@ import gtPlusPlus.core.util.minecraft.RecipeUtils;
 import net.minecraft.init.Items;
 import net.minecraft.item.ItemStack;
 
+import static gtPlusPlus.core.util.Utils.addBookPagesLocalization;
+import static gtPlusPlus.core.util.Utils.addBookTitleLocalization;
+
 public class BookHandler {
 
 	public static int mBookKeeperCount = 0;
@@ -379,7 +382,12 @@ public class BookHandler {
 
 	private static BookTemplate writeBookTemplate(String aMapping, String aTitle, String aAuthor, String[] aPages){
 		mBookKeeperCount++;
-		BookTemplate mTemp = new BookTemplate(mBookKeeperCount, aMapping, aTitle, aAuthor, aPages);
+        for (int i = 0; i < aPages.length; i++) {
+            aPages[i] = aPages[i].replaceAll("\n", "<BR>");
+        }
+        addBookTitleLocalization(aTitle);
+        addBookPagesLocalization(aTitle, aPages);
+        BookTemplate mTemp = new BookTemplate(mBookKeeperCount, aMapping, aTitle, aAuthor, aPages);
 		mBookMap.put(mBookKeeperCount-1, mTemp);
 		return mTemp;
 	}

--- a/src/main/java/gtPlusPlus/core/item/general/books/ItemBaseBook.java
+++ b/src/main/java/gtPlusPlus/core/item/general/books/ItemBaseBook.java
@@ -1,6 +1,7 @@
 package gtPlusPlus.core.item.general.books;
 
 import static gtPlusPlus.core.handler.BookHandler.mBookMap;
+import static gtPlusPlus.core.util.Utils.addBookTitleLocalization;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
@@ -65,7 +66,7 @@ public class ItemBaseBook extends ItemWritableBook{
 			return NBTUtils.getString(tItem, "title");
 		}
 		else if (tItem.getItemDamage() > -1 && tItem.getItemDamage() <= mBookMap.size()){
-			return EnumChatFormatting.ITALIC+""+mBookMap.get(tItem.getItemDamage()).mTitle;
+            return EnumChatFormatting.ITALIC + "" + addBookTitleLocalization(mBookMap.get(tItem.getItemDamage()).mTitle);
 		}
 		//NBTUtils.tryIterateNBTData(tItem);
 		return "GT++ Storybook";

--- a/src/main/java/gtPlusPlus/core/util/Utils.java
+++ b/src/main/java/gtPlusPlus/core/util/Utils.java
@@ -28,6 +28,7 @@ import cpw.mods.fml.common.FMLCommonHandler;
 import cpw.mods.fml.common.registry.EntityRegistry;
 import cpw.mods.fml.common.registry.EntityRegistry.EntityRegistration;
 import gregtech.GT_Mod;
+import gregtech.api.GregTech_API;
 import gregtech.api.enums.GT_Values;
 import gregtech.api.enums.ItemList;
 import gregtech.api.enums.Materials;
@@ -723,6 +724,21 @@ public class Utils {
 		}
 	}
 
+    public static String addBookTitleLocalization(final String aTitle) {
+        return GT_LanguageManager.addStringLocalization(
+                new StringBuilder().append("Book.").append(aTitle).append(".Name").toString(), aTitle, !GregTech_API.sPostloadFinished);
+    }
+
+    public static String[] addBookPagesLocalization(final String aTitle, final String[] aPages) {
+        String[] aLocalizationPages = new String[aPages.length];
+        for (byte i = 0; i < aPages.length; i = (byte) (i + 1)) {
+            aLocalizationPages[i] = GT_LanguageManager
+                    .addStringLocalization(new StringBuilder().append("Book.").append(aTitle).append(".Page")
+                            .append((i < 10) ? new StringBuilder().append("0").append(i).toString() : Byte.valueOf(i))
+                            .toString(), aPages[i], !GregTech_API.sPostloadFinished);
+        }
+        return aLocalizationPages;
+    }
 
 	public static ItemStack getWrittenBook(final ItemStack aBook, final int aID, final String aMapping, final String aTitle, final String aAuthor,
 			final String[] aPages) {
@@ -739,15 +755,13 @@ public class Utils {
 		final int vMeta = aID;
 		rStack = (aBook == null ? new ItemStack(ModItems.itemCustomBook, 1, vMeta) : aBook);
 		final NBTTagCompound tNBT = new NBTTagCompound();
-		tNBT.setString("title", GT_LanguageManager.addStringLocalization(
-				new StringBuilder().append("Book.").append(aTitle).append(".Name").toString(), aTitle));
+        String localizationTitle = addBookTitleLocalization(aTitle);
+		tNBT.setString("title", localizationTitle);
 		tNBT.setString("author", aAuthor);
 		final NBTTagList tNBTList = new NBTTagList();
-		for (byte i = 0; i < aPages.length; i = (byte) (i + 1)) {
-			aPages[i] = GT_LanguageManager
-					.addStringLocalization(new StringBuilder().append("Book.").append(aTitle).append(".Page")
-							.append((i < 10) ? new StringBuilder().append("0").append(i).toString() : Byte.valueOf(i))
-							.toString(), aPages[i]);
+        final String[] aLocalizationPages = addBookPagesLocalization(aTitle, aPages);
+        for (byte i = 0; i < aPages.length; i = (byte) (i + 1)) {
+			aPages[i] = aLocalizationPages[i].replaceAll("<BR>", "\n");
 			if (i < 48) {
 				if (aPages[i].length() < 256) {
 					tNBTList.appendTag(new NBTTagString(aPages[i]));


### PR DESCRIPTION
There are several changes as follows.

- write to `GregTech.lang` when the game is loaded, rather than when the book is opened, to make it easier to localize

- localized the display names of the books

- Avoid using `\n` in `GregTech.lang` and use `<BR>` instead