### PR TITLE
Fix description of speed boost in tooltips

### DIFF
--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/misc/GMTE_AmazonPackager.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/misc/GMTE_AmazonPackager.java
@@ -110,7 +110,7 @@ public class GMTE_AmazonPackager extends GregtechMeta_MultiBlockBase<GMTE_Amazon
 		.addInfo("Dust Schematics are inserted into the input busses")
 		.addInfo("If inserted into the controller, it is shared across all busses")
 		.addInfo("1x, 2x, 3x & Other Schematics are to be placed into the controller GUI slot")
-		.addInfo("Uncomparably fast compared to a single packager of the same tier")
+		.addInfo("500% faster than using single block machines of the same voltage")
 		.addInfo("Only uses 75% of the eu/t normally required")
 		.addInfo("Processes 16 items per voltage tier")
 		.addPollutionAmount(getPollutionPerSecond(null))

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/misc/GMTE_AmazonPackager.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/misc/GMTE_AmazonPackager.java
@@ -111,7 +111,7 @@ public class GMTE_AmazonPackager extends GregtechMeta_MultiBlockBase<GMTE_Amazon
 		.addInfo("If inserted into the controller, it is shared across all busses")
 		.addInfo("1x, 2x, 3x & Other Schematics are to be placed into the controller GUI slot")
 		.addInfo("500% faster than using single block machines of the same voltage")
-		.addInfo("Only uses 75% of the eu/t normally required")
+		.addInfo("Only uses 75% of the EU/t normally required")
 		.addInfo("Processes 16 items per voltage tier")
 		.addPollutionAmount(getPollutionPerSecond(null))
 		.addSeparator()

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/GregtechMetaTileEntity_IndustrialAlloySmelter.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/GregtechMetaTileEntity_IndustrialAlloySmelter.java
@@ -124,7 +124,7 @@ public class GregtechMetaTileEntity_IndustrialAlloySmelter extends GregtechMeta_
 				.addInfo("Controller Block for the Industrial Alloy Smelter")
 				.addInfo("Gains one parallel per voltage tier")
 				.addInfo("Gains one multiplier per coil tier")
-				.addInfo("parallel = tier * coil tier")
+				.addInfo("Parallel = Tier * Coil Tier")
 				.addInfo("Gains 5% speed bonus per coil tier")
 				.addPollutionAmount(getPollutionPerSecond(null))
 				.addSeparator()

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/GregtechMetaTileEntity_IndustrialCentrifuge.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/GregtechMetaTileEntity_IndustrialCentrifuge.java
@@ -67,7 +67,7 @@ public class GregtechMetaTileEntity_IndustrialCentrifuge extends GregtechMeta_Mu
 				.addInfo("Controller Block for the Industrial Centrifuge")
 				.addInfo("125% faster than using single block machines of the same voltage")
 				.addInfo("Disable animations with a screwdriver")
-				.addInfo("Only uses 90% of the eu/t normally required")
+				.addInfo("Only uses 90% of the EU/t normally required")
 				.addInfo("Processes six items per voltage tier")
 				.addPollutionAmount(getPollutionPerSecond(null))
 				.addSeparator()

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/GregtechMetaTileEntity_IndustrialChisel.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/GregtechMetaTileEntity_IndustrialChisel.java
@@ -66,7 +66,7 @@ public class GregtechMetaTileEntity_IndustrialChisel extends GregtechMeta_MultiB
 				.addInfo("Factory Grade Auto Chisel")
 				.addInfo("Target block goes in GUI slot")
 				.addInfo("If no target provided, firdt chisel result is used")
-				.addInfo("Speed: +200% | Eu Usage: 75% | Parallel: Tier x 16")
+				.addInfo("Speed: +200% | EU Usage: 75% | Parallel: Tier x 16")
 				.addPollutionAmount(getPollutionPerSecond(null))
 				.addSeparator()
 				.beginStructureBlock(3, 3, 3, true)

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/GregtechMetaTileEntity_IndustrialChisel.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/GregtechMetaTileEntity_IndustrialChisel.java
@@ -66,7 +66,7 @@ public class GregtechMetaTileEntity_IndustrialChisel extends GregtechMeta_MultiB
 				.addInfo("Factory Grade Auto Chisel")
 				.addInfo("Target block goes in GUI slot")
 				.addInfo("If no target provided, firdt chisel result is used")
