### PR TITLE
Add XL Large Boiler - Industrial Superheater

### DIFF
--- a/src/main/java/gtPlusPlus/core/handler/COMPAT_HANDLER.java
+++ b/src/main/java/gtPlusPlus/core/handler/COMPAT_HANDLER.java
@@ -166,6 +166,7 @@ public class COMPAT_HANDLER {
 			GregtechIndustrialRockBreaker.run();
 			GregtechIndustrialChisel.run();
 			GregtechIndustrialFluidHeater.run();
+			GregtechIndustrialSuperheater.run();
 
 			//New Horizons Content
 			NewHorizonsAccelerator.run();

--- a/src/main/java/gtPlusPlus/core/item/ModItems.java
+++ b/src/main/java/gtPlusPlus/core/item/ModItems.java
@@ -639,6 +639,8 @@ public final class ModItems {
 			MaterialGenerator.generate(ALLOY.BABBIT_ALLOY, false);
 			MaterialGenerator.generate(ALLOY.BLACK_TITANIUM, false);
 
+			MaterialGenerator.generate(ALLOY.RPTH_STEELUX);
+
 			// High Level Bioplastic
 			MaterialGenerator.generate(ELEMENT.STANDALONE.RHUGNOR, false, false);
 

--- a/src/main/java/gtPlusPlus/core/lib/CORE.java
+++ b/src/main/java/gtPlusPlus/core/lib/CORE.java
@@ -255,6 +255,7 @@ public class CORE {
 		public static boolean enableMultiblock_IndustrialExtrudingMachine = true;
 		public static boolean enableMultiblock_IndustrialMultiMachine = true;
 		public static boolean enableMultiblock_Cyclotron = true;
+		public static boolean enableMultiblock_IndustrialSuperheater = true;
 
 		//Visuals
 		public static boolean enableTreeFarmerParticles = true;

--- a/src/main/java/gtPlusPlus/core/material/ALLOY.java
+++ b/src/main/java/gtPlusPlus/core/material/ALLOY.java
@@ -968,7 +968,23 @@ public final class ALLOY {
 					new MaterialStack(ELEMENT.getInstance().ARSENIC, 2)
 			});
 
-
+	public static final Material RPTH_STEELUX = new Material(
+			"RPTh Steelux Alloy", //Material Name
+			MaterialState.SOLID, //State
+			null, //Material Colour
+			2500, //Melting Point in C
+			5000,
+			-1,
+			-1,
+			true, //Uses Blast furnace?
+			//Material Stacks with Percentage of required elements.
+			new MaterialStack[]{
+					new MaterialStack(ELEMENT.getInstance().RHODIUM, 5),
+					new MaterialStack(ELEMENT.getInstance().PALLADIUM, 5),
+					new MaterialStack(ELEMENT.getInstance().TUNGSTEN, 2),
+					new MaterialStack(ELEMENT.getInstance().THAUMIUM, 3),
+					new MaterialStack(ELEMENT.getInstance().HELIUM, 2)
+			});
 
 
 

--- a/src/main/java/gtPlusPlus/core/recipe/RECIPES_Machines.java
+++ b/src/main/java/gtPlusPlus/core/recipe/RECIPES_Machines.java
@@ -16,6 +16,7 @@ import gtPlusPlus.core.lib.CORE;
 import gtPlusPlus.core.lib.LoadedMods;
 import gtPlusPlus.core.material.ALLOY;
 import gtPlusPlus.core.material.ELEMENT;
+import gtPlusPlus.core.material.MISC_MATERIALS;
 import gtPlusPlus.core.material.Material;
 import gtPlusPlus.core.recipe.common.CI;
 import gtPlusPlus.core.util.minecraft.*;
@@ -27,6 +28,7 @@ import gtPlusPlus.xmod.gregtech.common.Meta_GT_Proxy;
 import gtPlusPlus.xmod.gregtech.common.covers.CoverManager;
 import gtPlusPlus.xmod.gregtech.common.helpers.VolumetricFlaskHelper;
 import gtPlusPlus.xmod.gregtech.common.items.MetaCustomCoverItem;
+import gtPlusPlus.xmod.gregtech.loaders.recipe.RecipeLoader_GlueLine;
 import net.minecraft.block.Block;
 import net.minecraft.init.Blocks;
 import net.minecraft.init.Items;
@@ -2395,6 +2397,31 @@ public class RECIPES_Machines {
 						"wireFineElectrum", ItemUtils.getSimpleStack(ModBlocks.blockFishTrap), "wireFineElectrum",
 						plate,CI.getTieredCircuit(2),plate,
 						GregtechItemList.Industrial_FishingPond.get(1));
+			}
+
+			if (CORE.ConfigSwitches.enableMultiblock_IndustrialSuperheater){
+				ItemStack plate = ALLOY.RPTH_STEELUX.getPlate(1);
+				RecipeUtils.addShapedRecipe(
+						plate, CI.craftingToolHammer_Hard, plate,
+						"plateTalonite", "frameGtTalonite", "plateTalonite",
+						plate, CI.craftingToolWrench, plate,
+						GregtechItemList.Casing_IndustrialSuperheater.get(1));
+
+				CORE.RA.addSixSlotAssemblingRecipe(
+						new ItemStack[] {
+								GregtechItemList.Casing_IndustrialSuperheater.get(1),
+								ALLOY.RPTH_STEELUX.getPlate(2)
+						},
+						MISC_MATERIALS.ETHYL_CYANOACRYLATE.getFluidStack(200), //Input Fluid
+						GregtechItemList.Casing_IndustrialSuperheaterReinforced.get(1),
+						20 * 10  * 6,
+						MaterialUtils.getVoltageForTier(6));
+
+				RecipeUtils.addShapedRecipe(
+						plate,CI.getTieredCircuit(7),plate,
+						"plateTalonite", ItemUtils.getSimpleStack(ModBlocks.blockFishTrap), "plateTalonite",
+						plate,CI.getTieredCircuit(6),plate,
+						GregtechItemList.Controller_IndustrialSuperheater.get(1));
 			}
 
 			if (true) {

--- a/src/main/java/gtPlusPlus/xmod/gregtech/api/enums/GregtechItemList.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/api/enums/GregtechItemList.java
@@ -435,6 +435,11 @@ public enum GregtechItemList implements GregtechItemContainer {
 	// Industrial Fluid Heater
 	Controller_IndustrialFluidHeater,
 
+	// Industrial Superheater
+	Controller_IndustrialSuperheater,
+	Casing_IndustrialSuperheater,
+	Casing_IndustrialSuperheaterReinforced,
+
 	// Custom Machine Casings
 	Casing_Machine_Custom_1,
 	Casing_Machine_Custom_2,

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/blocks/GregtechMetaCasingBlocks2.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/blocks/GregtechMetaCasingBlocks2.java
@@ -41,7 +41,7 @@ extends GregtechMetaCasingBlocksAbstract {
 	public GregtechMetaCasingBlocks2() {
 		super(GregtechMetaCasingItemBlocks2.class, "gtplusplus.blockcasings.2", GT_Material_Casings.INSTANCE);
 		for (byte i = 0; i < 16; i = (byte) (i + 1)) {
-			if (i == 4 || i == 10 || i == 11 || i == 12 || i == 14) {
+			if (i == 4 || i == 10 || i == 11 || i == 12 || i == 13 || i == 14) {
 				continue;
 			}
 			TAE.registerTexture(1, i, new GTPP_CopiedBlockTexture(this, 6, i));

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/blocks/GregtechMetaCasingBlocks5.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/blocks/GregtechMetaCasingBlocks5.java
@@ -36,8 +36,9 @@ extends GregtechMetaCasingBlocksAbstract {
 		TAE.registerTexture(1, 10, new GTPP_CopiedBlockTexture(this, 6, 5));
 		GT_LanguageManager.addStringLocalization(this.getUnlocalizedName() + ".6.name", "Forge Casing"); // Forge Hammer Casing
 		TAE.registerTexture(1, 11, new GTPP_CopiedBlockTexture(this, 6, 6));
-		GT_LanguageManager.addStringLocalization(this.getUnlocalizedName() + ".7.name", ""); // Unused
-		GT_LanguageManager.addStringLocalization(this.getUnlocalizedName() + ".8.name", ""); // Unused
+		GT_LanguageManager.addStringLocalization(this.getUnlocalizedName() + ".7.name", "Industrial Superheater Casing"); // Large Boiler Casing
+		GT_LanguageManager.addStringLocalization(this.getUnlocalizedName() + ".8.name", "Reinforced Superheater Casing"); // Reinforced Large Boiler Casing
+		TAE.registerTexture(1, 13, new GTPP_CopiedBlockTexture(this, 6, 6));
 		GT_LanguageManager.addStringLocalization(this.getUnlocalizedName() + ".9.name", ""); // Unused
 		GT_LanguageManager.addStringLocalization(this.getUnlocalizedName() + ".10.name", ""); // Unused
 		GT_LanguageManager.addStringLocalization(this.getUnlocalizedName() + ".11.name", ""); // Unused
@@ -53,6 +54,8 @@ extends GregtechMetaCasingBlocksAbstract {
 		GregtechItemList.Casing_Sparge_Tower_Exterior.set(new ItemStack(this, 1, 4));
 		GregtechItemList.Casing_IndustrialAutoChisel.set(new ItemStack(this, 1, 5));
 		GregtechItemList.Casing_IndustrialForgeHammer.set(new ItemStack(this, 1, 6));
+		GregtechItemList.Casing_IndustrialSuperheater.set(new ItemStack(this, 1, 7));
+		GregtechItemList.Casing_IndustrialSuperheaterReinforced.set(new ItemStack(this, 1, 8));
 	}
 	
 	@Override
@@ -78,6 +81,10 @@ extends GregtechMetaCasingBlocksAbstract {
 					return TexturesGtBlock.Casing_Machine_Metal_Sheet_I.getIcon();
 				case 6:
 					return TexturesGtBlock.TEXTURE_TECH_PANEL_H.getIcon();
+				case 7:
+					return TexturesGtBlock.TEXTURE_CASING_INDUSTRIAL_SUPERHEATER.getIcon();
+				case 8:
+					return TexturesGtBlock.TEXTURE_CASING_INDUSTRIAL_SUPERHEATER_REINFORCED.getIcon();
 			}
 		}
 		return Textures.BlockIcons.RENDERING_ERROR.getIcon();		

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/blocks/textures/TexturesGtBlock.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/blocks/textures/TexturesGtBlock.java
@@ -318,6 +318,8 @@ public class TexturesGtBlock {
 	public static final CustomIcon TEXTURE_CASING_ROCKETDYNE = new CustomIcon("TileEntities/MACHINE_CASING_ROCKETDYNE");
 	public static final CustomIcon TEXTURE_CASING_GRINDING_MILL = new CustomIcon("TileEntities/MACHINE_CASING_GRINDING_FACTORY");
 	public static final CustomIcon TEXTURE_CASING_FLOTATION = new CustomIcon("TileEntities/MACHINE_CASING_FLOTATION");
+	public static final CustomIcon TEXTURE_CASING_INDUSTRIAL_SUPERHEATER = new CustomIcon("TileEntities/MACHINE_CASING_INDUSTRIAL_SUPERHEATER");
+	public static final CustomIcon TEXTURE_CASING_INDUSTRIAL_SUPERHEATER_REINFORCED = new CustomIcon("TileEntities/MACHINE_CASING_INDUSTRIAL_SUPERHEATER_REINFORCED");
 		
 	// Custom Pipes
 	public static final CustomIcon TEXTURE_PIPE_GRINDING_MILL = new CustomIcon("TileEntities/MACHINE_CASING_PIPE_T1");	

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/GregtechMetaTileEntity_IndustrialSuperheater.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/GregtechMetaTileEntity_IndustrialSuperheater.java
@@ -1,0 +1,248 @@
+package gtPlusPlus.xmod.gregtech.common.tileentities.machines.multi.processing;
+
+import com.gtnewhorizon.structurelib.structure.IStructureDefinition;
+import com.gtnewhorizon.structurelib.structure.StructureDefinition;
+import gregtech.api.GregTech_API;
+import gregtech.api.enums.TAE;
+import gregtech.api.enums.Textures;
+import gregtech.api.interfaces.ITexture;
+import gregtech.api.interfaces.metatileentity.IMetaTileEntity;
+import gregtech.api.interfaces.tileentity.IGregTechTileEntity;
+import gregtech.api.metatileentity.implementations.*;
+import gregtech.api.objects.GT_RenderedTexture;
+import gregtech.api.util.GT_Multiblock_Tooltip_Builder;
+import gregtech.api.util.GT_Recipe;
+import gregtech.api.util.GT_Utility;
+import gtPlusPlus.core.block.ModBlocks;
+import gtPlusPlus.core.lib.CORE;
+import gtPlusPlus.xmod.gregtech.api.metatileentity.implementations.base.GregtechMeta_MultiBlockBase;
+import gtPlusPlus.xmod.gregtech.common.blocks.textures.TexturesGtBlock;
+import net.minecraft.block.Block;
+import net.minecraft.item.ItemStack;
+
+import static com.gtnewhorizon.structurelib.structure.StructureUtility.*;
+import static com.gtnewhorizon.structurelib.structure.StructureUtility.ofBlock;
+import static gregtech.api.util.GT_StructureUtility.ofHatchAdder;
+
+public class GregtechMetaTileEntity_IndustrialSuperheater extends GregtechMeta_MultiBlockBase<GregtechMetaTileEntity_IndustrialSuperheater> {
+    private int mCasing1;
+    private IStructureDefinition<GregtechMetaTileEntity_IndustrialSuperheater> STRUCTURE_DEFINITION = null;
+
+    public GregtechMetaTileEntity_IndustrialSuperheater(final int aID, final String aName, final String aNameRegional) {
+        super(aID, aName, aNameRegional);
+    }
+
+    public GregtechMetaTileEntity_IndustrialSuperheater(final String aName) {
+        super(aName);
+    }
+
+    @Override
+    public IMetaTileEntity newMetaEntity(final IGregTechTileEntity aTileEntity) {
+        return new GregtechMetaTileEntity_IndustrialSuperheater(this.mName);
+    }
+
+    @Override
+    public String getMachineType() {
+        return "Large Steam Boiler";
+    }
+
+    @Override
+    protected GT_Multiblock_Tooltip_Builder createTooltip() {
+        GT_Multiblock_Tooltip_Builder tt = new GT_Multiblock_Tooltip_Builder();
+        tt.addMachineType(getMachineType())
+                .addInfo("Controller Block for the Industrial Fluid Heater")
+                .addInfo("120% faster than using single block machines of the same voltage")
+                .addInfo("Only uses 90% of the eu/t normally required")
+                .addInfo("Processes eight items per voltage tier")
+                .addPollutionAmount(getPollutionPerSecond(null))
+                .addSeparator()
+                .beginStructureBlock(5, 6, 5, true)
+                .addController("Front Center")
+                .addCasingInfo("Top/Bottom layer: Multi-use Casings", 34)
+                .addCasingInfo("Middle layers: Thermal Containment Casing", 47)
+                .addInputBus("Bottom Layer (optional)", 1)
+                .addInputHatch("Bottom Layer", 1)
+                .addOutputBus("Top Layer (optional)", 1)
+                .addOutputHatch("Top Layer", 1)
+                .addEnergyHatch("Any Multi-use Casing", 1)
+                .addMaintenanceHatch("Any Multi-use Casing", 1)
+                .addMufflerHatch("Any Multi-use Casing", 1)
+                .toolTipFinisher(CORE.GT_Tooltip_Builder);
+        return tt;
+    }
+
+    @Override
+    public IStructureDefinition<GregtechMetaTileEntity_IndustrialSuperheater> getStructureDefinition() {
+        if (STRUCTURE_DEFINITION == null) {
+            STRUCTURE_DEFINITION = StructureDefinition.<GregtechMetaTileEntity_IndustrialSuperheater>builder()
+                    .addShape(mName, transpose(new String[][]{
+                            {"  LLL  ", "  CCC  ", "  CCC  ", "  CCC  ", "  CCC  ", "  CCC  ", "  CCC  ", "  CCC  ", "  CCC  ", "  CCC  ", "  CCC  ", "  LLL  "},
+                            {" LRRRL ", " C---C ", " C---C ", " C---C ", " C---C ", " C---C ", " C---C ", " C---C ", " C---C ", " C---C ", " C---C ", " LSSSL "},
+                            {"LRRRRRL", "L-----L", "L-----L", "L-----L", "L-----L", "L-----L", "L-----L", "L-----L", "L-----L", "L-----L", "L-----L", "LSSSSSL"},
+                            {"LRR~RRL", "I-----I", "I-----I", "I-----I", "I-----I", "I-----I", "I-----I", "I-----I", "I-----I", "I-----I", "I-----I", "LSSSSSL"},
+                            {"LRRRRRL", "L-----L", "L-----L", "L-----L", "L-----L", "L-----L", "L-----L", "L-----L", "L-----L", "L-----L", "L-----L", "LSSSSSL"},
+                            {" LRRRL ", " C---C ", " C---C ", " C---C ", " C---C ", " C---C ", " C---C ", " C---C ", " C---C ", " C---C ", " C---C ", " LSSSL "},
+                            {"  LLL  ", "  CCC  ", "  CCC  ", "  CCC  ", "  CCC  ", "  CCC  ", "  CCC  ", "  CCC  ", "  CCC  ", "  CCC  ", "  CCC  ", "  LLL  "}
+                    }))
+
+                    .addElement('C', ofBlock(getCasingBlock1(), getCasingMeta1()))
+
+                    .addElement('L', ofBlock(getCasingBlock2(), getCasingMeta2()))
+
+                    .addElement('I', ofChain(
+                            ofHatchAdder(GregtechMetaTileEntity_IndustrialSuperheater::addIndustrialSuperheaterFuelInputList, getCasingTextureIndex(), 1),
+                            onElementPass(x -> ++x.mCasing1, ofBlock(getCasingBlock2(), getCasingMeta2()))))
+
+                    .addElement('R', ofChain(
+                            ofHatchAdder(GregtechMetaTileEntity_IndustrialSuperheater::addIndustrialSuperheaterInputList, getCasingTextureIndex(), 1),
+                            onElementPass(x -> ++x.mCasing1, ofBlock(getCasingBlock2(), getCasingMeta2()))))
+
+                    .addElement('S', ofChain(
+                            ofHatchAdder(GregtechMetaTileEntity_IndustrialSuperheater::addIndustrialSuperheaterOutputList, getCasingTextureIndex(), 1),
+                            onElementPass(x -> ++x.mCasing1, ofBlock(getCasingBlock2(), getCasingMeta2()))))
+
+                    .build();
+        }
+        return STRUCTURE_DEFINITION;
+    }
+
+    @Override
+    public void construct(ItemStack stackSize, boolean hintsOnly) {
+        buildPiece(mName , stackSize, hintsOnly, 3, 3, 0);
+    }
+
+    @Override
+    public boolean checkMachine(IGregTechTileEntity aBaseMetaTileEntity, ItemStack aStack) {
+        mCasing1 = 0;
+        boolean didBuild = checkPiece(mName, 3, 3, 0);
+        log("Built? "+didBuild+", "+mCasing1);
+        return didBuild && mCasing1 >= 34 && checkHatch();
+    }
+
+    public final boolean addIndustrialSuperheaterInputList(IGregTechTileEntity aTileEntity, int aBaseCasingIndex) {
+        if (aTileEntity == null) {
+            return false;
+        }
+        else {
+            IMetaTileEntity aMetaTileEntity = aTileEntity.getMetaTileEntity();
+            if (aMetaTileEntity instanceof GT_MetaTileEntity_Hatch_Maintenance){
+                return addToMachineList(aTileEntity, aBaseCasingIndex);
+            }
+            else if (aMetaTileEntity instanceof GT_MetaTileEntity_Hatch_Muffler) {
+                return addToMachineList(aTileEntity, aBaseCasingIndex);
+            }
+            else if (aMetaTileEntity instanceof GT_MetaTileEntity_Hatch_Input) {
+                return addToMachineList(aTileEntity, aBaseCasingIndex);
+            }
+        }
+        return false;
+    }
+
+    public final boolean addIndustrialSuperheaterFuelInputList(IGregTechTileEntity aTileEntity, int aBaseCasingIndex) {
+        if (aTileEntity == null) {
+            return false;
+        }
+        else {
+            IMetaTileEntity aMetaTileEntity = aTileEntity.getMetaTileEntity();
+            if (aMetaTileEntity instanceof GT_MetaTileEntity_Hatch_InputBus){
+                return addToMachineList(aTileEntity, aBaseCasingIndex);
+            }
+        }
+        return false;
+    }
+
+    public final boolean addIndustrialSuperheaterOutputList(IGregTechTileEntity aTileEntity, int aBaseCasingIndex) {
+        if (aTileEntity == null) {
+            return false;
+        }
+        else {
+            IMetaTileEntity aMetaTileEntity = aTileEntity.getMetaTileEntity();
+            if (aMetaTileEntity instanceof GT_MetaTileEntity_Hatch_Maintenance){
+                return addToMachineList(aTileEntity, aBaseCasingIndex);
+            }
+            else if (aMetaTileEntity instanceof GT_MetaTileEntity_Hatch_Muffler) {
+                return addToMachineList(aTileEntity, aBaseCasingIndex);
+            }
+            else if (aMetaTileEntity instanceof GT_MetaTileEntity_Hatch_Output) {
+                return addToMachineList(aTileEntity, aBaseCasingIndex);
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public ITexture[] getTexture(final IGregTechTileEntity aBaseMetaTileEntity, final byte aSide, final byte aFacing, final byte aColorIndex, final boolean aActive, final boolean aRedstone) {
+        if (aSide == aFacing) {
+            return new ITexture[]{Textures.BlockIcons.getCasingTextureForId(TAE.getIndexFromPage(0, 1)), new GT_RenderedTexture(aActive ? TexturesGtBlock.Overlay_Machine_Controller_Advanced_Active : TexturesGtBlock.Overlay_Machine_Controller_Advanced)};
+        }
+        return new ITexture[]{Textures.BlockIcons.getCasingTextureForId(TAE.getIndexFromPage(0, 1))};
+    }
+
+    @Override
+    public boolean hasSlotInGUI() {
+        return false;
+    }
+
+    @Override
+    public String getCustomGUIResourceName() {
+        return "IndustrialSuperheater";
+    }
+
+    @Override
+    public GT_Recipe.GT_Recipe_Map getRecipeMap() {
+        return GT_Recipe.GT_Recipe_Map.sFluidHeaterRecipes;
+    }
+
+    @Override
+    public boolean checkRecipe(final ItemStack aStack) {
+        return checkRecipeGeneric(getMaxParallelRecipes(), getEuDiscountForParallelism(), 120);
+    }
+
+    @Override
+    public int getMaxParallelRecipes() {
+        return (8 * GT_Utility.getTier(this.getMaxInputVoltage()));
+    }
+
+    @Override
+    public int getEuDiscountForParallelism() {
+        return 90;
+    }
+
+    @Override
+    public int getMaxEfficiency(final ItemStack aStack) {
+        return 10000;
+    }
+
+    @Override
+    public int getPollutionPerSecond(final ItemStack aStack) {
+        return CORE.ConfigSwitches.pollutionPerSecondMultiIndustrialThermalCentrifuge;
+    }
+
+    @Override
+    public int getAmountOfOutputs() {
+        return 1;
+    }
+
+    @Override
+    public boolean explodesOnComponentBreak(final ItemStack aStack) {
+        return true;
+    }
+
+    public Block getCasingBlock1() {
+        return ModBlocks.blockCasings5Misc;
+    }
+
+    public byte getCasingMeta1() { return 7; }
+
+    public Block getCasingBlock2() {
+        return ModBlocks.blockCasings5Misc;
+    }
+
+    public byte getCasingMeta2() {
+        return 8;
+    }
+
+    public byte getCasingTextureIndex() {
+        return (byte) TAE.getIndexFromPage(1, 13);
+    }
+}

--- a/src/main/java/gtPlusPlus/xmod/gregtech/registration/gregtech/GregtechIndustrialSuperheater.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/registration/gregtech/GregtechIndustrialSuperheater.java
@@ -1,0 +1,22 @@
+package gtPlusPlus.xmod.gregtech.registration.gregtech;
+
+import gtPlusPlus.api.objects.Logger;
+import gtPlusPlus.xmod.gregtech.api.enums.GregtechItemList;
+import gtPlusPlus.xmod.gregtech.common.tileentities.machines.multi.processing.GregtechMetaTileEntity_IndustrialSuperheater;
+
+public class GregtechIndustrialSuperheater {
+
+    public static void run() {
+        if (gtPlusPlus.core.lib.LoadedMods.Gregtech) {
+            Logger.INFO("Gregtech5u Content | Registering Industrial Superheater Multiblock.");
+            run1();
+        }
+
+    }
+
+    private static void run1() {
+        GregtechItemList.Controller_IndustrialSuperheater.set(new GregtechMetaTileEntity_IndustrialSuperheater(31080,
+                "industrialsuperheater.controller.tier.single", "Industrial Superheater").getStackForm(1L));
+
+    }
+}


### PR DESCRIPTION
- Groundwork for the Industrial Superheater Implementation, a LuV Steam Boiler multiblock that turns Super Fuels into Superheated Steam at a much faster rate than any of the Large Boilers;
- Added a new alloy, RPTh Steelux Alloy, to be used in the casings of this multi;
- Added recipes for the casings and controller (recipes are not final, still need changes);
-  Added custom textures for the casings.

Missing the logic and some fixes to structure lib, to properly define how many of each hatch are needed and to fix the textures of hatches when the multi is formed.