### PR TITLE
Remove misleading description for "cannot overclock"

### DIFF
--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/GregtechMetaTileEntity_IndustrialMolecularTransformer.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/GregtechMetaTileEntity_IndustrialMolecularTransformer.java
@@ -60,7 +60,6 @@ public class GregtechMetaTileEntity_IndustrialMolecularTransformer extends Gregt
 		tt.addMachineType(getMachineType())
 				.addInfo("Changes the structure of items to produce new ones")
 				.addInfo("Speed: 100% | Eu Usage: 100%")
-				.addInfo("This multiblock cannot be overclocked")
 				.addInfo("Maximum 1x of each bus/hatch.")
 				.addPollutionAmount(getPollutionPerSecond(null))
 				.addSeparator()

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/GregtechMTE_ElementalDuplicator.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/GregtechMTE_ElementalDuplicator.java
@@ -81,7 +81,6 @@ public class GregtechMTE_ElementalDuplicator extends GregtechMeta_MultiBlockBase
 		tt.addMachineType(getMachineType())
 		.addInfo("Produces Elemental Material from UU Matter")
 		.addInfo("Speed: 100% | Eu Usage: 100% | Parallel: 8 * Tier")
-		.addInfo("This multiblock cannot be overclocked")
 		.addInfo("Maximum 1x of each bus/hatch.")
 		.addInfo("Does not require both Output Hatch & Bus")
 		.addPollutionAmount(getPollutionPerSecond(null))


### PR DESCRIPTION
"Maximum 1x of each bus/hatch." is enough for implying "It does not accept 2 energy hatches to perform 1 tier above recipe"