### PR TITLE
Fix void protection with locked fluid hatches

### DIFF
--- a/src/main/java/gtPlusPlus/xmod/gregtech/api/metatileentity/implementations/base/GregtechMeta_MultiBlockBase.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/api/metatileentity/implementations/base/GregtechMeta_MultiBlockBase.java
@@ -617,6 +617,8 @@ public abstract class GregtechMeta_MultiBlockBase<T extends GT_MetaTileEntity_En
 				GT_MetaTileEntity_Hatch_Output aHatch = aOutputHatches.get(i).getValue_1();
 				// Fluid in the Hatch
 				FluidStack aHatchStack = aOutputHatches.get(i).getValue_2();
+				// Fluid that the hatch is locked to
+				String aHatchLockedFluid = aOutputHatches.get(i).getValue_1().getLockedFluidName();
 				// Space left in Hatch
 				int aSpaceLeftInHatch = aHatch.getCapacity() - aHatch.getFluidAmount();		
 				// Hatch is full,
@@ -625,14 +627,14 @@ public abstract class GregtechMeta_MultiBlockBase<T extends GT_MetaTileEntity_En
 					aOutputHatches.remove(aOutputHatches.get(i));
 					i--;
 					continue;
-				}			
+				}
 				// Hatch has space
 				else {	
 					// Check if any fluids match
 					//aFluidMatch: for (FluidStack aOutputStack : aOutputFluids) {
 					for(int j = 0;j<aOutputFluids.size();j++) {
 						//log(" aHatchStack "+aHatchStack.getLocalizedName()+" aOutput stack "+aOutputStack.getLocalizedName());
-						if (GT_Utility.areFluidsEqual(aHatchStack, aOutputFluids.get(j))) {
+						if (GT_Utility.areFluidsEqual(aHatchStack, aOutputFluids.get(j)) && (aHatchLockedFluid == null || aHatchLockedFluid.equals(aOutputFluids.get(j).getFluid().getName()))) {
 							int aFluidToPutIntoHatch = aOutputFluids.get(j).amount * aParallelRecipes;
 							// Not Enough space to insert all of the fluid.
 							// We fill this hatch and add a smaller Fluidstack back to the iterator.
@@ -698,6 +700,9 @@ public abstract class GregtechMeta_MultiBlockBase<T extends GT_MetaTileEntity_En
 							}
 
 						}
+						else if (aHatchLockedFluid == null || aHatchLockedFluid.equals(aOutputFluids.get(j).getFluid().getName())) {
+							aEmptyFluidHatches++;
+						}
 						else {
 							continue;
 						}
@@ -707,7 +712,7 @@ public abstract class GregtechMeta_MultiBlockBase<T extends GT_MetaTileEntity_En
 
 			for (Triplet<GT_MetaTileEntity_Hatch_Output, FluidStack, Integer> aFreeHatchCheck : aOutputHatches) {
 				// Free Hatch
-				if (aFreeHatchCheck.getValue_2() == null || aFreeHatchCheck.getValue_3() == 0 || aFreeHatchCheck.getValue_1().getFluid() == null) {
+				if ((aFreeHatchCheck.getValue_2() == null || aFreeHatchCheck.getValue_3() == 0 || aFreeHatchCheck.getValue_1().getFluid() == null) && !aFreeHatchCheck.getValue_1().isFluidLocked()) {
 					aEmptyFluidHatches++;
 				}
 			}


### PR DESCRIPTION
Previously empty hatches that had a fluid locked to them would be counted as free, now they will not.
- Kinda fixes https://github.com/GTNewHorizons/GTplusplus/issues/136. The fluid will no longer be voided, however the machine doesn't check the other recipe in the described scenario but that doesn't have anything to do with void protection but with how the recipe is checked