### PR TITLE
Flotation Cell fixes

### DIFF
--- a/src/main/java/gregtech/api/util/GTPP_Recipe.java
+++ b/src/main/java/gregtech/api/util/GTPP_Recipe.java
@@ -294,7 +294,7 @@ public class GTPP_Recipe extends GT_Recipe implements IComparableRecipe {
 		public static final GT_Recipe_Map_Fuel sSemiFluidLiquidFuels = new GT_Recipe_Map_Fuel(new HashSet<GT_Recipe>(10), "gtpp.recipe.semifluidgeneratorfuels", "Semifluid Generator Fuels", null, RES_PATH_GUI + "basicmachines/Default", 1, 1, 0, 0, 1, "Fuel Value: ", 1000, " EU", true, true);
 
 		// Flotation Cell
-		public static final GTPP_Recipe_Map_Internal sFlotationCellRecipes = new GTPP_Recipe_Map_Internal(new HashSet<GT_Recipe>(10000), "gtpp.recipe.flotationcell", "Flotation Cell", null, RES_PATH_GUI + "basicmachines/LFTR", 6, 4, 1, 1, 1, "Ore Key: ", 1, E, true, true);
+		public static final GTPP_Recipe_Map_Internal sFlotationCellRecipes = new GTPP_Recipe_Map_Internal(new HashSet<GT_Recipe>(10000), "gtpp.recipe.flotationcell", "Flotation Cell", null, RES_PATH_GUI + "basicmachines/LFTR", 6, 4, 1, 1, 1, "", 1, E, true, true);
 
 		// Tree Growth Simulator
 		public static final GTPP_Recipe_Map_Internal sTreeSimFakeRecipes = new GTPP_Recipe_Map_MultiNoCell(new HashSet<GT_Recipe>(100), "gtpp.recipe.treefarm", "Tree Growth Simulator", null, RES_PATH_GUI + "basicmachines/FissionFuel", 9, 9, 1, 0, 1, "", 1, "", false, true);

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/helpers/FlotationRecipeHandler.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/helpers/FlotationRecipeHandler.java
@@ -2,25 +2,23 @@ package gtPlusPlus.xmod.gregtech.common.helpers;
 
 import java.util.HashMap;
 
-import gregtech.api.enums.OrePrefixes;
 import gregtech.api.util.GT_Recipe;
 import gregtech.api.util.GT_Utility;
-import gtPlusPlus.core.lib.CORE;
 import gtPlusPlus.core.material.Material;
-import gtPlusPlus.core.util.data.AES;
+import gtPlusPlus.core.util.sys.Log;
 import gtPlusPlus.xmod.gregtech.api.enums.CustomOrePrefix;
 import net.minecraft.item.ItemStack;
+import net.minecraftforge.oredict.OreDictionary;
 
 public class FlotationRecipeHandler {
 
-	private static HashMap<String, Material> sMaterialMap = new HashMap<String, Material>();
-	private static HashMap<String, ItemStack> sMilledMap = new HashMap<String, ItemStack>();
-	private static final AES sEncodingHandler = new AES();
+	private static final HashMap<String, Material> sMaterialMap = new HashMap<String, Material>();
+	private static final HashMap<String, ItemStack> sMilledMap = new HashMap<String, ItemStack>();
 	
 	public static boolean registerOreType(Material aMaterial) {	
-		String aMaterialKey = sEncodingHandler.encode(aMaterial.getUnlocalizedName());
+		String aMaterialKey = aMaterial.getUnlocalizedName();
 		if (sMaterialMap.containsKey(aMaterialKey)) {
-			CORE.crash("Tried to register a Flotation material to an ID already in use. ID: "+aMaterialKey);
+			Log.warn("Tried to register a Flotation material already in use. Material: "+aMaterialKey);
 			return false;
 		}
 		else {
@@ -28,19 +26,6 @@ public class FlotationRecipeHandler {
 			sMilledMap.put(aMaterialKey, aMaterial.getMilled(1));
 		}		
 		return true;
-	}
-	
-	public static int getHashForMaterial(Material aMaterial) {
-		return getMaterialsID(aMaterial).hashCode();
-	}
-	
-	public static String getMaterialsID(Material aMaterial) {
-		for (String aKey : sMaterialMap.keySet()) {
-			if (sMaterialMap.get(aKey).equals(aMaterial)) {
-				return aKey;
-			}
-		}		
-		return "BAD_MATERIAL_ID";
 	}
 	
 	public static Material getMaterialOfMilledProduct(ItemStack aMilled) {
@@ -65,15 +50,14 @@ public class FlotationRecipeHandler {
 			return null;
 		}
 		for (ItemStack aStack : aInputs) {
-			if (CustomOrePrefix.milled.get().contains(aStack)) {
-				return aStack;
+			for (int oredictID : OreDictionary.getOreIDs(aStack)) {
+				String oredict = OreDictionary.getOreName(oredictID);
+				if (oredict.startsWith(CustomOrePrefix.milled.toString())) {
+					return aStack;
+				}
 			}
 		}		
 		return null;
-	}
-	
-	public static AES getEncoder() {
-		return sEncodingHandler;
 	}
 	
 }

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/GregtechMTE_FrothFlotationCell.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/GregtechMTE_FrothFlotationCell.java
@@ -291,14 +291,6 @@ public class GregtechMTE_FrothFlotationCell extends GregtechMeta_MultiBlockBase<
 			foundMaterialName = foundMaterial.getUnlocalizedName();
 		}
 
-		// Set material locked for this controller
-		if (lockedMaterialName == null) {
-			if (foundMaterialName != null) {
-				lockedMaterialName = foundMaterialName;
-			}
-		}
-
-		// Check material match
 		if (foundMaterialName == null) {
 			log("Did not find material from Milled Ore.");
 			ItemStack milledStack = FlotationRecipeHandler.findMilledStack(tRecipe);
@@ -307,6 +299,13 @@ public class GregtechMTE_FrothFlotationCell extends GregtechMeta_MultiBlockBase<
 			}
 			return false;
 		}
+
+		// Set material locked for this controller
+		if (lockedMaterialName == null) {
+			lockedMaterialName = foundMaterialName;
+		}
+
+		// Check material match
 		if (!Objects.equals(lockedMaterialName, foundMaterialName)) {
 			log("Did not find the correct milled type.");
 			log("Found: "+foundMaterialName);

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/GregtechMTE_FrothFlotationCell.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/GregtechMTE_FrothFlotationCell.java
@@ -8,8 +8,11 @@ import static gtPlusPlus.core.util.data.ArrayUtils.removeNulls;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 import gregtech.api.interfaces.IIconContainer;
+import gtPlusPlus.core.material.Material;
+import net.minecraftforge.common.util.Constants;
 import org.apache.commons.lang3.ArrayUtils;
 
 import com.gtnewhorizon.structurelib.structure.IStructureDefinition;
@@ -275,26 +278,38 @@ public class GregtechMTE_FrothFlotationCell extends GregtechMeta_MultiBlockBase<
 		
 		/*
 		 * 
-		 * Material Hash checks
+		 * Material checks
 		 * Makes sure we can only ever use one type of material in this flotation cell.
+		 * We used to depend on Alk's hash, but it's unreliable and user-hostile
+		 * So we're using unlocalized name of material now.
 		 * 
 		 */
-		int aExpectedMaterialHash;
-		// Set the hash of expected material type
-		if (mLockedOreType == -1) {
-			mLockedOreType = FlotationRecipeHandler.getHashForMaterial(FlotationRecipeHandler.getMaterialOfMilledProduct(FlotationRecipeHandler.findMilledStack(aRecipe)));
+		Material foundMaterial = FlotationRecipeHandler.getMaterialOfMilledProduct(FlotationRecipeHandler.findMilledStack(tRecipe));
+		String foundMaterialName = null;
+		if (foundMaterial != null) {
+			foundMaterialName = foundMaterial.getUnlocalizedName();
 		}
-		// Set the hash for this recipe check
-		aExpectedMaterialHash = mLockedOreType;
-		
-		// Compute hash of current inputs
-		int aFoundMaterialHash = FlotationRecipeHandler.getHashForMaterial(FlotationRecipeHandler.getMaterialOfMilledProduct(FlotationRecipeHandler.findMilledStack(aItemInputs)));
-		
-		// Check hashes match
-		if (aExpectedMaterialHash != aFoundMaterialHash) {
+
+		// Set material locked for this controller
+		if (lockedMaterialName == null) {
+			if (foundMaterialName != null) {
+				lockedMaterialName = foundMaterialName;
+			}
+		}
+
+		// Check material match
+		if (foundMaterialName == null) {
+			log("Did not find material from Milled Ore.");
+			ItemStack milledStack = FlotationRecipeHandler.findMilledStack(tRecipe);
+			if (milledStack != null) {
+				log("Found stack: " + milledStack.getDisplayName());
+			}
+			return false;
+		}
+		if (!Objects.equals(lockedMaterialName, foundMaterialName)) {
 			log("Did not find the correct milled type.");
-			log("Found: "+aFoundMaterialHash);
-			log("Expected: "+mLockedOreType);
+			log("Found: "+foundMaterialName);
+			log("Expected: "+lockedMaterialName);
 			return false;
 		}
 		
@@ -432,12 +447,12 @@ public class GregtechMTE_FrothFlotationCell extends GregtechMeta_MultiBlockBase<
 	 * Handle NBT
 	 */
 
-	private int mLockedOreType = -1;
+	private String lockedMaterialName = null;
 
 	@Override
 	public void setItemNBT(NBTTagCompound aNBT) {
-		if (mLockedOreType != -1) {
-			aNBT.setInteger("mLockedOreType", mLockedOreType);			
+		if (lockedMaterialName != null) {
+			aNBT.setString("lockedMaterialName", lockedMaterialName);
 		}
 		super.setItemNBT(aNBT);
 	}
@@ -445,24 +460,23 @@ public class GregtechMTE_FrothFlotationCell extends GregtechMeta_MultiBlockBase<
 	@Override
 	public void saveNBTData(NBTTagCompound aNBT) {
 		super.saveNBTData(aNBT);
-		if (mLockedOreType != -1) {
-			aNBT.setInteger("mLockedOreType", mLockedOreType);
+		if (lockedMaterialName != null) {
+			aNBT.setString("lockedMaterialName", lockedMaterialName);
 		}
 	}
 
 	@Override
 	public void loadNBTData(NBTTagCompound aNBT) {
 		super.loadNBTData(aNBT);
-		mLockedOreType = aNBT.getInteger("mLockedOreType");
-		if (mLockedOreType == 0) {
-			mLockedOreType = -1;
+		if (aNBT.hasKey("lockedMaterialName", Constants.NBT.TAG_STRING)) {
+			lockedMaterialName = aNBT.getString("lockedMaterialName");
 		}
 	}
 
 	@Override
 	public String[] getExtraInfoData() {
 		return new String[] {
-				"Locked Ore Type: " + mLockedOreType
+				"Locked material: " + lockedMaterialName
 		};
 	}
 }

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/GregtechMTE_FrothFlotationCell.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/GregtechMTE_FrothFlotationCell.java
@@ -68,6 +68,7 @@ public class GregtechMTE_FrothFlotationCell extends GregtechMeta_MultiBlockBase<
 		GT_Multiblock_Tooltip_Builder tt = new GT_Multiblock_Tooltip_Builder();
 		tt.addMachineType(getMachineType())
 				.addInfo("Process that milled ore!")
+				.addInfo("You can only ever process one type of material per controller")
 				.addPollutionAmount(getPollutionPerSecond(null))
 				.addSeparator()
 				.beginStructureBlock(3, 9, 3, true)

--- a/src/main/java/gtPlusPlus/xmod/gregtech/recipes/GregtechRecipeAdder.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/recipes/GregtechRecipeAdder.java
@@ -1723,7 +1723,6 @@ public class GregtechRecipeAdder implements IGregtech_RecipeAdder {
 	public boolean addFlotationRecipe(Material aMat, ItemStack aXanthate, FluidStack[] aInputFluids, FluidStack[] aOutputFluids, int aTime, int aEU) {
 
 		FlotationRecipeHandler.registerOreType(aMat);
-		int aSpecialValue = FlotationRecipeHandler.getHashForMaterial(aMat);
 
 		int aSize = GTPP_Recipe.GTPP_Recipe_Map.sFlotationCellRecipes.mRecipeList.size();
 		int aSize2 = aSize;		
@@ -1746,7 +1745,7 @@ public class GregtechRecipeAdder implements IGregtech_RecipeAdder {
 				aOutputFluids,
 				aTime,
 				aEU,
-				aSpecialValue); 
+				0);
 
 		GTPP_Recipe.GTPP_Recipe_Map.sFlotationCellRecipes.add(aRecipe);
 		aSize = GTPP_Recipe.GTPP_Recipe_Map.sFlotationCellRecipes.mRecipeList.size();


### PR DESCRIPTION
- Use material unlocalized name instead of Alk's hash
  - I'm shocked at what Alk used for hash: https://github.com/GTNewHorizons/GTplusplus/blob/master/src/main/java/gtPlusPlus/core/util/data/AES.java This is terrible. Also showing hash is user-hostile. So I changed to use material name instead.
- Fix `findMilledStack` is called with incorrect argument `aRecipe`
- Fix `findMilledStack` not working
  - This is probably why the hash is locked to value that no ore has. Still not sure why it worked with my env though.
  - Close https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/10924