### PR TITLE
Make Mutated Living Solder divisible by 144

### DIFF
--- a/src/main/java/gtPlusPlus/core/item/chemistry/GenericChem.java
+++ b/src/main/java/gtPlusPlus/core/item/chemistry/GenericChem.java
@@ -504,7 +504,7 @@ public class GenericChem extends ItemPackage {
 
 				},
 				new FluidStack[] {
-						MISC_MATERIALS.MUTATED_LIVING_SOLDER.getFluidStack(40000)
+						MISC_MATERIALS.MUTATED_LIVING_SOLDER.getFluidStack(144 * 280)
 				},
 				20*800,
 				3842160,


### PR DESCRIPTION
All recipes use multiple of 144, why not