### PR TITLE
Update industrial sledgehammer and forge casing recipes to be easier

### DIFF
--- a/src/main/java/gtPlusPlus/core/recipe/RECIPES_Machines.java
+++ b/src/main/java/gtPlusPlus/core/recipe/RECIPES_Machines.java
@@ -483,34 +483,28 @@ public class RECIPES_Machines {
 	}
 
 	private static void multiForgeHammer() {
-		
+
 		CORE.RA.addSixSlotAssemblingRecipe(
 				new ItemStack[] {
-						CI.getTieredGTPPMachineCasing(4, 1), 
+						ItemUtils.getSimpleStack(CI.machineHull_IV, 2),
 						ItemList.Machine_IV_Hammer.get(1),
 						CI.getPlate(4, 8),
 						CI.getBolt(5, 32),
 						ELEMENT.getInstance().ZIRCONIUM.getFineWire(32),
 						ItemUtils.getItemStackOfAmountFromOreDict("circuitElite", 4)
-				}, 
+				},
 				CI.getTieredFluid(4, 144 * 12),
-				GregtechItemList.Controller_IndustrialForgeHammer.get(1), 
+				GregtechItemList.Controller_IndustrialForgeHammer.get(1),
 				20 * 30,
 				MaterialUtils.getVoltageForTier(5));
-		
-		CORE.RA.addSixSlotAssemblingRecipe(
-				new ItemStack[] {
-						CI.getTieredGTPPMachineCasing(3, 1),
-						ItemList.Casing_HeatProof.get(1),
-						CI.getPlate(4, 2),
-						CI.getBolt(4, 8),
-						ALLOY.BABBIT_ALLOY.getFineWire(16),
-						ItemUtils.getItemStackOfAmountFromOreDict("circuitGood", 4)
-				}, 
-				CI.getTieredFluid(4, 144 * 2),
-				GregtechItemList.Casing_IndustrialForgeHammer.get(1), 
-				20 * 30,
-				MaterialUtils.getVoltageForTier(4));
+
+		GT_ModHandler.addCraftingRecipe(GregtechItemList.Casing_IndustrialForgeHammer.get(1),
+				CI.bitsd,
+				new Object[]{"IBI", "HCH", "IHI",
+						'I', CI.getPlate(4, 1),
+						'B', ALLOY.BABBIT_ALLOY.getPlate(1),
+						'C', ItemList.Casing_HeatProof.get(1),
+						'H', ALLOY.HASTELLOY_X.getRod(1)});
 		
 	}
 


### PR DESCRIPTION
Solves https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/11024

Updated the Industrial Sledgehammer recipe to be more in line with other multiblocks from its tier. As mentioned in the issue, the industrial sledgehammer is, if not _expensive,_ more complicated to craft than most other multiblocks on its tier. I aim to bring it and its casings (which suffer from the same problem) more in line with this pull request.

Updated controller recipe:
![image](https://user-images.githubusercontent.com/8249348/184720806-372561ac-83ce-4ac6-b357-5f068c65f614.png)
Swapped the integral encasement IV to be 2 IV machine hulls. It is otherwise unchanged.

 Updated casing recipe:
![image](https://user-images.githubusercontent.com/8249348/184721206-8e83f330-9bbe-4fab-ad07-aa72a4a07b34.png)
Completely redone in a crafting table recipe instead. Requires 4 incoloy-ma956 plates, 1 babbit alloy plate, 3 hastealloy-X rods, and 1 heat proof machine casing.