### PR TITLE
Change Durability Loss Speed in XL Turbines

### DIFF
--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/turbines/GregtechMetaTileEntity_LargerTurbineBase.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/turbines/GregtechMetaTileEntity_LargerTurbineBase.java
@@ -618,8 +618,12 @@ public abstract class GregtechMetaTileEntity_LargerTurbineBase extends GregtechM
 				}
 			}            
 			for (GT_MetaTileEntity_Hatch_Turbine aHatch : getFullTurbineAssemblies()) {
+				// This cycle depletes durability from the turbine rotors.
+				// The amount of times it is run depends on turbineDamageMultiplier
+				// In XL turbines, durability loss is around 5.2-5.3x faster than in singles
+				// To compensate for that, the mEU/t scaling is divided by 5 to make it only slightly faster
 				for (int i = 0; i < turbineDamageMultiplier; i++) {
-					aHatch.damageTurbine(mEUt, damageFactorLow, damageFactorHigh);
+					aHatch.damageTurbine(mEUt / 5, damageFactorLow, damageFactorHigh);
 				}
 			}            
 		}
@@ -759,7 +763,7 @@ public abstract class GregtechMetaTileEntity_LargerTurbineBase extends GregtechM
 			speedMultiplier = 48;
 			maintenanceThreshold = 12;
 			pollutionMultiplier = 3;
-			turbineDamageMultiplier = 12;
+			turbineDamageMultiplier = 3;
 		}
 		else {
 			PlayerUtils.messagePlayer(aPlayer, "Running in Slow (16x) Mode.");


### PR DESCRIPTION
- Change the values for the speed of durability loss of rotors in XL Turbines, given that this loss scales with EU/t, and is not a fixed number as the speed of the multiblock changes.

The XL turbines take in the EU/t output of the entire multi, and then applies it to every turbine, Additionally, there is already an increase in durability consumption when making the multi run faster. Therefore, this chance reduces the durability consumption speed to match the numbers I intended when implementing Normal and Fast Modes.