### PR TITLE
Buff Sphalerite milling

### DIFF
--- a/src/main/java/gtPlusPlus/core/item/chemistry/MilledOreProcessing.java
+++ b/src/main/java/gtPlusPlus/core/item/chemistry/MilledOreProcessing.java
@@ -161,7 +161,7 @@ public class MilledOreProcessing extends ItemPackage {
 				SphaleriteFlotationFroth, 
 				ELEMENT.getInstance().ZINC, 180, 
 				ELEMENT.getInstance().IRON, 120,
-				ELEMENT.getInstance().INDIUM, 40, 
+				ELEMENT.getInstance().INDIUM, 64,
 				ELEMENT.getInstance().GERMANIUM, 15
 				);		
 		//milledChalcopyrite

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/GregtechMetaTileEntity_IsaMill.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/GregtechMetaTileEntity_IsaMill.java
@@ -83,7 +83,7 @@ public class GregtechMetaTileEntity_IsaMill extends GregtechMeta_MultiBlockBase<
 				.beginStructureBlock(3, 3, 7, false)
 				.addController("Front Center")
 				.addCasingInfo("IsaMill Exterior Casing", 40)
-                .addOtherStructurePart("IsaMill Gearbox", "Inner Blocks")
+                .addOtherStructurePart("IsaMill Gearbox", "5x, Inner Blocks")
                 .addOtherStructurePart("IsaMill Piping", "8x, ring around controller")
                 .addStructureInfo("IsaMill Pipings must not be obstructed in front (only air blocks)")
 				.addOtherStructurePart("Milling Ball Hatch", "Any Casing")

--- a/src/main/java/gtPlusPlus/xmod/gregtech/recipes/GregtechRecipeAdder.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/recipes/GregtechRecipeAdder.java
@@ -1698,7 +1698,7 @@ public class GregtechRecipeAdder implements IGregtech_RecipeAdder {
 
 		ItemStack[][] aInputArray = new ItemStack[][] {aInputsOre1, aInputsOre2, aInputsCrushed1, aInputsCrushed2};
 		ItemStack[][] aOutputArray = new ItemStack[][] {aOutputsOre1, aOutputsOre2, aOutputsCrushed1, aOutputsCrushed2};		
-		int[] aTime = new int[] {6000, 7500, 7500, 9000};		
+		int[] aTime = new int[] {6000, 7500, 3000, 3750};
 
 		int aSize = GTPP_Recipe.GTPP_Recipe_Map.sOreMillRecipes.mRecipeList.size();
 		int aSize2 = aSize;


### PR DESCRIPTION
aluminium way : 9x Crushed Sphalerite Ore -> 1x Indium
milling (before) : 12.8 -> 1
milling (after) : 8 -> 1

Milling machines should fill the gap between EV-tier dumb aluminium way and UHV-tier T3 fusion.

I also adjusted milling duration for plain ore and crushed ore to be the same, since already crushed ore taking longer time doesn't make sense.