### PR TITLE
Require Super Glue in Higher Graphene Production

### DIFF
--- a/src/main/java/gtPlusPlus/xmod/gregtech/loaders/recipe/RecipeLoader_GlueLine.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/loaders/recipe/RecipeLoader_GlueLine.java
@@ -329,12 +329,12 @@ public class RecipeLoader_GlueLine {
         // Graphene recipes from later wafer tiers, using superglue instead of the bronze age glue
         GT_Values.RA.addAssemblerRecipe(
                 new ItemStack[] {
-                        ItemUtils.getItemStackOfAmountFromOreDict("dustGraphite", 32),
+                        ItemUtils.getItemStackOfAmountFromOreDict("dustGraphite", 64),
                         ItemList.Circuit_Silicon_Wafer4.get(1L),
                         CI.getNumberedCircuit(2)
                 },
-                MISC_MATERIALS.ETHYL_CYANOACRYLATE.getFluidStack(200),
-                ItemUtils.getItemStackOfAmountFromOreDict("dustGraphene", 32),
+                MISC_MATERIALS.ETHYL_CYANOACRYLATE.getFluidStack(500),
+                ItemUtils.getItemStackOfAmountFromOreDict("dustGraphene", 64),
                 120,
                 30
         );
@@ -345,7 +345,7 @@ public class RecipeLoader_GlueLine {
                         ItemList.Circuit_Silicon_Wafer5.get(1L),
                         CI.getNumberedCircuit(2)
                 },
-                MISC_MATERIALS.ETHYL_CYANOACRYLATE.getFluidStack(200),
+                MISC_MATERIALS.ETHYL_CYANOACRYLATE.getFluidStack(250),
                 ItemUtils.getItemStackOfAmountFromOreDict("dustGraphene", 64),
                 120,
                 30

--- a/src/main/java/gtPlusPlus/xmod/gregtech/loaders/recipe/RecipeLoader_GlueLine.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/loaders/recipe/RecipeLoader_GlueLine.java
@@ -330,7 +330,7 @@ public class RecipeLoader_GlueLine {
         GT_Values.RA.addAssemblerRecipe(
                 new ItemStack[] {
                         ItemUtils.getItemStackOfAmountFromOreDict("dustGraphite", 64),
-                        ItemList.Circuit_Silicon_Wafer4.get(1L),
+                        ItemList.Circuit_Silicon_Wafer4.get(2L),
                         CI.getNumberedCircuit(2)
                 },
                 MISC_MATERIALS.ETHYL_CYANOACRYLATE.getFluidStack(500),


### PR DESCRIPTION
- Edited the existing Super Glue recipes to make Graphene with some wafer inputs, to match the other PR that makes these the only option with these wafers.

Referencing https://github.com/GTNewHorizons/GT5-Unofficial/pull/1179. Check that PR for more details.