### PR TITLE
Fixed XL Turbines Not Running With Pollution Disabled

### DIFF
--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/turbines/GregtechMetaTileEntity_LargerTurbineBase.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/turbines/GregtechMetaTileEntity_LargerTurbineBase.java
@@ -153,6 +153,9 @@ public abstract class GregtechMetaTileEntity_LargerTurbineBase extends GregtechM
 	}
 
 	private boolean requiresMufflers() {
+		if (!PollutionUtils.isPollutionEnabled()) {
+			return false;
+		}
 		return getPollutionPerSecond(null) > 0;
 	}
 


### PR DESCRIPTION
XL Turbines would not run with pollution disabled because they couldn't polluteEnvironment.