### PR TITLE
Boost XL Turbine Speed and Allow TecTech Hatches

### DIFF
--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/turbines/GT_MTE_LargeTurbine_Plasma.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/turbines/GT_MTE_LargeTurbine_Plasma.java
@@ -107,7 +107,7 @@ public class GT_MTE_LargeTurbine_Plasma extends GregtechMetaTileEntity_LargerTur
 					float aTotalBaseEff = 0;
 					float aTotalOptimalFlow = 0;
 					ItemStack aStack = getFullTurbineAssemblies().get(0).getTurbine();
-					for (int i=0;i<18;i++) {
+					for (int i=0;i<speedMultiplier;i++) {
 						if (i == 0) {
 							aTotalBaseEff += GT_Utility.safeInt((long) ((5F + ((GT_MetaGenerated_Tool) aStack.getItem()).getToolCombatDamage(aStack)) * 1000F));					
 						}		

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/turbines/GT_MTE_LargeTurbine_SHSteam.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/turbines/GT_MTE_LargeTurbine_SHSteam.java
@@ -11,6 +11,7 @@ import gregtech.api.util.GT_ModHandler;
 import gregtech.api.util.GT_Utility;
 import gtPlusPlus.core.lib.CORE;
 import gtPlusPlus.core.util.math.MathUtils;
+import gtPlusPlus.core.util.minecraft.PlayerUtils;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
@@ -117,11 +118,24 @@ public class GT_MTE_LargeTurbine_SHSteam extends GregtechMetaTileEntity_LargerTu
 
     @Override
     public void onModeChangeByScrewdriver(byte aSide, EntityPlayer aPlayer, float aX, float aY, float aZ) {
+        //Using a screwdriver to change modes should allow for any combination of Slow/Fast and Tight/Loose Mode
+        //Whenever there's a mode switch, there will be two messages on the player chat
+        //The two messages specify which two modes the turbine is on after the change
+        //(Tight/Loose changes on every action, Slow/Fast changes every other action, all pairs are cycled this way)
         if (aSide == getBaseMetaTileEntity().getFrontFacing()) {
             looseFit^=true;
-            GT_Utility.sendChatToPlayer(aPlayer, looseFit ? "Fitting: Loose - More Flow" : "Fitting: Tight - More Efficiency");
+            GT_Utility.sendChatToPlayer(aPlayer, looseFit ? "Fitting is Loose (Higher Flow)" : "Fitting is Tight (Higher Efficiency)");
         }
-		super.onModeChangeByScrewdriver(aSide, aPlayer, aX, aY, aZ);	
+
+        if (looseFit) {
+            super.onModeChangeByScrewdriver(aSide, aPlayer, aX, aY, aZ);
+        }
+        else if (mFastMode) {
+            PlayerUtils.messagePlayer(aPlayer, "Running in Fast (48x) Mode.");
+        }
+        else {
+            PlayerUtils.messagePlayer(aPlayer, "Running in Slow (16x) Mode.");
+        }
     }
 
     @Override

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/turbines/GT_MTE_LargeTurbine_Steam.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/turbines/GT_MTE_LargeTurbine_Steam.java
@@ -12,6 +12,7 @@ import gregtech.api.objects.GT_RenderedTexture;
 import gregtech.api.util.GT_ModHandler;
 import gregtech.api.util.GT_Utility;
 import gtPlusPlus.core.util.math.MathUtils;
+import gtPlusPlus.core.util.minecraft.PlayerUtils;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
@@ -124,11 +125,24 @@ public class GT_MTE_LargeTurbine_Steam extends GregtechMetaTileEntity_LargerTurb
 
     @Override
     public void onModeChangeByScrewdriver(byte aSide, EntityPlayer aPlayer, float aX, float aY, float aZ) {
+        //Using a screwdriver to change modes should allow for any combination of Slow/Fast and Tight/Loose Mode
+        //Whenever there's a mode switch, there will be two messages on the player chat
+        //The two messages specify which two modes the turbine is on after the change
+        //(Tight/Loose changes on every action, Slow/Fast changes every other action, all pairs are cycled this way)
         if (aSide == getBaseMetaTileEntity().getFrontFacing()) {
             looseFit^=true;
             GT_Utility.sendChatToPlayer(aPlayer, looseFit ? "Fitting: Loose - More Flow" : "Fitting: Tight - More Efficiency");
         }
-		super.onModeChangeByScrewdriver(aSide, aPlayer, aX, aY, aZ);	
+
+        if (looseFit) {
+            super.onModeChangeByScrewdriver(aSide, aPlayer, aX, aY, aZ);
+        }
+        else if (mFastMode) {
+            PlayerUtils.messagePlayer(aPlayer, "Running in Fast (48x) Mode.");
+        }
+        else {
+            PlayerUtils.messagePlayer(aPlayer, "Running in Slow (16x) Mode.");
+        }
     }
 
     @Override

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/turbines/GregtechMetaTileEntity_LargerTurbineBase.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/turbines/GregtechMetaTileEntity_LargerTurbineBase.java
@@ -105,6 +105,7 @@ public abstract class GregtechMetaTileEntity_LargerTurbineBase extends GregtechM
 		.addInfo("Optimal flow will increase or decrease accordingly on mode switch")
 		.addInfo("Fast Mode increases speed to 48x instead of 16x, with some penalties")
 		.addInfo("Maintenance problems and turbine damage happen 12x as often in Fast Mode")
+		.addInfo("XL Steam Turbines can use Loose Mode with either Slow or Fast Mode")
 		.addPollutionAmount(getPollutionPerSecond(null))
 		.addInfo("Pollution is 3x higher in Fast Mode")
 		.addSeparator()

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/turbines/GregtechMetaTileEntity_LargerTurbineBase.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/turbines/GregtechMetaTileEntity_LargerTurbineBase.java
@@ -33,7 +33,10 @@ import gtPlusPlus.api.objects.data.AutoMap;
 import gtPlusPlus.api.objects.minecraft.BlockPos;
 import gtPlusPlus.core.block.ModBlocks;
 import gtPlusPlus.core.lib.CORE;
+import gtPlusPlus.core.lib.LoadedMods;
+import gtPlusPlus.core.util.Utils;
 import gtPlusPlus.core.util.math.MathUtils;
+import gtPlusPlus.core.util.minecraft.PlayerUtils;
 import gtPlusPlus.core.util.minecraft.gregtech.PollutionUtils;
 import gtPlusPlus.core.util.sys.KeyboardUtils;
 import gtPlusPlus.xmod.gregtech.api.metatileentity.implementations.GT_MetaTileEntity_Hatch_Turbine;
@@ -43,6 +46,7 @@ import net.minecraft.block.Block;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.InventoryPlayer;
 import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.EnumChatFormatting;
 import net.minecraft.util.StatCollector;
 import net.minecraftforge.fluids.FluidStack;
@@ -55,6 +59,11 @@ public abstract class GregtechMetaTileEntity_LargerTurbineBase extends GregtechM
 	protected int storedFluid = 0;
 	protected int counter = 0;
 	protected int mCasing;
+	protected boolean mFastMode = false;
+	protected int speedMultiplier = 16;
+	protected int maintenanceThreshold = 1;
+	protected int pollutionMultiplier = 1;
+	protected int turbineDamageMultiplier = 1;
 
 	public ITexture frontFace;
 	public ITexture frontFaceActive;	
@@ -91,7 +100,13 @@ public abstract class GregtechMetaTileEntity_LargerTurbineBase extends GregtechM
 		GT_Multiblock_Tooltip_Builder tt = new GT_Multiblock_Tooltip_Builder();
 		tt.addMachineType(getMachineType())
 		.addInfo("Controller Block for the XL "+getTurbineType()+" Turbine")
+		.addInfo("Runs as fast as 16 Large Turbines of the same type, takes the space of 12")
+		.addInfo("Right-click with screwdriver to enable Fast Mode, to run it even faster")
+		.addInfo("Optimal flow will increase or decrease accordingly on mode switch")
+		.addInfo("Fast Mode increases speed to 48x instead of 16x, with some penalties")
+		.addInfo("Maintenance problems and turbine damage happen 12x as often in Fast Mode")
 		.addPollutionAmount(getPollutionPerSecond(null))
+		.addInfo("Pollution is 3x higher in Fast Mode")
 		.addSeparator()
 		.beginStructureBlock(7, 9, 7, false)
 		.addController("Top Middle")
@@ -162,6 +177,7 @@ public abstract class GregtechMetaTileEntity_LargerTurbineBase extends GregtechM
 	@Override
 	public boolean checkMachine(IGregTechTileEntity aBaseMetaTileEntity, ItemStack aStack) {
 		this.mDynamoHatches.clear();
+		this.mTecTechDynamoHatches.clear();
 		this.mTurbineRotorHatches.clear();
 		this.mMaintenanceHatches.clear();
 		if (requiresMufflers()) {
@@ -180,7 +196,7 @@ public abstract class GregtechMetaTileEntity_LargerTurbineBase extends GregtechM
 		if (!aCasingCount || 
 				mTurbineRotorHatches.size() != 12 ||
 				mMaintenanceHatches.size() != 1 || 
-				mDynamoHatches.size() < 1 || 
+				(mDynamoHatches.size() < 1 && mTecTechDynamoHatches.size() < 1) ||
 				(requiresMufflers() && mMufflerHatches.size() != 4) ||
 				mInputBusses.size() < 1 ||
 				mInputHatches.size() < 1 ||
@@ -263,6 +279,11 @@ public abstract class GregtechMetaTileEntity_LargerTurbineBase extends GregtechM
 			}
 			else if (aMetaTileEntity instanceof GT_MetaTileEntity_Hatch_Dynamo) {
 				return addToMachineList(aTileEntity, aBaseCasingIndex);
+			}
+			else if (LoadedMods.TecTech) {
+				if (isThisHatchMultiDynamo(aMetaTileEntity)) {
+					return addToMachineList(aTileEntity, aBaseCasingIndex);
+				}
 			}
 		}
 		log("Bad Hatch");
@@ -478,7 +499,7 @@ public abstract class GregtechMetaTileEntity_LargerTurbineBase extends GregtechM
 					float aTotalOptimalFlow = 0;
 
 					ItemStack aStack = getFullTurbineAssemblies().get(0).getTurbine();
-					for (int i=0;i<18;i++) {
+					for (int i=0;i<speedMultiplier;i++) {
 						if (i == 0) {
 							aTotalBaseEff += GT_Utility.safeInt((long) ((5F + ((GT_MetaGenerated_Tool) aStack.getItem()).getToolCombatDamage(aStack)) * 1000F));
 							//log("Bumped base eff to "+aTotalBaseEff);							
@@ -560,7 +581,8 @@ public abstract class GregtechMetaTileEntity_LargerTurbineBase extends GregtechM
 		}
 		if (mRuntime++ > 1000) {
 			mRuntime = 0;
-			if (getBaseMetaTileEntity().getRandomNumber(6000) == 0) {
+
+			if (getBaseMetaTileEntity().getRandomNumber(6000) < maintenanceThreshold) {
 				switch (getBaseMetaTileEntity().getRandomNumber(6)) {
 					case 0:
 						mWrench = false;
@@ -583,7 +605,9 @@ public abstract class GregtechMetaTileEntity_LargerTurbineBase extends GregtechM
 				}
 			}            
 			for (GT_MetaTileEntity_Hatch_Turbine aHatch : getFullTurbineAssemblies()) {
-				aHatch.damageTurbine(mEUt, damageFactorLow, damageFactorHigh);         
+				for (int i = 0; i < turbineDamageMultiplier; i++) {
+					aHatch.damageTurbine(mEUt, damageFactorLow, damageFactorHigh);
+				}
 			}            
 		}
 		return true;
@@ -681,7 +705,7 @@ public abstract class GregtechMetaTileEntity_LargerTurbineBase extends GregtechM
 
 	public boolean polluteEnvironment(int aPollutionLevel) {
 		if (this.requiresMufflers()) {
-			mPollution += aPollutionLevel;
+			mPollution += aPollutionLevel * pollutionMultiplier;
 			for (GT_MetaTileEntity_Hatch_Muffler tHatch : mMufflerHatches) {
 				if (isValidMetaTileEntity(tHatch)) {
 					if (mPollution >= 10000) {					
@@ -699,17 +723,50 @@ public abstract class GregtechMetaTileEntity_LargerTurbineBase extends GregtechM
 	}
 	@Override
 	public long maxAmperesOut() {
-		return 16;
-	}
-
-
-	@Override
-	public void onModeChangeByScrewdriver(byte aSide, EntityPlayer aPlayer, float aX, float aY, float aZ) {
-		if (!KeyboardUtils.isShiftKeyDown()) {
-			//super.onModeChangeByScrewdriver(aSide, aPlayer, aX, aY, aZ);		
+		// This should not be a hard limit, due to TecTech dynamos
+		if (mFastMode) {
+			return 64;
 		}
 		else {
-			/*
+			return 16;
+		}
+	}
+
+	@Override
+	public void saveNBTData(NBTTagCompound aNBT) {
+		aNBT.setBoolean("mFastMode", mFastMode);
+		super.saveNBTData(aNBT);
+	}
+
+	@Override
+	public void loadNBTData(NBTTagCompound aNBT) {
+		mFastMode = aNBT.getBoolean("mFastMode");
+		super.loadNBTData(aNBT);
+	}
+	@Override
+	public void onModeChangeByScrewdriver(byte aSide, EntityPlayer aPlayer, float aX, float aY, float aZ) {
+		mFastMode = Utils.invertBoolean(mFastMode);
+		if (mFastMode){
+			PlayerUtils.messagePlayer(aPlayer, "Running in Fast (48x) Mode.");
+			speedMultiplier = 48;
+			maintenanceThreshold = 12;
+			pollutionMultiplier = 3;
+			turbineDamageMultiplier = 12;
+		}
+		else {
+			PlayerUtils.messagePlayer(aPlayer, "Running in Slow (16x) Mode.");
+			speedMultiplier = 16;
+			maintenanceThreshold = 1;
+			pollutionMultiplier = 1;
+			turbineDamageMultiplier = 1;
+		}
+	}
+
+		/*if (!KeyboardUtils.isShiftKeyDown()) {
+			super.onModeChangeByScrewdriver(aSide, aPlayer, aX, aY, aZ);
+		}
+		else {
+
 			this.mIsAnimated = Utils.invertBoolean(mIsAnimated);
 			if (this.mIsAnimated) {
 			PlayerUtils.messagePlayer(aPlayer, "Using Animated Turbine Texture.");
@@ -724,8 +781,8 @@ public abstract class GregtechMetaTileEntity_LargerTurbineBase extends GregtechM
 				}
 			}
 			}	
-			 */}			
-	}
+			 }
+	}*/
 
 	@Override
 	public final ITexture[] getTexture(IGregTechTileEntity aBaseMetaTileEntity, byte aSide, byte aFacing, byte aColorIndex, boolean aActive, boolean aRedstone) {


### PR DESCRIPTION
- Added the option to use Tectech Dynamo Hatches on XL turbines;
- Tweaked the current speed from 18x to the 16x that Alkalus told me was intended (not 100% sure about this, breaks current setups somewhat but my testing gave a higher value than intended);
- Added Fast Mode, which can be switched into to triple the multi's speed to 48x, but with greatly accelerated (12x) turbine damage and maintenance problems;
- Integrated Loose Mode into the mode changing for Steam and SH Steam XL Turbines, so that any combination is possible;
- Added information to the tooltip to clarify the numbers and speed.

**All numbers can be adjusted, feedback is welcome.**

While looking at the XL Turbines, I realized that they only run a bit faster than the same volume of regular Large Turbines. One XL takes the space of 12 Large, but my testing showed a 18x speed difference, which is 50% higher per volume. Of course, having all the inputs and outputs + dynamos in the same multi is fantastic, but all mega multis give a much faster speed boost than this. Upon reaching endgame powergen that uses turbines, like fusion, spamming XL turbines will be required at a certain point, which I think should not be intended.

To not force everyone into 48x speed, I created two modes and made Slow Mode the default. The Steam Turbines' Loose mode can be interchanged with these two in any desired combination. Optimal flow and pollution raise in the same right, but problems such as maintenance and turbine damage become much more frequent in Fast Mode.

This huge speed boost merits a recipe change to the XL Turbines to make them more expensive, in my opinion. On that end, I'd like to hear suggestions.