-				.addInfo("Speed: 200% | Eu Usage: 75% | Parallel: Tier x 16")
+				.addInfo("Speed: +200% | Eu Usage: 75% | Parallel: Tier x 16")
 				.addPollutionAmount(getPollutionPerSecond(null))
 				.addSeparator()
 				.beginStructureBlock(3, 3, 3, true)

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/GregtechMetaTileEntity_IndustrialCuttingMachine.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/GregtechMetaTileEntity_IndustrialCuttingMachine.java
@@ -60,7 +60,7 @@ public class GregtechMetaTileEntity_IndustrialCuttingMachine extends GregtechMet
 		tt.addMachineType(getMachineType())
 				.addInfo("Controller Block for the Industrial Cutting Factory")
 				.addInfo("200% faster than using single block machines of the same voltage")
-				.addInfo("Only uses 75% of the eu/t normally required")
+				.addInfo("Only uses 75% of the EU/t normally required")
 				.addInfo("Processes four items per voltage tier")
 				.addPollutionAmount(getPollutionPerSecond(null))
 				.addSeparator()

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/GregtechMetaTileEntity_IndustrialDehydrator.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/GregtechMetaTileEntity_IndustrialDehydrator.java
@@ -69,7 +69,7 @@ public class GregtechMetaTileEntity_IndustrialDehydrator extends GregtechMeta_Mu
 				.addInfo("Factory Grade Vacuum Furnace")
 				.addInfo("Can toggle the operation temperature with a Screwdriver")
 				.addInfo("All Dehydrator recipes are Low Temp recipes")
-				.addInfo("Speed: 120% | Eu Usage: 50% | Parallel: 4")
+				.addInfo("Speed: +120% | Eu Usage: 50% | Parallel: 4")
 				.addInfo("Each 900K over the min. Heat Capacity grants 5% speedup (multiplicatively)")
 				.addInfo("Each 1800K over the min. Heat Capacity allows for one upgraded overclock")
 				.addInfo("Upgraded overclocks reduce recipe time to 25% and increase EU/t to 400%")

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/GregtechMetaTileEntity_IndustrialDehydrator.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/GregtechMetaTileEntity_IndustrialDehydrator.java
@@ -69,7 +69,7 @@ public class GregtechMetaTileEntity_IndustrialDehydrator extends GregtechMeta_Mu
 				.addInfo("Factory Grade Vacuum Furnace")
 				.addInfo("Can toggle the operation temperature with a Screwdriver")
 				.addInfo("All Dehydrator recipes are Low Temp recipes")
-				.addInfo("Speed: +120% | Eu Usage: 50% | Parallel: 4")
+				.addInfo("Speed: +120% | EU Usage: 50% | Parallel: 4")
 				.addInfo("Each 900K over the min. Heat Capacity grants 5% speedup (multiplicatively)")
 				.addInfo("Each 1800K over the min. Heat Capacity allows for one upgraded overclock")
 				.addInfo("Upgraded overclocks reduce recipe time to 25% and increase EU/t to 400%")

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/GregtechMetaTileEntity_IndustrialElectrolyzer.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/GregtechMetaTileEntity_IndustrialElectrolyzer.java
@@ -54,7 +54,7 @@ public class GregtechMetaTileEntity_IndustrialElectrolyzer extends GregtechMeta_
 		tt.addMachineType(getMachineType())
 				.addInfo("Controller Block for the Industrial Electrolyzer")
 				.addInfo("180% faster than using single block machines of the same voltage")
-				.addInfo("Only uses 90% of the eu/t normally required")
+				.addInfo("Only uses 90% of the EU/t normally required")
 				.addInfo("Processes two items per voltage tier")
 				.addPollutionAmount(getPollutionPerSecond(null))
 				.addSeparator()

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/GregtechMetaTileEntity_IndustrialFluidHeater.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/GregtechMetaTileEntity_IndustrialFluidHeater.java
@@ -55,7 +55,7 @@ public class GregtechMetaTileEntity_IndustrialFluidHeater extends GregtechMeta_M
 		tt.addMachineType(getMachineType())
 				.addInfo("Controller Block for the Industrial Fluid Heater")
 				.addInfo("120% faster than using single block machines of the same voltage")
