### PR TITLE
Fixed oversight by me, whoops

### DIFF
--- a/src/main/java/gtPlusPlus/core/recipe/RECIPES_GREGTECH.java
+++ b/src/main/java/gtPlusPlus/core/recipe/RECIPES_GREGTECH.java
@@ -2188,7 +2188,7 @@ public class RECIPES_GREGTECH {
 				}, 
 				null,
 				new int[] {100},
-				20 * (GTNH ? 300 : 60),
+				20 * (GTNH ? 25 : 60),
 				(int) MaterialUtils.getVoltageForTier(8),
 				500 * 20);
 


### PR DESCRIPTION
Made the Quantum Anomaly recipe the intended 25 seconds instead of 500 seconds. This stuff is confusing as hell. The recipe still is processed at UV tier
Closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/10702