### PR TITLE
Added Bismuth Indium Solder Alloy

### DIFF
--- a/src/main/java/gtPlusPlus/core/item/ModItems.java
+++ b/src/main/java/gtPlusPlus/core/item/ModItems.java
@@ -638,6 +638,7 @@ public final class ModItems {
 
 			MaterialGenerator.generate(ALLOY.BABBIT_ALLOY, false);
 			MaterialGenerator.generate(ALLOY.BLACK_TITANIUM, false);
+			MaterialGenerator.generate(ALLOY.INDALLOY_140, false);
 
 			// High Level Bioplastic
 			MaterialGenerator.generate(ELEMENT.STANDALONE.RHUGNOR, false, false);

--- a/src/main/java/gtPlusPlus/core/material/ALLOY.java
+++ b/src/main/java/gtPlusPlus/core/material/ALLOY.java
@@ -968,6 +968,25 @@ public final class ALLOY {
 					new MaterialStack(ELEMENT.getInstance().ARSENIC, 2)
 			});
 
+	public static final Material INDALLOY_140 = new Material(
+			"Indalloy 140", //Material Name
+			MaterialState.SOLID, //State
+			null, //Material Colour
+			5200, //Melting Point in C
+			6500,
+			-1,
+			-1,
+			true, //Uses Blast furnace?
+			//Material Stacks with Percentage of required elements.
+			new MaterialStack[]{
+					new MaterialStack(ELEMENT.getInstance().BISMUTH, 47),
+					new MaterialStack(ELEMENT.getInstance().LEAD, 25),
+					new MaterialStack(ELEMENT.getInstance().TIN, 13),
+					new MaterialStack(ELEMENT.getInstance().CADMIUM, 10),
+					new MaterialStack(ELEMENT.getInstance().INDIUM, 5)
+			});
+
+
 
 
 


### PR DESCRIPTION
- Added Indalloy 140, IV recipe, meant for Assembly Line recipes.

Assembly Line recipes use all kinds of high tier items to craft the machine components for LuV and above. In the middle of all that, most recipes use the LV-tier Soldering Alloy, since nobody else implemented a higher tier one. That is what this alloy is for, to be used as a solder in those recipes.

[This is a real soldering alloy, as seen here.](https://www.matweb.com/search/DataSheet.aspx?MatGUID=61beeec304154e14b711984757f073ed&ckck=1). It's made in the ABS, with one IV Energy Hatch being required. It's mostly Bismuth, but also requires Indium.

![image](https://user-images.githubusercontent.com/70096037/170494536-8a4a6a2b-77a2-4102-8dd2-ac1253d7897d.png)
