### PR TITLE
Fixes EU discount typo in Adv_DistillationTower

### DIFF
--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/advanced/GregtechMetaTileEntity_Adv_DistillationTower.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/advanced/GregtechMetaTileEntity_Adv_DistillationTower.java
@@ -426,7 +426,7 @@ public class GregtechMetaTileEntity_Adv_DistillationTower
 
     @Override
     public int getEuDiscountForParallelism() {
-        return 15;
+        return 85;
     }
 
     private int getTierOfTower() {


### PR DESCRIPTION
This function is used in:

```java
    @Override
    public boolean checkRecipe(final ItemStack aStack) {
        // Run standard recipe handling for distillery recipes
        if (mMode == Mode.Distillery) {
            return this.checkRecipeGeneric(getMaxParallelRecipes(), getEuDiscountForParallelism(), 100);
        }
// ...
```

According to the tooltip of this machine, it should have a discount of 85% instead of 15%. I tried one EV single-block distillery recipe in GTNH 2.1.2.4.29-pre, it was indeed operating with too much parallelism...