### PR TITLE
Fixed Indalloy Recipe Time

### DIFF
--- a/src/main/java/gtPlusPlus/core/item/ModItems.java
+++ b/src/main/java/gtPlusPlus/core/item/ModItems.java
@@ -638,7 +638,7 @@ public final class ModItems {
 
 			MaterialGenerator.generate(ALLOY.BABBIT_ALLOY, false);
 			MaterialGenerator.generate(ALLOY.BLACK_TITANIUM, false);
-			MaterialGenerator.generate(ALLOY.INDALLOY_140, false);
+			MaterialGenerator.generate(ALLOY.INDALLOY_140, false, false);
 
 			// High Level Bioplastic
 			MaterialGenerator.generate(ELEMENT.STANDALONE.RHUGNOR, false, false);

--- a/src/main/java/gtPlusPlus/core/material/ALLOY.java
+++ b/src/main/java/gtPlusPlus/core/material/ALLOY.java
@@ -976,7 +976,7 @@ public final class ALLOY {
 			6500,
 			-1,
 			-1,
-			true, //Uses Blast furnace?
+			false, //Uses Blast furnace?
 			//Material Stacks with Percentage of required elements.
 			new MaterialStack[]{
 					new MaterialStack(ELEMENT.getInstance().BISMUTH, 47),

--- a/src/main/java/gtPlusPlus/core/recipe/RECIPES_GREGTECH.java
+++ b/src/main/java/gtPlusPlus/core/recipe/RECIPES_GREGTECH.java
@@ -1011,6 +1011,21 @@ public class RECIPES_GREGTECH {
 				20 * 75,
 				7680);
 
+		//INDALLOY_140
+		CORE.RA.addBlastSmelterRecipe(
+				new ItemStack[] {
+						ItemUtils.getGregtechCircuit(5),
+						ELEMENT.getInstance().BISMUTH.getDust(47),
+						ELEMENT.getInstance().LEAD.getDust(25),
+						ELEMENT.getInstance().TIN.getDust(13),
+						ELEMENT.getInstance().CADMIUM.getDust(10),
+						ELEMENT.getInstance().INDIUM.getDust(5)
+
+				},
+				ALLOY.INDALLOY_140.getFluidStack(100 * 144),
+				0,
+				20 * 40,
+				7680);
 
 
 


### PR DESCRIPTION
- Manually added the ABS recipe to Indalloy, instead of the auto-generated one, since the previous one has a higher recipe time than indended when CoreMod is loaded.

The intended recipe time is 40 seconds for 100 ingots, but I was told that the recipe in the full pack has a 300s recipe time. This is likely due to something in GT++ code that changes time if CoreMod is loaded, so I manually added the recipe and tested with CoreMod. Recipe time is now 40 seconds as intended.