### PR TITLE
Fixes for Housing

### DIFF
--- a/src/main/java/gtPlusPlus/xmod/gregtech/api/metatileentity/implementations/nbthandlers/GT_MetaTileEntity_Hatch_MillingBalls.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/api/metatileentity/implementations/nbthandlers/GT_MetaTileEntity_Hatch_MillingBalls.java
@@ -11,15 +11,15 @@ import net.minecraft.item.ItemStack;
 public class GT_MetaTileEntity_Hatch_MillingBalls extends GT_MetaTileEntity_Hatch_NbtConsumable {
 	
     public GT_MetaTileEntity_Hatch_MillingBalls(int aID, String aName, String aNameRegional) {
-        super(aID, aName, aNameRegional, 6, 4, "Dedicated Milling Ball Storage", true);
+        super(aID, aName, aNameRegional, 6, 4, "Dedicated Milling Ball Storage", false);
     }
 
     public GT_MetaTileEntity_Hatch_MillingBalls(String aName, String aDescription, ITexture[][][] aTextures) {
-        super(aName, 6, 4, aDescription, true, aTextures);
+        super(aName, 6, 4, aDescription, false, aTextures);
     }
     
     public GT_MetaTileEntity_Hatch_MillingBalls(String aName, String[] aDescription, ITexture[][][] aTextures) {
-        super(aName, 6, 4, aDescription[0], true, aTextures);
+        super(aName, 6, 4, aDescription[0], false, aTextures);
     }
 
     @Override

--- a/src/main/java/gtPlusPlus/xmod/gregtech/api/metatileentity/implementations/nbthandlers/GT_MetaTileEntity_Hatch_NbtConsumable.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/api/metatileentity/implementations/nbthandlers/GT_MetaTileEntity_Hatch_NbtConsumable.java
@@ -72,7 +72,7 @@ public abstract class GT_MetaTileEntity_Hatch_NbtConsumable extends GT_MetaTileE
 
 	@Override
 	public final boolean isValidSlot(int aIndex) {
-		return aIndex < mInputslotCount;
+		return true;
 	}
 
 	@Override
@@ -253,7 +253,7 @@ public abstract class GT_MetaTileEntity_Hatch_NbtConsumable extends GT_MetaTileE
 
 	@Override
 	public final boolean allowPutStack(IGregTechTileEntity aBaseMetaTileEntity, int aIndex, byte aSide, ItemStack aStack) {
-		return aSide == getBaseMetaTileEntity().getFrontFacing() && isItemValidForUsageSlot(aStack);
+		return aSide == getBaseMetaTileEntity().getFrontFacing() && isItemValidForUsageSlot(aStack) && aIndex < mInputslotCount;
 	}
 	
 	/**

--- a/src/main/java/gtPlusPlus/xmod/gregtech/api/metatileentity/implementations/nbthandlers/GT_MetaTileEntity_Hatch_NbtConsumable.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/api/metatileentity/implementations/nbthandlers/GT_MetaTileEntity_Hatch_NbtConsumable.java
@@ -112,6 +112,7 @@ public abstract class GT_MetaTileEntity_Hatch_NbtConsumable extends GT_MetaTileE
 
 	@Override
 	public void onPostTick(IGregTechTileEntity aBaseMetaTileEntity, long aTimer) {
+		validateUsageSlots();
 		if (aBaseMetaTileEntity.isServerSide() && aBaseMetaTileEntity.hasInventoryBeenModified()) {
 			fillStacksIntoFirstSlots();
 			tryFillUsageSlots();
@@ -126,6 +127,14 @@ public abstract class GT_MetaTileEntity_Hatch_NbtConsumable extends GT_MetaTileE
 			// Only moves items in the first four slots
 			if (i <= getSlotID_LastInput()) {
 				fillStacksIntoFirstSlots();
+			}
+		}
+	}
+
+	protected void validateUsageSlots() {
+		for (int i = getSlotID_FirstUsage(); i <= getSlotID_LastUsage(); i++) {
+			if (mInventory[i] != null && mInventory[i].stackSize < 1) {
+				mInventory[i] = null;
 			}
 		}
 	}


### PR DESCRIPTION
- Fix balls (and probably catalysts) not being depleted properly
- Fix breaking housing does not drop items in usage slots
- Disallow moving duplicated types of balls into usage slots
  - Ball housing had wierd behavior. When you insert stacked balls, only 1 is moved, but if you insert 1 by 1, all balls are moved eventually. So I just disabled it.