### PR TITLE
Change UV Hi-Amp Transformer UHV Cable to Bedrockium

### DIFF
--- a/src/main/java/gtPlusPlus/xmod/gregtech/registration/gregtech/GregtechHiAmpTransformer.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/registration/gregtech/GregtechHiAmpTransformer.java
@@ -106,7 +106,7 @@ public class GregtechHiAmpTransformer {
 							mItem_2 });
 			GT_ModHandler.addCraftingRecipe(GregtechItemList.Transformer_HA_MAX_UV.get(1L, new Object[0]), bitsd,
 					new Object[] { "KBB", "CM ", "KBB", Character.valueOf('M'), ItemList.Hull_UV, Character.valueOf('C'),
-							OrePrefixes.wireGt01.get(Materials.Superconductor), Character.valueOf('B'),
+							OrePrefixes.wireGt01.get(Materials.Bedrockium), Character.valueOf('B'),
 							OrePrefixes.wireGt04.get(Materials.NaquadahAlloy), Character.valueOf('K'),
 							mItem_3 });
 		}else{


### PR DESCRIPTION
Allows you actually craft this thing in UV instead of having to go through a long & arduous task of making the UHV SC in the first place (unless you're playing on a very old pre-changed SC patch). I have no idea if this'll throw a fit because of the 'Bedrockium' material, though I hope it doesn't