### PR TITLE
Werkstoff bridge

### DIFF
--- a/src/main/java/gtPlusPlus/core/item/ModItems.java
+++ b/src/main/java/gtPlusPlus/core/item/ModItems.java
@@ -658,6 +658,13 @@ public final class ModItems {
 			MaterialGenerator.generateOreMaterial(ALLOY.KOBOLDITE);
 			GTplusplus_Everglades.GenerateOreMaterials();
 
+			// Werkstoff bridge
+			ELEMENT.getInstance().ZIRCONIUM.setWerkstoffID((short) 3);
+			ELEMENT.getInstance().THORIUM232.setWerkstoffID((short) 30);
+			ELEMENT.getInstance().RUTHENIUM.setWerkstoffID((short) 64);
+			ELEMENT.getInstance().HAFNIUM.setWerkstoffID((short) 11000);
+			ELEMENT.getInstance().IODINE.setWerkstoffID((short) 11012);
+
 
 		} catch (final Throwable r){
 			Logger.INFO("Failed to Generated a Material. "+r.getMessage());

--- a/src/main/java/gtPlusPlus/core/material/Material.java
+++ b/src/main/java/gtPlusPlus/core/material/Material.java
@@ -88,6 +88,8 @@ public class Material {
 	
 	public BaseTinkersMaterial vTiConHandler;
 
+	public short werkstoffID;
+
 
 	public static AutoMap<Materials> invalidMaterials = new AutoMap<Materials>();
 	
@@ -1525,6 +1527,10 @@ public class Material {
 		else {
 			return aGregtechMaterial;
 		}
+	}
+
+	public void setWerkstoffID(short werkstoffID) {
+		this.werkstoffID = werkstoffID;
 	}
 
 }

--- a/src/main/java/gtPlusPlus/core/material/MaterialStack.java
+++ b/src/main/java/gtPlusPlus/core/material/MaterialStack.java
@@ -3,6 +3,8 @@ package gtPlusPlus.core.material;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 
+import gregtech.api.enums.OrePrefixes;
+import gtPlusPlus.xmod.bartworks.BW_Utils;
 import net.minecraft.item.ItemStack;
 
 import gtPlusPlus.api.objects.Logger;
@@ -51,6 +53,16 @@ public class MaterialStack {
 
 	public ItemStack getDustStack(final int amount){
 		return this.stackMaterial.getDust(amount);
+	}
+
+	public ItemStack getUnificatedDustStack(final int amount) {
+		if (this.stackMaterial.werkstoffID != 0) {
+			ItemStack stack = BW_Utils.getCorrespondingItemStack(OrePrefixes.dust, this.stackMaterial.werkstoffID, amount);
+			if (stack != null) {
+				return stack;
+			}
+		}
+		return getDustStack(amount);
 	}
 
 	public Material getStackMaterial(){

--- a/src/main/java/gtPlusPlus/xmod/gregtech/loaders/RecipeGen_BlastSmelter.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/loaders/RecipeGen_BlastSmelter.java
@@ -216,7 +216,7 @@ public class RecipeGen_BlastSmelter extends RecipeGen_Base {
 									}
 								}
 								else {
-									components[irc] = M.getComposites().get(irc).getDustStack(r);
+									components[irc] = M.getComposites().get(irc).getUnificatedDustStack(r);
 								}
 							}
 						}


### PR DESCRIPTION
Closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/10629

So I spent hours on figuring out the root cause of the issue.
If I understand correctly, `getNonUnifiedStacks` creates link (`sUnificationTable`) from "representative" item (`mUnificationTarget`) to others, and `get` or `get_nocopy` return the representative.
As for BW material v.s. GT++ one, BW one is set to `mUnificationTarget`, since GT++ does not call `set` (and covered by BW `StaticRecipeChangeLoaders#runMaterialLinker`).
So I created link from GT++ material to BW one (`werkstoffID`), so that we can get unificated stack (`MaterialStack#getUnificatedDustStack`).