### PR TITLE
fix Early Everglades portal in dev version #10318

### DIFF
--- a/src/main/java/gtPlusPlus/core/recipe/RECIPES_GREGTECH.java
+++ b/src/main/java/gtPlusPlus/core/recipe/RECIPES_GREGTECH.java
@@ -1521,7 +1521,7 @@ public class RECIPES_GREGTECH {
 
 
 
-		CORE.RA.addSixSlotAssemblingRecipe(new ItemStack[] {
+		/*CORE.RA.addSixSlotAssemblingRecipe(new ItemStack[] {
 				GregtechItemList.Casing_Multi_Use.get(1),
 				ItemUtils.getItemStackOfAmountFromOreDict(CI.getTieredCircuitOreDictName(6), 1),
 				ItemUtils.getItemStackOfAmountFromOreDict(CI.getTieredCircuitOreDictName(4), 8),
@@ -1534,7 +1534,7 @@ public class RECIPES_GREGTECH {
 				20*20,
 				2048);
 
-
+		*/
 
 
 


### PR DESCRIPTION
https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/10318

(cherry picked from commit 2a0481232f92ef604e7e302b7274189e5fe5112d)