### PR TITLE
Re-buff Milling

### DIFF
--- a/src/main/java/gtPlusPlus/core/item/chemistry/MilledOreProcessing.java
+++ b/src/main/java/gtPlusPlus/core/item/chemistry/MilledOreProcessing.java
@@ -454,7 +454,7 @@ public class MilledOreProcessing extends ItemPackage {
 				new FluidStack[] {
 						FluidUtils.getFluidStack(SphaleriteFlotationFroth, 1000)						
 				},
-				20 * 1200, 
+				20 * 480,
 				MaterialUtils.getVoltageForTier(6)
 				);
 
@@ -468,7 +468,7 @@ public class MilledOreProcessing extends ItemPackage {
 				new FluidStack[] {
 						FluidUtils.getFluidStack(ChalcopyriteFlotationFroth, 1000)						
 				},
-				20 * 1200, 
+				20 * 480,
 				MaterialUtils.getVoltageForTier(5)
 				);
 
@@ -482,7 +482,7 @@ public class MilledOreProcessing extends ItemPackage {
 				new FluidStack[] {
 						FluidUtils.getFluidStack(NickelFlotationFroth, 1000)						
 				},
-				20 * 1200, 
+				20 * 480,
 				MaterialUtils.getVoltageForTier(5)
 				);
 
@@ -496,7 +496,7 @@ public class MilledOreProcessing extends ItemPackage {
 				new FluidStack[] {
 						FluidUtils.getFluidStack(PlatinumFlotationFroth, 1000)						
 				},
-				20 * 1200, 
+				20 * 480,
 				MaterialUtils.getVoltageForTier(6)
 				);
 
@@ -511,7 +511,7 @@ public class MilledOreProcessing extends ItemPackage {
 				new FluidStack[] {
 						FluidUtils.getFluidStack(PentlanditeFlotationFroth, 1000)						
 				},
-				20 * 1200, 
+				20 * 480,
 				MaterialUtils.getVoltageForTier(6)
 				);
 		
@@ -529,7 +529,7 @@ public class MilledOreProcessing extends ItemPackage {
 				new FluidStack[] {
 						FluidUtils.getFluidStack(RedstoneFlotationFroth, 1000)						
 				},
-				20 * 1200, 
+				20 * 480,
 				MaterialUtils.getVoltageForTier(5)
 				);
 
@@ -543,7 +543,7 @@ public class MilledOreProcessing extends ItemPackage {
 				new FluidStack[] {
 						FluidUtils.getFluidStack(SpessartineFlotationFroth, 1000)						
 				},
-				20 * 1200, 
+				20 * 480,
 				MaterialUtils.getVoltageForTier(6)
 				);
 
@@ -557,7 +557,7 @@ public class MilledOreProcessing extends ItemPackage {
 				new FluidStack[] {
 						FluidUtils.getFluidStack(GrossularFlotationFroth, 1000)						
 				},
-				20 * 1200, 
+				20 * 480,
 				MaterialUtils.getVoltageForTier(6)
 				);
 
@@ -571,7 +571,7 @@ public class MilledOreProcessing extends ItemPackage {
 				new FluidStack[] {
 						FluidUtils.getFluidStack(AlmandineFlotationFroth, 1000)						
 				},
-				20 * 1200, 
+				20 * 480,
 				MaterialUtils.getVoltageForTier(5)
 				);
 
@@ -585,7 +585,7 @@ public class MilledOreProcessing extends ItemPackage {
 				new FluidStack[] {
 						FluidUtils.getFluidStack(PyropeFlotationFroth, 1000)						
 				},
-				20 * 1200, 
+				20 * 480,
 				MaterialUtils.getVoltageForTier(4)
 				);
 
@@ -599,7 +599,7 @@ public class MilledOreProcessing extends ItemPackage {
 				new FluidStack[] {
 						FluidUtils.getFluidStack(MonaziteFlotationFroth, 1000)						
 				},
-				20 * 1200, 
+				20 * 480,
 				MaterialUtils.getVoltageForTier(6)
 				);
 

--- a/src/main/java/gtPlusPlus/xmod/gregtech/recipes/GregtechRecipeAdder.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/recipes/GregtechRecipeAdder.java
@@ -1698,7 +1698,7 @@ public class GregtechRecipeAdder implements IGregtech_RecipeAdder {
 
 		ItemStack[][] aInputArray = new ItemStack[][] {aInputsOre1, aInputsOre2, aInputsCrushed1, aInputsCrushed2};
 		ItemStack[][] aOutputArray = new ItemStack[][] {aOutputsOre1, aOutputsOre2, aOutputsCrushed1, aOutputsCrushed2};		
-		int[] aTime = new int[] {6000, 7500, 3000, 3750};
+		int[] aTime = new int[] {2400, 3000, 1200, 1500};
 
 		int aSize = GTPP_Recipe.GTPP_Recipe_Map.sOreMillRecipes.mRecipeList.size();
 		int aSize2 = aSize;


### PR DESCRIPTION
Reduce duration for Milling and Flotation to 2/5, so that they can beat uum.

EU cost
uum: 245M / Indium
uum + uua: 64M / Indium
milling (before previous buff): 149M / Indium
milling (after previous buff, before this change): 93M / Indium
milling (after this change): 37M / Indium

duration required for T2 Fusion controller (1024x Indium)
milling (before previous buff): 34 hours
milling (after previous buff, before this change): 21 hours
milling (after this change): 8.5 hours
