### PR TITLE
Disable the large generator array

### DIFF
--- a/src/main/java/gtPlusPlus/core/recipe/RECIPES_Machines.java
+++ b/src/main/java/gtPlusPlus/core/recipe/RECIPES_Machines.java
@@ -263,7 +263,6 @@ public class RECIPES_Machines {
 		gt4Redstone();
 		gt4Inventory();
 		
-		multiGeneratorArray();
 		multiForgeHammer();
 		multiMolecularTransformer();
 		multiXlTurbines();
@@ -465,19 +464,6 @@ public class RECIPES_Machines {
 			aTier++;
 		}
 		
-	}
-
-	private static void multiGeneratorArray() {
-
-        GT_ModHandler.addCraftingRecipe(
-        		GregtechItemList.Generator_Array_Controller.get(1L),
-        		CI.bitsd, 
-        		new Object[]{"CTC", "FMF", "CBC",
-        				'M', CI.getTieredGTPPMachineCasing(4, 1),
-        				'B', OrePrefixes.pipeHuge.get(Materials.StainlessSteel),
-        				'C', OrePrefixes.circuit.get(Materials.Data),
-        				'F', ItemList.Electric_Pump_EV,
-        				'T', CI.getSensor(4, 1)});
 	}
 
 	private static void multiForgeHammer() {

--- a/src/main/java/gtPlusPlus/core/recipe/RECIPES_Machines.java
+++ b/src/main/java/gtPlusPlus/core/recipe/RECIPES_Machines.java
@@ -262,7 +262,8 @@ public class RECIPES_Machines {
 		gt4FarmManager();
 		gt4Redstone();
 		gt4Inventory();
-		
+
+		//multiGeneratorArray();
 		multiForgeHammer();
 		multiMolecularTransformer();
 		multiXlTurbines();
@@ -464,6 +465,19 @@ public class RECIPES_Machines {
 			aTier++;
 		}
 		
+	}
+
+	private static void multiGeneratorArray() {
+
+		GT_ModHandler.addCraftingRecipe(
+				GregtechItemList.Generator_Array_Controller.get(1L),
+				CI.bitsd,
+				new Object[]{"CTC", "FMF", "CBC",
+						'M', CI.getTieredGTPPMachineCasing(4, 1),
+						'B', OrePrefixes.pipeHuge.get(Materials.StainlessSteel),
+						'C', OrePrefixes.circuit.get(Materials.Data),
+						'F', ItemList.Electric_Pump_EV,
+						'T', CI.getSensor(4, 1)});
 	}
 
 	private static void multiForgeHammer() {

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/GregtechMetaTileEntityGeneratorArray.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/GregtechMetaTileEntityGeneratorArray.java
@@ -237,11 +237,12 @@ public class GregtechMetaTileEntityGeneratorArray extends GregtechMeta_MultiBloc
 		}		
 		return MODE_NONE;		
 	}
-	
+
 	@Override
 	public boolean checkRecipe(ItemStack aStack) {
-		
-		this.resetRecipeMapForAllInputHatches();
+		return false;
+
+/**		this.resetRecipeMapForAllInputHatches();
 		this.mMode = getModeFromInventorySlot(aStack);		
 		if (mMode == MODE_NONE) {
 			Logger.INFO("Did not find valid generator.");
@@ -291,7 +292,7 @@ public class GregtechMetaTileEntityGeneratorArray extends GregtechMeta_MultiBloc
 									Logger.INFO("No Lube.");
 									return false;
 								}*/
-
+/**
 								if (this.mRuntime % 72 == 0 || this.mRuntime == 0) {
 									this.depleteInput(Materials.Lubricant.getFluid(this.boostEu ? 2L : 1L));
 								}
@@ -317,6 +318,7 @@ public class GregtechMetaTileEntityGeneratorArray extends GregtechMeta_MultiBloc
 		this.mEUt = 0;
 		this.mEfficiency = 0;
 		return false;
+ **/
 	}
 
 	public static ItemStack[] clean(final ItemStack[] v) {


### PR DESCRIPTION
The multi doesn't work as intended and allows for free power generation. This PR makes them uncraftable and makes them stop working. Code is still there if someone wants to work on them at some point