### PR TITLE
Fix Calamari

### DIFF
--- a/src/main/java/gtPlusPlus/xmod/growthcraft/fishtrap/FishTrapHandler.java
+++ b/src/main/java/gtPlusPlus/xmod/growthcraft/fishtrap/FishTrapHandler.java
@@ -101,7 +101,7 @@ public class FishTrapHandler {
 	final static String seaweed = "cropSeaweed";
 	final static String greenheartFish = "foodGreenheartfish";
 	private static final String[] harvestcraftFish = {
-			"Anchovy", "Bass", "Carp", "Catfish", "Charr", "Clam", "Crab", "Crayfish", "Eel", "Frog", "Grouper", "Herring",
+			"Anchovy", "Bass", "Calamari", "Carp", "Catfish", "Charr", "Clam", "Crab", "Crayfish", "Eel", "Frog", "Grouper", "Herring",
 			"Jellyfish", "Mudfish", "Octopus", "Perch", "Scallop", "Shrimp", "Snail", "Snapper", "Tilapia", "Trout", "Tuna", "Turtle", "Walley"};
 	public static void pamsHarvestCraftCompat(){
 		for (int i = 0; i < harvestcraftFish.length; i++){


### PR DESCRIPTION
https://github.com/GTNewHorizons/harvestcraft/pull/34/commits/5b5f47490de87e0b8a6798667d77c9d85f784dc6 broke standard automations (e.g. bone meal, raw meat) as calamari were not listed in gt++ for recipe generation. That was not the intent, so here is the fix.