-				.addInfo("Only uses 90% of the eu/t normally required")
+				.addInfo("Only uses 90% of the EU/t normally required")
 				.addInfo("Processes eight items per voltage tier")
 				.addPollutionAmount(getPollutionPerSecond(null))
 				.addSeparator()

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/GregtechMetaTileEntity_IndustrialForgeHammer.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/GregtechMetaTileEntity_IndustrialForgeHammer.java
@@ -67,7 +67,7 @@ public class GregtechMetaTileEntity_IndustrialForgeHammer extends GregtechMeta_M
 		GT_Multiblock_Tooltip_Builder tt = new GT_Multiblock_Tooltip_Builder();
 		tt.addMachineType(getMachineType())
 		.addInfo("Controller Block for the Industrial Forge Hammer")
-		.addInfo("Speed: +100% | Eu Usage: 100% | Parallel: Tier x Anvil Tier x 8")
+		.addInfo("Speed: +100% | EU Usage: 100% | Parallel: Tier x Anvil Tier x 8")
 		.addInfo("T1 - Vanilla Anvil")
 		.addInfo("Anvil goes in Middle 3x3x3 Structure");
 		if (LoadedMods.Railcraft) {

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/GregtechMetaTileEntity_IndustrialForgeHammer.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/GregtechMetaTileEntity_IndustrialForgeHammer.java
@@ -67,7 +67,7 @@ public class GregtechMetaTileEntity_IndustrialForgeHammer extends GregtechMeta_M
 		GT_Multiblock_Tooltip_Builder tt = new GT_Multiblock_Tooltip_Builder();
 		tt.addMachineType(getMachineType())
 		.addInfo("Controller Block for the Industrial Forge Hammer")
-		.addInfo("Speed: 100% x Anvil Tier | Eu Usage: 100% | Parallel: Tier x 8")
+		.addInfo("Speed: +100% | Eu Usage: 100% | Parallel: Tier x Anvil Tier x 8")
 		.addInfo("T1 - Vanilla Anvil")
 		.addInfo("Anvil goes in Middle 3x3x3 Structure");
 		if (LoadedMods.Railcraft) {

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/GregtechMetaTileEntity_IndustrialMultiMachine.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/GregtechMetaTileEntity_IndustrialMultiMachine.java
@@ -95,7 +95,7 @@ public class GregtechMetaTileEntity_IndustrialMultiMachine extends GregtechMeta_
 		tt.addMachineType(getMachineType())
 				.addInfo("Controller Block for the Industrial Multi-Machine")
 				.addInfo("250% faster than using single block machines of the same voltage")
-				.addInfo("Only uses 80% of the eu/t normally required")
+				.addInfo("Only uses 80% of the EU/t normally required")
 				.addInfo("Processes two items per voltage tier")
 				.addInfo("Machine Type: [A] - " + EnumChatFormatting.YELLOW + aBuiltStrings[0] + EnumChatFormatting.RESET)
 				.addInfo("Machine Type: [B] - " + EnumChatFormatting.YELLOW + aBuiltStrings[1] + EnumChatFormatting.RESET)

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/GregtechMetaTileEntity_IndustrialSifter.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/GregtechMetaTileEntity_IndustrialSifter.java
@@ -57,7 +57,7 @@ public class GregtechMetaTileEntity_IndustrialSifter extends GregtechMeta_MultiB
 		tt.addMachineType(getMachineType())
 				.addInfo("Controller Block for the Industrial Sifter")
 				.addInfo("400% faster than single-block machines of the same voltage")
-				.addInfo("Only uses 75% of the eu/t normally required")
+				.addInfo("Only uses 75% of the EU/t normally required")
 				.addInfo("Processes four items per voltage tier")
 				.addPollutionAmount(getPollutionPerSecond(null))
 				.addSeparator()

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/GregtechMetaTileEntity_IndustrialThermalCentrifuge.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/GregtechMetaTileEntity_IndustrialThermalCentrifuge.java
@@ -57,7 +57,7 @@ public class GregtechMetaTileEntity_IndustrialThermalCentrifuge extends Gregtech
 		tt.addMachineType(getMachineType())
 				.addInfo("Controller Block for the Industrial Thermal Centrifuge")
 				.addInfo("150% faster than using single block machines of the same voltage")
-				.addInfo("Only uses 80% of the eu/t normally required")
+				.addInfo("Only uses 80% of the EU/t normally required")
 				.addInfo("Processes eight items per voltage tier")
 				.addPollutionAmount(getPollutionPerSecond(null))
 				.addSeparator()

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/GregtechMetaTileEntity_IndustrialVacuumFreezer.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/GregtechMetaTileEntity_IndustrialVacuumFreezer.java
@@ -70,7 +70,7 @@ public class GregtechMetaTileEntity_IndustrialVacuumFreezer extends GregtechMeta
 		GT_Multiblock_Tooltip_Builder tt = new GT_Multiblock_Tooltip_Builder();
 		tt.addMachineType(getMachineType())
 				.addInfo("Factory Grade Advanced Vacuum Freezer")
-				.addInfo("Speed: +100% | Eu Usage: 100% | Parallel: 4")
+				.addInfo("Speed: +100% | EU Usage: 100% | Parallel: 4")
 				.addInfo("Consumes 1L of " + mCryoFuelName + "/t during operation")
 				.addInfo("Constructed exactly the same as a normal Vacuum Freezer")
 				.addPollutionAmount(getPollutionPerSecond(null))

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/GregtechMetaTileEntity_IndustrialVacuumFreezer.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/GregtechMetaTileEntity_IndustrialVacuumFreezer.java
@@ -70,7 +70,7 @@ public class GregtechMetaTileEntity_IndustrialVacuumFreezer extends GregtechMeta
 		GT_Multiblock_Tooltip_Builder tt = new GT_Multiblock_Tooltip_Builder();
 		tt.addMachineType(getMachineType())
 				.addInfo("Factory Grade Advanced Vacuum Freezer")
-				.addInfo("Speed: 200% | Eu Usage: 100% | Parallel: 4")
+				.addInfo("Speed: +100% | Eu Usage: 100% | Parallel: 4")
 				.addInfo("Consumes 1L of " + mCryoFuelName + "/t during operation")
 				.addInfo("Constructed exactly the same as a normal Vacuum Freezer")
 				.addPollutionAmount(getPollutionPerSecond(null))

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/GregtechMetaTileEntity_IndustrialWireMill.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/GregtechMetaTileEntity_IndustrialWireMill.java
@@ -56,7 +56,7 @@ public class GregtechMetaTileEntity_IndustrialWireMill extends GregtechMeta_Mult
 		tt.addMachineType(getMachineType())
 				.addInfo("Controller Block for the Industrial Wire Factory")
 				.addInfo("200% faster than using single block machines of the same voltage")
-				.addInfo("Only uses 75% of the eu/t normally required")
+				.addInfo("Only uses 75% of the EU/t normally required")
 				.addInfo("Processes four items per voltage tier")
 				.addPollutionAmount(getPollutionPerSecond(null))
 				.addSeparator()

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/advanced/GregtechMetaTileEntity_Adv_EBF.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/advanced/GregtechMetaTileEntity_Adv_EBF.java
@@ -78,7 +78,7 @@ public class GregtechMetaTileEntity_Adv_EBF extends GregtechMeta_MultiBlockBase<
 		GT_Multiblock_Tooltip_Builder tt = new GT_Multiblock_Tooltip_Builder();
 		tt.addMachineType(getMachineType())
 		.addInfo("Factory Grade Advanced Blast Furnace")
-		.addInfo("Speed: 120% | Eu Usage: 90% | Parallel: 8")
+		.addInfo("Speed: +120% | Eu Usage: 90% | Parallel: 8")
 		.addInfo("Consumes 10L of " + mHotFuelName + " per second during operation")
 		.addInfo("Constructed exactly the same as a normal EBF")
 		.addPollutionAmount(getPollutionPerSecond(null))

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/advanced/GregtechMetaTileEntity_Adv_EBF.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/advanced/GregtechMetaTileEntity_Adv_EBF.java
@@ -78,7 +78,7 @@ public class GregtechMetaTileEntity_Adv_EBF extends GregtechMeta_MultiBlockBase<
 		GT_Multiblock_Tooltip_Builder tt = new GT_Multiblock_Tooltip_Builder();
 		tt.addMachineType(getMachineType())
 		.addInfo("Factory Grade Advanced Blast Furnace")
-		.addInfo("Speed: +120% | Eu Usage: 90% | Parallel: 8")
+		.addInfo("Speed: +120% | EU Usage: 90% | Parallel: 8")
 		.addInfo("Consumes 10L of " + mHotFuelName + " per second during operation")
 		.addInfo("Constructed exactly the same as a normal EBF")
 		.addPollutionAmount(getPollutionPerSecond(null))

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/advanced/GregtechMetaTileEntity_Adv_Implosion.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/advanced/GregtechMetaTileEntity_Adv_Implosion.java
@@ -45,7 +45,7 @@ public class GregtechMetaTileEntity_Adv_Implosion extends GregtechMeta_MultiBloc
 		GT_Multiblock_Tooltip_Builder tt = new GT_Multiblock_Tooltip_Builder();
 		tt.addMachineType(getMachineType())
 				.addInfo("Factory Grade Advanced Implosion Compressor")
-				.addInfo("Speed: 100% | Eu Usage: 100% | Parallel: ((Tier/2)+1)")
+				.addInfo("Speed: +100% | Eu Usage: 100% | Parallel: ((Tier/2)+1)")
 				.addInfo("Constructed exactly the same as a normal Implosion Compressor")
 				.addPollutionAmount(getPollutionPerSecond(null))
 				.addSeparator()

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/advanced/GregtechMetaTileEntity_Adv_Implosion.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/advanced/GregtechMetaTileEntity_Adv_Implosion.java
@@ -45,7 +45,7 @@ public class GregtechMetaTileEntity_Adv_Implosion extends GregtechMeta_MultiBloc
 		GT_Multiblock_Tooltip_Builder tt = new GT_Multiblock_Tooltip_Builder();
 		tt.addMachineType(getMachineType())
 				.addInfo("Factory Grade Advanced Implosion Compressor")
-				.addInfo("Speed: +100% | Eu Usage: 100% | Parallel: ((Tier/2)+1)")
+				.addInfo("Speed: +100% | EU Usage: 100% | Parallel: ((Tier/2)+1)")
 				.addInfo("Constructed exactly the same as a normal Implosion Compressor")
 				.addPollutionAmount(getPollutionPerSecond(null))
 				.addSeparator()

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/GregtechMTE_ElementalDuplicator.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/GregtechMTE_ElementalDuplicator.java
@@ -71,7 +71,7 @@ public class GregtechMTE_ElementalDuplicator extends GregtechMeta_MultiBlockBase
 		GT_Multiblock_Tooltip_Builder tt = new GT_Multiblock_Tooltip_Builder();
 		tt.addMachineType(getMachineType())
 		.addInfo("Produces Elemental Material from UU Matter")
-		.addInfo("Speed: +100% | Eu Usage: 100% | Parallel: 8 * Tier")
+		.addInfo("Speed: +100% | EU Usage: 100% | Parallel: 8 * Tier")
 		.addInfo("Maximum 1x of each bus/hatch.")
 		.addInfo("Does not require both Output Hatch & Bus")
 		.addPollutionAmount(getPollutionPerSecond(null))

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/GregtechMTE_ElementalDuplicator.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/GregtechMTE_ElementalDuplicator.java
@@ -71,7 +71,7 @@ public class GregtechMTE_ElementalDuplicator extends GregtechMeta_MultiBlockBase
 		GT_Multiblock_Tooltip_Builder tt = new GT_Multiblock_Tooltip_Builder();
 		tt.addMachineType(getMachineType())
 		.addInfo("Produces Elemental Material from UU Matter")
-		.addInfo("Speed: 100% | Eu Usage: 100% | Parallel: 8 * Tier")
+		.addInfo("Speed: +100% | Eu Usage: 100% | Parallel: 8 * Tier")
 		.addInfo("Maximum 1x of each bus/hatch.")
 		.addInfo("Does not require both Output Hatch & Bus")
 		.addPollutionAmount(getPollutionPerSecond(null))

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/GregtechMetaTileEntity_IndustrialRockBreaker.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/GregtechMetaTileEntity_IndustrialRockBreaker.java
@@ -70,7 +70,7 @@ public class GregtechMetaTileEntity_IndustrialRockBreaker extends GregtechMeta_M
 		GT_Multiblock_Tooltip_Builder tt = new GT_Multiblock_Tooltip_Builder();
 		tt.addMachineType(getMachineType())
 		.addInfo("Controller Block for the Industrial Rock Breaker")
-		.addInfo("Speed: 200% | Eu Usage: 75% | Parallel: Tier x 8")
+		.addInfo("Speed: +200% | Eu Usage: 75% | Parallel: Tier x 8")
 		.addInfo("Circuit goes in the GUI slot")
 		.addInfo("1 = cobble, 2 = stone, 3 = obsidian")
 		.addInfo("Supply Water/Lava")

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/GregtechMetaTileEntity_IndustrialRockBreaker.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/GregtechMetaTileEntity_IndustrialRockBreaker.java
@@ -70,7 +70,7 @@ public class GregtechMetaTileEntity_IndustrialRockBreaker extends GregtechMeta_M
 		GT_Multiblock_Tooltip_Builder tt = new GT_Multiblock_Tooltip_Builder();
 		tt.addMachineType(getMachineType())
 		.addInfo("Controller Block for the Industrial Rock Breaker")
-		.addInfo("Speed: +200% | Eu Usage: 75% | Parallel: Tier x 8")
+		.addInfo("Speed: +200% | EU Usage: 75% | Parallel: Tier x 8")
 		.addInfo("Circuit goes in the GUI slot")
 		.addInfo("1 = cobble, 2 = stone, 3 = obsidian")
 		.addInfo("Supply Water/Lava")

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/GregtechMetaTileEntity_MassFabricator.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/GregtechMetaTileEntity_MassFabricator.java
@@ -100,7 +100,7 @@ public class GregtechMetaTileEntity_MassFabricator extends GregtechMeta_MultiBlo
 		GT_Multiblock_Tooltip_Builder tt = new GT_Multiblock_Tooltip_Builder();
 		tt.addMachineType(getMachineType())
 				.addInfo("Controller Block for the Matter Fabricator")
-				.addInfo("Speed: +0% | Eu Usage: 80%")
+				.addInfo("Speed: +0% | EU Usage: 80%")
 				.addInfo("Parallel: Scrap = 64 | UU = 8 * Tier")
 				.addInfo("Produces UU-A, UU-M & Scrap")
 				.addInfo("Change mode with screwdriver")

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/GregtechMetaTileEntity_MassFabricator.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/GregtechMetaTileEntity_MassFabricator.java
@@ -100,7 +100,7 @@ public class GregtechMetaTileEntity_MassFabricator extends GregtechMeta_MultiBlo
 		GT_Multiblock_Tooltip_Builder tt = new GT_Multiblock_Tooltip_Builder();
 		tt.addMachineType(getMachineType())
 				.addInfo("Controller Block for the Matter Fabricator")
-				.addInfo("Speed: 100% | Eu Usage: 80%")
+				.addInfo("Speed: +0% | Eu Usage: 80%")
 				.addInfo("Parallel: Scrap = 64 | UU = 8 * Tier")
 				.addInfo("Produces UU-A, UU-M & Scrap")
 				.addInfo("Change mode with screwdriver")


### PR DESCRIPTION
The descriptions "speed: x%" in GT++ multis' tooltips have different meanings and some of them are wrong.

- For cryogenic freezer and matter fabrication CPU, x% is the speed ratio of GT++ multis to corresponding GT machines.
- For other multis, x% is how much they are faster than corresponding single block machines or GT multis.
- The tooltip of industrial sledgehammer is wrong. It actually runs 100% faster than single block forge hammers, and can do 8*AnvilTier*Tier parallel.
- Amazon warehousing depot actually runs 500% faster than single block packagers, which is not clearly mentioned in tooltip.

This pull request intends to:

1. modify the "speed: x%" in GT++ multis' tooltips to "speed: +x%", making it easier to understand
2. fix industrial sledgehammer's tooltip
3. update amazon warehousing depot's tooltip