### PR TITLE
Algae Farm Buffs and Tweaks

### DIFF
--- a/src/main/java/gtPlusPlus/plugin/agrichem/BioRecipes.java
+++ b/src/main/java/gtPlusPlus/plugin/agrichem/BioRecipes.java
@@ -258,7 +258,7 @@ public class BioRecipes {
 		// Sodium Carbonate
 		CORE.RA.addChemicalRecipe(
 				getBrownAlgaeRecipeChip(),
-				ItemUtils.getSimpleStack(AgriculturalChem.mBrownAlgaeBiosmass, 20),
+				ItemUtils.getSimpleStack(AgriculturalChem.mBrownAlgaeBiosmass, 40),
 				FluidUtils.getDistilledWater(2000), 
 				GT_Values.NF, 
 				ItemUtils.getSimpleStack(AgriculturalChem.mSodiumCarbonate, 20),
@@ -515,7 +515,7 @@ public class BioRecipes {
 				FluidUtils.getFluidStack(mFermentationBase, 1000),
 				null, 
 				new ItemStack[] {
-						ItemUtils.getSimpleStack(AgriculturalChem.mCompost, 10),
+						ItemUtils.getSimpleStack(AgriculturalChem.mCompost, 2),
 						ItemUtils.getItemStackOfAmountFromOreDict("cellAceticAcid", 1)						
 				},
 				new int[] {10000, 10000}, 
@@ -664,7 +664,7 @@ public class BioRecipes {
 				new FluidStack[] {
 						FluidUtils.getFluidStack(BioRecipes.mFermentationBase, 2000),
 				},
-				30 * 20,
+				10 * 20,
 				30,
 				0);
 
@@ -704,7 +704,7 @@ public class BioRecipes {
 					new FluidStack[] {
 							FluidUtils.getFluidStack(BioRecipes.mFermentationBase, 2000),
 					},
-					30 * 20,
+					10 * 20,
 					30,
 					0);
 		}
@@ -1059,8 +1059,8 @@ public class BioRecipes {
 		CORE.RA.addChemicalPlantRecipe(
 				new ItemStack[] {
 						getBioChip(7),
-						ItemUtils.getSimpleStack(AgriculturalChem.mGoldenBrownCelluloseFiber, 6),
-						ItemUtils.getSimpleStack(AgriculturalChem.mBrownAlgaeBiosmass, 30)
+						ItemUtils.getSimpleStack(AgriculturalChem.mGreenAlgaeBiosmass, 10),
+						ItemUtils.getSimpleStack(AgriculturalChem.mBrownAlgaeBiosmass, 6)
 				},
 				new FluidStack[] {
 						FluidUtils.getFluidStack(BioRecipes.mDistilledWater, 5000),
@@ -1078,8 +1078,8 @@ public class BioRecipes {
 		CORE.RA.addChemicalPlantRecipe(
 				new ItemStack[] {
 						getBioChip(7),
-						ItemUtils.getSimpleStack(AgriculturalChem.mRedCelluloseFiber, 1),
-						ItemUtils.getSimpleStack(AgriculturalChem.mRedAlgaeBiosmass, 10)
+						ItemUtils.getSimpleStack(AgriculturalChem.mGoldenBrownCelluloseFiber, 2),
+						ItemUtils.getSimpleStack(AgriculturalChem.mBrownAlgaeBiosmass, 10)
 				},
 				new FluidStack[] {
 						FluidUtils.getFluidStack(BioRecipes.mDistilledWater, 5000),
@@ -1090,9 +1090,9 @@ public class BioRecipes {
 				new FluidStack[] {
 						FluidUtils.getFluidStack(BioRecipes.mSulfuricAcid, 5000),
 				},
-				25 * 20,
-				120,
-				2);
+				6 * 20,
+				180,
+				3);
 
 	}
 
@@ -1203,7 +1203,7 @@ public class BioRecipes {
 	private static void recipeCompost() {
 		ItemStack aFert;
 		if (LoadedMods.Forestry) {
-			aFert = ItemUtils.getSimpleStack(AgriculturalChem.aFertForestry, 64);
+			aFert = ItemUtils.getSimpleStack(AgriculturalChem.aFertForestry, 32);
 			CORE.RA.addChemicalPlantRecipe(
 					new ItemStack[] {
 							getBioChip(11),
@@ -1211,7 +1211,7 @@ public class BioRecipes {
 							ItemUtils.getSimpleStack(AgriculturalChem.mCompost, 8)
 					},
 					new FluidStack[] {
-							FluidUtils.getFluidStack(BioRecipes.mUrea, 500),
+							FluidUtils.getFluidStack(BioRecipes.mUrea, 200),
 					},
 					new ItemStack[] {
 							aFert
@@ -1219,12 +1219,12 @@ public class BioRecipes {
 					new FluidStack[] {
 
 					},
-					120 * 20,
+					30 * 20,
 					60,
 					1);
 		}
 
-		aFert = ItemUtils.getSimpleStack(AgriculturalChem.aFertIC2, 2);
+		aFert = ItemUtils.getSimpleStack(AgriculturalChem.aFertIC2, 32);
 		CORE.RA.addChemicalPlantRecipe(
 				new ItemStack[] {
 						getBioChip(12),
@@ -1232,7 +1232,7 @@ public class BioRecipes {
 						ItemUtils.getSimpleStack(AgriculturalChem.mCompost, 8)
 				},
 				new FluidStack[] {
-						FluidUtils.getFluidStack(BioRecipes.mUrea, 500),
+						FluidUtils.getFluidStack(BioRecipes.mUrea, 200),
 				},
 				new ItemStack[] {
 						aFert
@@ -1240,7 +1240,7 @@ public class BioRecipes {
 				new FluidStack[] {
 
 				},
-				120 * 20,
+				30 * 20,
 				60,
 				1);
 
@@ -1262,8 +1262,8 @@ public class BioRecipes {
 				new FluidStack[] {
 						FluidUtils.getFluidStack(BioRecipes.mMethane, 500),
 				},
-				20 * 20,
-				8,
+				5 * 20,
+				64,
 				1);
 
 		CORE.RA.addChemicalPlantRecipe(

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/algae/GregtechMTE_AlgaePondBase.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/algae/GregtechMTE_AlgaePondBase.java
@@ -49,6 +49,7 @@ public class GregtechMTE_AlgaePondBase extends GregtechMeta_MultiBlockBase<Gregt
 	private int mCasing;
 	private IStructureDefinition<GregtechMTE_AlgaePondBase> STRUCTURE_DEFINITION = null;
 	private int checkMeta;
+	private int minTierOfHatch = 100;
 	private static final Class<?> cofhWater;
 
 	static {
@@ -82,6 +83,8 @@ public class GregtechMTE_AlgaePondBase extends GregtechMeta_MultiBlockBase<Gregt
 				.addInfo("Provide compost to boost production by one tier")
 				.addInfo("Does not require power or maintenance")
 				.addInfo("All Machine Casings must be the same tier, this dictates machine speed.")
+				.addInfo("All Buses/Hatches must, at least, match the tier of the Casings")
+				.addInfo("Place the controller after everything else to make sure it forms correctly!")
 				.addInfo("Fill Input Hatch with water.")
 				.addPollutionAmount(getPollutionPerSecond(null))
 				.addSeparator()
@@ -150,7 +153,7 @@ public class GregtechMTE_AlgaePondBase extends GregtechMeta_MultiBlockBase<Gregt
 		checkMeta = 0;
 		if (checkPiece(mName, 4, 2, 0) && mCasing >= 64 && checkMeta > 0) {
 			mLevel = checkMeta - 1;
-			return true;
+			return mLevel <= minTierOfHatch;
 		}
 		return false;
 	}
@@ -161,10 +164,13 @@ public class GregtechMTE_AlgaePondBase extends GregtechMeta_MultiBlockBase<Gregt
 		} else {
 			IMetaTileEntity aMetaTileEntity = aTileEntity.getMetaTileEntity();
 			if (aMetaTileEntity instanceof GT_MetaTileEntity_Hatch_InputBus){
+				minTierOfHatch = Math.min(minTierOfHatch, ((GT_MetaTileEntity_Hatch_InputBus) aMetaTileEntity).mTier);
 				return addToMachineList(aTileEntity, aBaseCasingIndex);
 			} else if (aMetaTileEntity instanceof GT_MetaTileEntity_Hatch_OutputBus) {
+				minTierOfHatch = Math.min(minTierOfHatch, ((GT_MetaTileEntity_Hatch_OutputBus) aMetaTileEntity).mTier);
 				return addToMachineList(aTileEntity, aBaseCasingIndex);
 			}else if (aMetaTileEntity instanceof GT_MetaTileEntity_Hatch_Input) {
+				minTierOfHatch = Math.min(minTierOfHatch, ((GT_MetaTileEntity_Hatch_Input) aMetaTileEntity).mTier);
 				return addToMachineList(aTileEntity, aBaseCasingIndex);
 			}
 		}

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/algae/GregtechMTE_AlgaePondBase.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/algae/GregtechMTE_AlgaePondBase.java
@@ -49,7 +49,7 @@ public class GregtechMTE_AlgaePondBase extends GregtechMeta_MultiBlockBase<Gregt
 	private int mCasing;
 	private IStructureDefinition<GregtechMTE_AlgaePondBase> STRUCTURE_DEFINITION = null;
 	private int checkMeta;
-	private int minTierOfHatch = 100;
+	private int minTierOfHatch;
 	private static final Class<?> cofhWater;
 
 	static {
@@ -84,8 +84,7 @@ public class GregtechMTE_AlgaePondBase extends GregtechMeta_MultiBlockBase<Gregt
 				.addInfo("Does not require power or maintenance")
 				.addInfo("All Machine Casings must be the same tier, this dictates machine speed.")
 				.addInfo("All Buses/Hatches must, at least, match the tier of the Casings")
-				.addInfo("Place the controller after everything else to make sure it forms correctly!")
-				.addInfo("Fill Input Hatch with water.")
+				.addInfo("Fill Input Hatch with Water to fill the inside of the multiblock.")
 				.addPollutionAmount(getPollutionPerSecond(null))
 				.addSeparator()
 				.beginStructureBlock(9, 3, 9, true)
@@ -151,6 +150,7 @@ public class GregtechMTE_AlgaePondBase extends GregtechMeta_MultiBlockBase<Gregt
 		mCasing = 0;
 		mLevel = 0;
 		checkMeta = 0;
+		minTierOfHatch = 100;
 		if (checkPiece(mName, 4, 2, 0) && mCasing >= 64 && checkMeta > 0) {
 			mLevel = checkMeta - 1;
 			return mLevel <= minTierOfHatch;

--- a/src/main/java/gtPlusPlus/xmod/gregtech/loaders/recipe/RecipeLoader_AlgaeFarm.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/loaders/recipe/RecipeLoader_AlgaeFarm.java
@@ -94,7 +94,8 @@ public class RecipeLoader_AlgaeFarm {
 
 		if (aUsingCompost) {
 			// Make it use 4 compost per tier if we have some available
-			ItemStack aCompost = ItemUtils.getSimpleStack(AgriculturalChem.mCompost, aTier > 1 ? 2^(aTier - 1) : 1);
+			// Compost consumption maxes out at 1 stack per cycle
+			ItemStack aCompost = ItemUtils.getSimpleStack(AgriculturalChem.mCompost, aTier > 1 ? (int) Math.min(64, Math.pow(2, aTier-1)) : 1);
 			aInputs = new ItemStack[] {aCompost};
 			// Boost Tier by one if using compost so it gets a speed boost
 			aTier++;

--- a/src/main/java/gtPlusPlus/xmod/gregtech/loaders/recipe/RecipeLoader_AlgaeFarm.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/loaders/recipe/RecipeLoader_AlgaeFarm.java
@@ -72,29 +72,29 @@ public class RecipeLoader_AlgaeFarm {
 		}
 
 		final int[] aDurations = new int[] {
-				432000,					
-				378000,				
-				216000, 
-				162000,				
-				108000,
-				81000,				
-				54000,
-				40500,				
-				27000,
-				20250,
-				13500, 
-				6750, 
-				3375,
-				1686,
-				843, 
-				421
+				2000,
+				1800,
+				1600,
+				1400,
+				1200,
+				1000,
+				512,
+				256,
+				128,
+				64,
+				32,
+				16,
+				8,
+				4,
+				2,
+				1
 		};
 
-		ItemStack[] aInputs = new ItemStack[] {};	
+		ItemStack[] aInputs = new ItemStack[] {};
 
 		if (aUsingCompost) {
 			// Make it use 4 compost per tier if we have some available
-			ItemStack aCompost = ItemUtils.getSimpleStack(AgriculturalChem.mCompost, aTier * 4);
+			ItemStack aCompost = ItemUtils.getSimpleStack(AgriculturalChem.mCompost, aTier > 1 ? 2^(aTier - 1) : 1);
 			aInputs = new ItemStack[] {aCompost};
 			// Boost Tier by one if using compost so it gets a speed boost
 			aTier++;
@@ -124,73 +124,76 @@ public class RecipeLoader_AlgaeFarm {
 		
 		// Create an Automap to dump contents into
 		AutoMap<ItemStack> aOutputMap = new AutoMap<ItemStack>();
-		
-		// Buff output by yielding 6-8 times more.
-		for (int i=0;i<MathUtils.randInt(4, 8);i++) {
-			// Add loot relevant to tier and also add any from lower tiers.
-			if (aTier >= 0) {
-				aOutputMap.put(ItemUtils.getSimpleStack(AgriculturalChem.mAlgaeBiosmass, MathUtils.randInt(16, 32)));
-				aOutputMap.put(ItemUtils.getSimpleStack(AgriculturalChem.mAlgaeBiosmass, MathUtils.randInt(32, 64)));			
-				if (MathUtils.randInt(0, 10) > 9) {
-					aOutputMap.put(ItemUtils.getSimpleStack(AgriculturalChem.mGreenAlgaeBiosmass, MathUtils.randInt(8, 16)));				
-				}
-			}
-			if (aTier >= 1) {
-				aOutputMap.put(ItemUtils.getSimpleStack(AgriculturalChem.mAlgaeBiosmass, MathUtils.randInt(16, 32)));
-				aOutputMap.put(ItemUtils.getSimpleStack(AgriculturalChem.mGreenAlgaeBiosmass, MathUtils.randInt(16, 32)));			
-				if (MathUtils.randInt(0, 10) > 9) {
-					aOutputMap.put(ItemUtils.getSimpleStack(AgriculturalChem.mGreenAlgaeBiosmass, MathUtils.randInt(4, 8)));				
-				}
-			}
-			if (aTier >= 2) {
-				aOutputMap.put(ItemUtils.getSimpleStack(AgriculturalChem.mGreenAlgaeBiosmass, MathUtils.randInt(8, 16)));
-				aOutputMap.put(ItemUtils.getSimpleStack(AgriculturalChem.mGreenAlgaeBiosmass, MathUtils.randInt(16, 32)));			
-				if (MathUtils.randInt(0, 10) > 9) {
-					aOutputMap.put(ItemUtils.getSimpleStack(AgriculturalChem.mGreenAlgaeBiosmass, MathUtils.randInt(4, 8)));				
-				}
-			}
-			if (aTier >= 3) {
-				aOutputMap.put(ItemUtils.getSimpleStack(AgriculturalChem.mGreenAlgaeBiosmass, MathUtils.randInt(16, 32)));
-				aOutputMap.put(ItemUtils.getSimpleStack(AgriculturalChem.mBrownAlgaeBiosmass, MathUtils.randInt(2, 8)));			
-				if (MathUtils.randInt(0, 10) > 9) {
-					aOutputMap.put(ItemUtils.getSimpleStack(AgriculturalChem.mBrownAlgaeBiosmass, MathUtils.randInt(8, 16)));				
-				}
-			}
-			if (aTier >= 4) {
-				aOutputMap.put(ItemUtils.getSimpleStack(AgriculturalChem.mBrownAlgaeBiosmass, MathUtils.randInt(16, 32)));
-				aOutputMap.put(ItemUtils.getSimpleStack(AgriculturalChem.mBrownAlgaeBiosmass, MathUtils.randInt(32, 64)));			
-				if (MathUtils.randInt(0, 10) > 9) {
-					aOutputMap.put(ItemUtils.getSimpleStack(AgriculturalChem.mGoldenBrownAlgaeBiosmass, MathUtils.randInt(4, 8)));				
-				}
-			}
-			if (aTier >= 5) {
-				aOutputMap.put(ItemUtils.getSimpleStack(AgriculturalChem.mBrownAlgaeBiosmass, MathUtils.randInt(16, 32)));
-				aOutputMap.put(ItemUtils.getSimpleStack(AgriculturalChem.mGoldenBrownAlgaeBiosmass, MathUtils.randInt(16, 32)));			
-				if (MathUtils.randInt(0, 10) > 9) {
-					aOutputMap.put(ItemUtils.getSimpleStack(AgriculturalChem.mRedAlgaeBiosmass, MathUtils.randInt(1, 2)));				
-				}
-			}
-			// Tier 6 is Highest for outputs
-			if (aTier >= 6) {
-				aOutputMap.put(ItemUtils.getSimpleStack(AgriculturalChem.mGoldenBrownAlgaeBiosmass, MathUtils.randInt(16, 32)));
-				aOutputMap.put(ItemUtils.getSimpleStack(AgriculturalChem.mRedAlgaeBiosmass, MathUtils.randInt(8, 16)));			
-				if (MathUtils.randInt(0, 10) > 9) {
-					aOutputMap.put(ItemUtils.getSimpleStack(AgriculturalChem.mRedAlgaeBiosmass, MathUtils.randInt(8, 16)));				
-				}
-			}
-			
-			// Iterate a special loop at higher tiers to provide more Red/Gold Algae.
-			for (int i2=0;i2<(9-aTier);i2++) {
-				if (aTier >= (6+i2)) {
-					int aMulti = i2 + 1;
-					aOutputMap.put(ItemUtils.getSimpleStack(AgriculturalChem.mGoldenBrownAlgaeBiosmass, MathUtils.randInt(4, 8*aMulti)));
-					aOutputMap.put(ItemUtils.getSimpleStack(AgriculturalChem.mRedAlgaeBiosmass, MathUtils.randInt(4, 8*aMulti)));			
-					if (MathUtils.randInt(0, 10) > 8) {
-						aOutputMap.put(ItemUtils.getSimpleStack(AgriculturalChem.mRedAlgaeBiosmass, MathUtils.randInt(8, 16*aMulti)));				
-					}
-				}
+
+
+		// Add loot relevant to tier and also add any from lower tiers.
+
+		if (aTier >= 0) {
+			aOutputMap.put(ItemUtils.getSimpleStack(AgriculturalChem.mAlgaeBiosmass, 2));
+			aOutputMap.put(ItemUtils.getSimpleStack(AgriculturalChem.mAlgaeBiosmass, 4));
+			if (MathUtils.randInt(0, 10) > 9) {
+				aOutputMap.put(ItemUtils.getSimpleStack(AgriculturalChem.mGreenAlgaeBiosmass, 2));
 			}
 		}
+
+		if (aTier >= 1) {
+			aOutputMap.put(ItemUtils.getSimpleStack(AgriculturalChem.mAlgaeBiosmass, 4));
+			aOutputMap.put(ItemUtils.getSimpleStack(AgriculturalChem.mGreenAlgaeBiosmass, 2));
+			if (MathUtils.randInt(0, 10) > 9) {
+				aOutputMap.put(ItemUtils.getSimpleStack(AgriculturalChem.mGreenAlgaeBiosmass, 4));
+			}
+		}
+		if (aTier >= 2) {
+			aOutputMap.put(ItemUtils.getSimpleStack(AgriculturalChem.mGreenAlgaeBiosmass, 2));
+			aOutputMap.put(ItemUtils.getSimpleStack(AgriculturalChem.mGreenAlgaeBiosmass, 3));
+			if (MathUtils.randInt(0, 10) > 9) {
+				aOutputMap.put(ItemUtils.getSimpleStack(AgriculturalChem.mGreenAlgaeBiosmass, 8));
+			}
+		}
+		if (aTier >= 3) {
+			aOutputMap.put(ItemUtils.getSimpleStack(AgriculturalChem.mGreenAlgaeBiosmass, 4));
+			aOutputMap.put(ItemUtils.getSimpleStack(AgriculturalChem.mBrownAlgaeBiosmass, 1));
+			if (MathUtils.randInt(0, 10) > 9) {
+				aOutputMap.put(ItemUtils.getSimpleStack(AgriculturalChem.mBrownAlgaeBiosmass, 4));
+			}
+		}
+		if (aTier >= 4) {
+			aOutputMap.put(ItemUtils.getSimpleStack(AgriculturalChem.mBrownAlgaeBiosmass, 2));
+			aOutputMap.put(ItemUtils.getSimpleStack(AgriculturalChem.mBrownAlgaeBiosmass, 3));
+			if (MathUtils.randInt(0, 10) > 9) {
+				aOutputMap.put(ItemUtils.getSimpleStack(AgriculturalChem.mGoldenBrownAlgaeBiosmass, 4));
+			}
+		}
+		if (aTier >= 5) {
+			aOutputMap.put(ItemUtils.getSimpleStack(AgriculturalChem.mBrownAlgaeBiosmass, 4));
+			aOutputMap.put(ItemUtils.getSimpleStack(AgriculturalChem.mGoldenBrownAlgaeBiosmass, 2));
+			if (MathUtils.randInt(0, 10) > 9) {
+				aOutputMap.put(ItemUtils.getSimpleStack(AgriculturalChem.mRedAlgaeBiosmass, 4));
+			}
+		}
+		// Tier 6 is Highest for outputs
+		if (aTier >= 6) {
+			aOutputMap.put(ItemUtils.getSimpleStack(AgriculturalChem.mGoldenBrownAlgaeBiosmass, 4));
+			aOutputMap.put(ItemUtils.getSimpleStack(AgriculturalChem.mRedAlgaeBiosmass, 2));
+			if (MathUtils.randInt(0, 10) > 9) {
+				aOutputMap.put(ItemUtils.getSimpleStack(AgriculturalChem.mRedAlgaeBiosmass, 8));
+			}
+		}
+
+		// Iterate a special loop at higher tiers to provide more Red/Gold Algae.
+		for (int i2=0;i2<20;i2++) {
+			if (aTier >= (6+i2)) {
+				int aMulti = i2 + 1;
+				aOutputMap.put(ItemUtils.getSimpleStack(AgriculturalChem.mGreenAlgaeBiosmass, aMulti * 4));
+				aOutputMap.put(ItemUtils.getSimpleStack(AgriculturalChem.mBrownAlgaeBiosmass, aMulti * 3));
+				aOutputMap.put(ItemUtils.getSimpleStack(AgriculturalChem.mGoldenBrownAlgaeBiosmass, aMulti * 2));
+				aOutputMap.put(ItemUtils.getSimpleStack(AgriculturalChem.mRedAlgaeBiosmass, aMulti));
+			}
+			else {
+				i2 = 20;
+			}
+		}
+
 		
 		
 		


### PR DESCRIPTION
- Changed the Algae Farm cycles, so that the multi works much faster but outputs less algae, in a more similar fashion to other multiblocks;
- Tweaked some related recipes that were still too underpowered;
- Increased the cost of Compost per tier to reinforce the decision between using it, upgrading the Algae Farm or making more.

This PR is (hopefully) the final change to make the Algae Farm usable and more popular within progression. This multi runs on no power to generate algae, slowly, but running faster as its tier increases. From those algae, the player can automate many different kinds of items and fluids, including chemicals that are essential to progression like Sulfuric Acid, Ethylene, Methane, etc.

The recipe paths to obtain those and other outputs are generally better than the conventional ways, but at the cost of having to build Chemical Plants, since they are required for almost all recipes in the Algae Farm processing line. However, this structure investment should pay off with the automation of several important things at once, from a single source, and even some power generation from Methane or, later, Butanol.