### PR TITLE
LFTR Fixes and Changes

### DIFF
--- a/src/main/java/gtPlusPlus/core/item/chemistry/NuclearChem.java
+++ b/src/main/java/gtPlusPlus/core/item/chemistry/NuclearChem.java
@@ -68,7 +68,7 @@ public class NuclearChem extends ItemPackage {
 		Burnt_LiFBeF2ThF4UF4 = FluidUtils.generateFluidNonMolten("BurntLiFBeF2ThF4UF4", "Burnt LiFBeF2ThF4UF4 Salt", 545, new short[]{48, 175, 48, 100}, null, null);
 		Burnt_LiFBeF2ZrF4UF4 = FluidUtils.generateFluidNonMolten("BurntLiFBeF2ZrF4UF4", "Burnt LiFBeF2ZrF4UF4 Salt", 520, new short[]{48, 168, 68, 100}, null, null);
 		Burnt_LiFBeF2ZrF4U235 = FluidUtils.generateFluidNonMolten("BurntLiFBeF2ZrF4U235", "Burnt LiFBeF2ZrF4U235 Salt", 533, new short[]{68, 185, 48, 100}, null, null);
-		Impure_LiFBeF2 = FluidUtils.generateFluidNonMolten("ImpureLiFBeF2", "Impure LiFBeF2 Salt", 533, new short[]{110, 75, 186, 100}, null, null);
+		Impure_LiFBeF2 = FluidUtils.generateFluidNonMolten("ImpureLiFBeF2", "Impure Molten Salt Base", 533, new short[]{110, 75, 186, 100}, null, null);
 		if (FluidUtils.getFluidStack("fluid.Mutagen", 1) == null) {
 			GeneticMutagen = FluidUtils.generateFluidNonMolten("GeneticMutagen", "Genetic Mutagen", 12, new short[]{22, 148, 185, 100}, null, null);
 			generateMutagenRecipe = true;

--- a/src/main/java/gtPlusPlus/core/material/nuclear/NUCLIDE.java
+++ b/src/main/java/gtPlusPlus/core/material/nuclear/NUCLIDE.java
@@ -11,7 +11,7 @@ import gtPlusPlus.core.util.data.StringUtils;
 public final class NUCLIDE {
 
 	public static final Material Li2BeF4 = new Material(
-			"Lithium Tetrafluoroberyllate", //Material Name
+			"Lithium Tetrafluoroberyllate (LFTB)", //Material Name
 			MaterialState.LIQUID, //State
 			TextureSets.NUCLEAR.get(),
 			null, //Material Colour
@@ -29,7 +29,7 @@ public final class NUCLIDE {
 			});
 	
 	public static final Material LiFBeF2ThF4UF4 = new Material(
-			"LiFBeF2ThF4UF4", //Material Name
+			"LFTR Fuel 3", //Material Name
 			MaterialState.LIQUID, //State
 			TextureSets.NUCLEAR.get(),
 			null, //Material Colour
@@ -49,7 +49,7 @@ public final class NUCLIDE {
 			});
 	
 	public static final Material LiFBeF2ZrF4UF4 = new Material(
-			"LiFBeF2ZrF4UF4", //Material Name
+			"LFTR Fuel 2", //Material Name
 			MaterialState.LIQUID, //State
 			TextureSets.NUCLEAR.get(),
 			null, //Material Colour
@@ -69,7 +69,7 @@ public final class NUCLIDE {
 			});
 
 	public static final Material LiFBeF2ZrF4U235 = new Material(
-			"LiFBeF2ZrF4U235", //Material Name
+			"LFTR Fuel 1", //Material Name
 			MaterialState.LIQUID, //State
 			TextureSets.NUCLEAR.get(),
 			null, //Material Colour
@@ -129,7 +129,7 @@ public final class NUCLIDE {
 	
 	// LFTR Core Fluids
 	public static final Material LiFBeF2UF4FP = new Material(
-			"LiFBeF2UF4FP", //Material Name
+			"Uranium Depleted Molten Salt (U Salt)", //Material Name
 			MaterialState.PURE_LIQUID, //State
 			null, //Material Colour
 			-1, //Melting Point in C
@@ -147,7 +147,7 @@ public final class NUCLIDE {
 			});
 	
 	public static final Material Sparged_LiFBeF2UF4FP = new Material(
-			"Helium Sparged LiFBeF2UF4FP", //Material Name
+			"Helium Sparged U Salt", //Material Name
 			MaterialState.PURE_LIQUID, //State
 			null, //Material Colour
 			-1, //Melting Point in C
@@ -165,7 +165,7 @@ public final class NUCLIDE {
 			});
 	
 	public static final Material UF6F2FP = new Material(
-			"UF6F2FP", //Material Name
+			"Phosphorous Uranium Hexafluoride (P-UF6)", //Material Name
 			MaterialState.PURE_LIQUID, //State
 			null, //Material Colour
 			-1, //Melting Point in C
@@ -182,7 +182,7 @@ public final class NUCLIDE {
 			});
 	
 	public static final Material LiFBeF2 = new Material(
-			"LiFBeF2", //Material Name
+			"Stable Molten Salt Base", //Material Name
 			MaterialState.PURE_LIQUID, //State
 			null, //Material Colour
 			-1, //Melting Point in C
@@ -198,7 +198,7 @@ public final class NUCLIDE {
 			});
 	
 	public static final Material LiFBeF2UF4 = new Material(
-			"LiFBeF2UF4", //Material Name
+			"LFTR Fuel Base", //Material Name
 			MaterialState.PURE_LIQUID, //State
 			null, //Material Colour
 			-1, //Melting Point in C
@@ -222,7 +222,7 @@ public final class NUCLIDE {
 
 	// Tier 1 Fuel blanket output
 	public static final Material LiFThF4 = new Material(
-			"LiFThF4", //Material Name
+			"Thorium Depleted Molten Salt (T Salt)", //Material Name
 			MaterialState.PURE_LIQUID, //State
 			null, //Material Colour
 			-1, //Melting Point in C
@@ -239,7 +239,7 @@ public final class NUCLIDE {
 	
 	// Tier 2 Fuel blanket output
 	public static final Material LiFBeF2ThF4 = new Material(
-			"LiFBeF2ThF4", //Material Name
+			"Thorium-Beryllium Depleted Molten Salt (TB Salt)", //Material Name
 			MaterialState.PURE_LIQUID, //State
 			null, //Material Colour
 			-1, //Melting Point in C
@@ -257,7 +257,7 @@ public final class NUCLIDE {
 	
 	// Tier 1 Fuel blanket output
 	public static final Material Sparged_LiFThF4 = new Material(
-			"Fluorine Sparged LiFThF4", //Material Name
+			"Fluorine Sparged T Salt", //Material Name
 			MaterialState.PURE_LIQUID, //State
 			null, //Material Colour
 			-1, //Melting Point in C
@@ -274,7 +274,7 @@ public final class NUCLIDE {
 	
 	// Tier 2 Fuel blanket output
 	public static final Material Sparged_LiFBeF2ThF4 = new Material(
-			"Fluorine Sparged LiFBeF2ThF4", //Material Name
+			"Fluorine Sparged TB Salt", //Material Name
 			MaterialState.PURE_LIQUID, //State
 			null, //Material Colour
 			-1, //Melting Point in C
@@ -291,7 +291,7 @@ public final class NUCLIDE {
 			});
 	
 	public static final Material UF6F2 = new Material(
-			"UF6F2", //Material Name
+			"Fluorinated Uranium Hexafluoride (F-UF6)", //Material Name
 			MaterialState.PURE_LIQUID, //State
 			null, //Material Colour
 			-1, //Melting Point in C

--- a/src/main/java/gtPlusPlus/core/recipe/RECIPES_Machines.java
+++ b/src/main/java/gtPlusPlus/core/recipe/RECIPES_Machines.java
@@ -2095,15 +2095,15 @@ public class RECIPES_Machines {
 							RECIPE_LFTRController);
 				} else  {
 					RecipeUtils.addShapedGregtechRecipe(
-							controlCircuit, "cableGt12NaquadahAlloy", controlCircuit,
+							controlCircuit, "cableGt12Naquadah", controlCircuit,
 							"plateDoubleHastelloyN", GregtechItemList.Gregtech_Computer_Cube.get(1), "plateDoubleHastelloyN",
 							"plateThorium232", CI.machineHull_IV, "plateThorium232",
 							RECIPE_LFTRController);
 				}
 				RecipeUtils.addShapedGregtechRecipe(
-						"plateDoubleZeron100", CI.craftingToolScrewdriver, "plateDoubleZeron100",
+						"plateDoubleHastelloyC276", CI.craftingToolScrewdriver, "plateDoubleHastelloyC276",
 						"gearGtTalonite", CI.fieldGenerator_MV, "gearGtTalonite",
-						"plateDoubleZeron100", CI.craftingToolHammer_Hard, "plateDoubleZeron100",
+						"plateDoubleHastelloyC276", CI.craftingToolHammer_Hard, "plateDoubleHastelloyC276",
 						RECIPE_LFTRInnerCasing);
 
 				ItemStack IC2HeatPlate = ItemUtils.getItemStackFromFQRN("IC2:reactorPlatingHeat", 1);

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/GregtechMTE_NuclearReactor.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/GregtechMTE_NuclearReactor.java
@@ -368,6 +368,8 @@ public class GregtechMTE_NuclearReactor extends GregtechMeta_MultiBlockBase<Greg
 		// Warm up for 4~ minutes
 		Logger.WARNING("Checking LFTR recipes.");
 		if (mEfficiency < this.getMaxEfficiency(null)) {
+			this.mOutputItems = new ItemStack[]{};
+			this.mOutputFluids = new FluidStack[]{};
 			this.mProgresstime = 0;
 			this.mMaxProgresstime = 1;
 			this.mEfficiencyIncrease = 2;


### PR DESCRIPTION
- Changed the name of most LFTR-related chemicals to make it easier to distinguish and document them;
- Changed the recipes of the LFTR's controller and inner casings to be craftable in IV, the tier which this multi is first intended for;
- Fixed a bug where the LFTR would output the fluids of the last successfully recipe while heating up, on every tick. When it's heating up, it now sets the output fluids to an empty array. There are better ways to do this, I welcome an improvement to this part of the code.