### PR TITLE
Bugfixes and Speed Increases for the LFTR Chain

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,4 @@
-//version: 1661114848
+//version: 1662920829
 /*
  DO NOT CHANGE THIS FILE!
  Also, you may replace this file at any time if there is an update available.
@@ -8,6 +8,10 @@
 
 import com.github.jengelman.gradle.plugins.shadow.tasks.ConfigureShadowRelocation
 import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
+import com.matthewprenger.cursegradle.CurseArtifact
+import com.matthewprenger.cursegradle.CurseRelation
+import com.modrinth.minotaur.dependencies.ModDependency
+import com.modrinth.minotaur.dependencies.VersionDependency
 import org.gradle.internal.logging.text.StyledTextOutput.Style
 import org.gradle.internal.logging.text.StyledTextOutputFactory
 
@@ -59,6 +63,8 @@ plugins {
     id 'de.undercouch.download' version '5.0.1'
     id 'com.github.gmazzo.buildconfig' version '3.0.3' apply false
     id 'com.diffplug.spotless' version '6.7.2' apply false
+    id 'com.modrinth.minotaur' version '2.+' apply false
+    id 'com.matthewprenger.cursegradle' version '1.4.0' apply false
 }
 boolean settingsupdated = verifySettingsGradle()
 settingsupdated = verifyGitAttributes() || settingsupdated
@@ -127,11 +133,16 @@ checkPropertyExists("containsMixinsAndOrCoreModOnly")
 checkPropertyExists("usesShadowedDependencies")
 checkPropertyExists("developmentEnvironmentUserName")
 
-boolean noPublishedSources = project.hasProperty("noPublishedSources") ? project.noPublishedSources.toBoolean() : false
-boolean usesMixinDebug = project.hasProperty('usesMixinDebug') ?: project.usesMixins.toBoolean()
-boolean forceEnableMixins = project.hasProperty('forceEnableMixins') ? project.forceEnableMixins.toBoolean() : false
-String channel = project.hasProperty('channel') ? project.channel : 'stable'
-String mappingsVersion = project.hasProperty('mappingsVersion') ? project.mappingsVersion : '12'
+propertyDefaultIfUnset("noPublishedSources", false)
+propertyDefaultIfUnset("usesMixinDebug", project.usesMixins)
+propertyDefaultIfUnset("forceEnableMixins", false)
+propertyDefaultIfUnset("channel", "stable")
+propertyDefaultIfUnset("mappingsVersion", "12")
+propertyDefaultIfUnset("modrinthProjectId", "")
+propertyDefaultIfUnset("modrinthRelations", "")
+propertyDefaultIfUnset("curseForgeProjectId", "")
+propertyDefaultIfUnset("curseForgeRelations", "")
+
 String javaSourceDir = "src/main/java/"
 String scalaSourceDir = "src/main/scala/"
 String kotlinSourceDir = "src/main/kotlin/"
@@ -651,6 +662,107 @@ publishing {
     }
 }
 
+if (modrinthProjectId.size() != 0) {
+    apply plugin: 'com.modrinth.minotaur'
+
+    File changelogFile = new File("CHANGELOG.md")
+
+    modrinth {
+        token = System.getenv("MODRINTH_TOKEN")
+        projectId = modrinthProjectId
+        versionNumber = identifiedVersion
+        versionType = identifiedVersion.endsWith("-pre") ? "beta" : "release"
+        changelog = changelogFile.exists() ? changelogFile.getText("UTF-8") : ""
+        uploadFile = jar
+        additionalFiles = getSecondaryArtifacts()
+        gameVersions = [minecraftVersion]
+        loaders = ["forge"]
+        debugMode = false
+    }
+
+    if (modrinthRelations.size() != 0) {
+        String[] deps = modrinthRelations.split(";")
+        deps.each { dep ->
+            if (dep.size() == 0) {
+                return
+            }
+            String[] parts = dep.split(":")
+            String[] qual = parts[0].split("-")
+            addModrinthDep(qual[0], qual[1], parts[1])
+        }
+    }
+    tasks.modrinth.dependsOn(build)
+    tasks.publish.dependsOn(tasks.modrinth)
+}
+
+if (curseForgeProjectId.size() != 0) {
+    apply plugin: 'com.matthewprenger.cursegradle'
+
+    File changelogFile = new File("CHANGELOG.md")
+
+    curseforge {
+        apiKey = System.getenv("CURSEFORGE_TOKEN")
+        project {
+            id = curseForgeProjectId
+            if (changelogFile.exists()) {
+                changelogType = "markdown"
+                changelog = changelogFile
+            }
+            releaseType = identifiedVersion.endsWith("-pre") ? "beta" : "release"
+            addGameVersion minecraftVersion
+            addGameVersion "Forge"
+            mainArtifact jar
+            for (artifact in getSecondaryArtifacts()) addArtifact artifact
+        }
+
+        options {
+            javaIntegration = false
+            forgeGradleIntegration = false
+            debug = false
+        }
+    }
+
+    if (curseForgeRelations.size() != 0) {
+        String[] deps = curseForgeRelations.split(";")
+        deps.each { dep ->
+            if (dep.size() == 0) {
+                return
+            }
+            String[] parts = dep.split(":")
+            addCurseForgeRelation(parts[0], parts[1])
+        }
+    }
+    tasks.curseforge.dependsOn(build)
+    tasks.publish.dependsOn(tasks.curseforge)
+}
+
+def addModrinthDep(scope, type, name) {
+    com.modrinth.minotaur.dependencies.Dependency dep;
+    if (!(scope in ["required", "optional", "incompatible", "embedded"])) {
+        throw new Exception("Invalid modrinth dependency scope: " + scope)
+    }
+    switch (type) {
+        case "project":
+            dep = new ModDependency(name, scope)
+            break
+        case "version":
+            dep = new VersionDependency(name, scope)
+            break
+        default:
+            throw new Exception("Invalid modrinth dependency type: " + type)
+    }
+    project.modrinth.dependencies.add(dep)
+}
+
+def addCurseForgeRelation(type, name) {
+    if (!(type in ["requiredDependency", "embeddedLibrary", "optionalDependency", "tool", "incompatible"])) {
+        throw new Exception("Invalid CurseForge relation type: " + type)
+    }
+    CurseArtifact artifact = project.curseforge.curseProjects[0].mainArtifact
+    CurseRelation rel = (artifact.curseRelations ?: (artifact.curseRelations = new CurseRelation()))
+    rel."$type"(name)
+}
+
 // Updating
 task updateBuildScript {
     doLast {
@@ -963,6 +1075,21 @@ def checkPropertyExists(String propertyName) {
     }
 }
 
+def propertyDefaultIfUnset(String propertyName, defaultValue) {
+    if (!project.hasProperty(propertyName) || project.property(propertyName) == "") {
+        project.ext.setProperty(propertyName, defaultValue)
+    }
+}
+
 def getFile(String relativePath) {
     return new File(projectDir, relativePath)
+}
+
+def getSecondaryArtifacts() {
+    // Because noPublishedSources from the beginning of the script is somehow not visible here...
+    boolean noPublishedSources = project.hasProperty("noPublishedSources") ? project.noPublishedSources.toBoolean() : false
+    def secondaryArtifacts = [devJar]
+    if (!noPublishedSources) secondaryArtifacts += [sourcesJar]
+    if (apiPackage) secondaryArtifacts += [apiJar]
+    return secondaryArtifacts
 }

--- a/src/main/java/gregtech/api/util/GasSpargingRecipe.java
+++ b/src/main/java/gregtech/api/util/GasSpargingRecipe.java
@@ -31,8 +31,8 @@ public class GasSpargingRecipe implements Comparable<GasSpargingRecipe> {
         aOutputs = ArrayUtils.insertElementAtIndex(aOutputs, 1, aSpargedFuel);
         mFluidOutputs = aOutputs;
         mMaxOutputQuantity = aMaxOutputQuantity;
-        mDuration = 20 * 60 * 5;
-        mEUt = MaterialUtils.getVoltageForTier(3);
+        mDuration = 500 * 10; // Actual recipe time is 10x less than this number, not sure why
+        mEUt = MaterialUtils.getVoltageForTier(5);
     }
 
     @Override

--- a/src/main/java/gtPlusPlus/core/item/ModItems.java
+++ b/src/main/java/gtPlusPlus/core/item/ModItems.java
@@ -582,7 +582,7 @@ public final class ModItems {
             // MaterialGenerator.generate(MISC_MATERIALS.AMMONIUM); //LFTR fuel component
             MaterialGenerator.generateNuclearDusts(FLUORIDES.AMMONIUM_BIFLUORIDE); // LFTR fuel component
             MaterialGenerator.generateNuclearDusts(FLUORIDES.BERYLLIUM_HYDROXIDE); // LFTR fuel component
-            MaterialGenerator.generateNuclearDusts(FLUORIDES.AMMONIUM_TETRAFLUOROBERYLLATE); // LFTR fuel component
+            // MaterialGenerator.generateNuclearDusts(FLUORIDES.AMMONIUM_TETRAFLUOROBERYLLATE); // LFTR fuel component
 
             // Generate Fluorides
             MaterialGenerator.generateNuclearDusts(FLUORIDES.BERYLLIUM_FLUORIDE);

--- a/src/main/java/gtPlusPlus/core/item/general/ItemHealingDevice.java
+++ b/src/main/java/gtPlusPlus/core/item/general/ItemHealingDevice.java
@@ -58,7 +58,7 @@ public class ItemHealingDevice extends Item implements IElectricItem, IElectricI
 
     @Override
     public boolean canProvideEnergy(final ItemStack itemStack) {
-        return false;
+        return true;
     }
 
     @Override
@@ -179,10 +179,6 @@ public class ItemHealingDevice extends Item implements IElectricItem, IElectricI
             final boolean ignoreTransferLimit,
             final boolean externally,
             final boolean simulate) {
-        if (!simulate) {
-            ElectricItem.manager.discharge(stack, amount, tier, ignoreTransferLimit, externally, simulate);
-        }
-
         return ElectricItem.manager.discharge(stack, amount, tier, ignoreTransferLimit, externally, simulate);
     }
 
@@ -306,11 +302,13 @@ public class ItemHealingDevice extends Item implements IElectricItem, IElectricI
                 if (aFood != null) {
                     // Hunger Check
                     hunger = 20 - aFood.getFoodLevel();
-                    this.discharge(aBaubleStack, (1638400) * hunger, 6, true, true, false);
                     // Saturation Check
-                    saturation = 20f - aFood.getSaturationLevel();
-                    this.discharge(aBaubleStack, (1638400) * saturation, 6, true, true, false);
-                    aFood.addStats(hunger, saturation);
+                    if (hunger > 0) {
+                        saturation = 20f - aFood.getSaturationLevel();
+                        saturation /= hunger * 2f;
+                        this.discharge(aBaubleStack, (1638400) * (hunger + saturation), 6, true, true, false);
+                        aFood.addStats(hunger, saturation);
+                    }
                 }
 
                 // Only show Messages if they're enabled.

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/GregtechMTE_NuclearReactor.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/GregtechMTE_NuclearReactor.java
@@ -75,10 +75,10 @@ public class GregtechMTE_NuclearReactor extends GregtechMeta_MultiBlockBase<Greg
         tt.addMachineType(getMachineType())
                 .addInfo("Controller Block for the Liquid Fluoride Thorium Reactor.")
                 .addInfo("Produces Heat & Energy from Radioactive Beta Decay.")
-                .addInfo("Outputs U233 every 10 seconds, on average")
-                .addInfo("Input Fluorine and Helium for bonus byproducts")
-                .addInfo("Input Li2BeF4 and a molten salt as fuel.")
-                .addInfo("LiFBeF2ThF4UF4, LiFBeF2ZrF4UF4 or LiFBeF2ZrF4U235")
+                .addInfo("Input Li2BeF4 and a molten salt as fuel, and match the 4 Dynamo Hatches:")
+                .addInfo("LFTR Fuel 1 (4 IV amps), LFTR Fuel 2 (4 LuV amps), LFTR Fuel 3 (4 ZPM amps)")
+                .addInfo("Outputs U233 every 10 seconds, on average, while the reactor is running")
+                .addInfo("Check NEI to see the other outputs - they differ between fuels")
                 .addPollutionAmount(getPollutionPerSecond(null))
                 .addSeparator()
                 .beginStructureBlock(7, 4, 7, true)
@@ -90,7 +90,7 @@ public class GregtechMTE_NuclearReactor extends GregtechMeta_MultiBlockBase<Greg
                 .addDynamoHatch("Top or bottom layer edges", 1)
                 .addMaintenanceHatch("Top or bottom layer edges", 1)
                 .addMufflerHatch("Top 3x3", 2)
-                .addStructureInfo("All dynamos must be IV or LuV tier.")
+                .addStructureInfo("All dynamos must be between EV and LuV tier.")
                 .addStructureInfo("All other hatches must be IV+ tier.")
                 .addStructureInfo("3x Output Hatches, 2x Input Hatches, 4x Dynamo Hatches")
                 .addStructureInfo("2x Maintenance Hatches, 4x Mufflers")
@@ -190,7 +190,7 @@ public class GregtechMTE_NuclearReactor extends GregtechMeta_MultiBlockBase<Greg
             if (aMetaTileEntity instanceof GT_MetaTileEntity_Hatch_Maintenance) {
                 return addToMachineList(aTileEntity, aBaseCasingIndex);
             } else if (aMetaTileEntity instanceof GT_MetaTileEntity_Hatch_Dynamo
-                    && (((GT_MetaTileEntity_Hatch_Dynamo) aMetaTileEntity).mTier >= 5
+                    && (((GT_MetaTileEntity_Hatch_Dynamo) aMetaTileEntity).mTier >= 4
                             && ((GT_MetaTileEntity_Hatch_Dynamo) aMetaTileEntity).mTier <= 6)) {
                 return addToMachineList(aTileEntity, aBaseCasingIndex);
             } else if (aMetaTileEntity instanceof GT_MetaTileEntity_Hatch_Input
@@ -245,7 +245,7 @@ public class GregtechMTE_NuclearReactor extends GregtechMeta_MultiBlockBase<Greg
                                     buildHatchAdder(GregtechMTE_NuclearReactor.class)
                                             .atLeast(Dynamo)
                                             .adder(GregtechMTE_NuclearReactor::addNuclearReactorEdgeList)
-                                            .hatchItemFilterAnd(t -> filterByMTETier(5, 6))
+                                            .hatchItemFilterAnd(t -> filterByMTETier(4, 6))
                                             .casingIndex(TAE.GTPP_INDEX(12))
                                             .dot(1)
                                             .build(),

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/GregtechMetaTileEntity_Refinery.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/GregtechMetaTileEntity_Refinery.java
@@ -66,7 +66,7 @@ public class GregtechMetaTileEntity_Refinery extends GregtechMeta_MultiBlockBase
                 .addMufflerHatch("Base platform", 1)
                 .addMaintenanceHatch("Base platform", 1)
                 .addEnergyHatch("Base platform", 1)
-                .addStructureInfo("Muffler's Tier must be LuV+")
+                .addStructureInfo("Muffler's Tier must be IV+")
                 .addStructureInfo("4x Input Hatches, 2x Output Hatches, 1x Output Bus")
                 .addStructureInfo("1x Muffler, 1x Maintenance Hatch, 1x Energy Hatch")
                 .toolTipFinisher(CORE.GT_Tooltip_Builder);
@@ -131,7 +131,7 @@ public class GregtechMetaTileEntity_Refinery extends GregtechMeta_MultiBlockBase
         } else {
             IMetaTileEntity aMetaTileEntity = aTileEntity.getMetaTileEntity();
             if (aMetaTileEntity instanceof GT_MetaTileEntity_Hatch_Muffler
-                    && ((GT_MetaTileEntity_Hatch_Muffler) aMetaTileEntity).mTier >= 6) {
+                    && ((GT_MetaTileEntity_Hatch_Muffler) aMetaTileEntity).mTier >= 5) {
                 return addToMachineList(aTileEntity, aBaseCasingIndex);
             }
         }

--- a/src/main/java/gtPlusPlus/xmod/gregtech/loaders/recipe/RecipeLoader_LFTR.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/loaders/recipe/RecipeLoader_LFTR.java
@@ -89,7 +89,7 @@ public class RecipeLoader_LFTR {
                 },
                 100 * 20, // time
                 0, // cost
-                8192 * 4// fuel value
+                8192 * 4 // fuel value
                 );
 
         // LiFBeF2ZrF4U235 - T1

--- a/src/main/java/gtPlusPlus/xmod/gregtech/loaders/recipe/RecipeLoader_LFTR.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/loaders/recipe/RecipeLoader_LFTR.java
@@ -68,9 +68,9 @@ public class RecipeLoader_LFTR {
                     FLUORIDES.URANIUM_HEXAFLUORIDE.getFluidStack(20),
                     FLUORIDES.URANIUM_HEXAFLUORIDE.getFluidStack(10)
                 },
-                400 * 20, // time
+                100 * 20, // time
                 0, // cost
-                8192 * 4 // fuel value
+                32768 * 4 // fuel value
                 );
 
         // LiFBeF2ZrF4UF4 - T2
@@ -87,9 +87,9 @@ public class RecipeLoader_LFTR {
                     FLUORIDES.URANIUM_HEXAFLUORIDE.getFluidStack(10),
                     FLUORIDES.URANIUM_HEXAFLUORIDE.getFluidStack(5)
                 },
-                400 * 20, // time
+                100 * 20, // time
                 0, // cost
-                8192 // fuel value
+                8192 * 4// fuel value
                 );
 
         // LiFBeF2ZrF4U235 - T1
@@ -113,7 +113,7 @@ public class RecipeLoader_LFTR {
 
         // Sparging NEI Recipes
         GasSpargingRecipeMap.addRecipe(
-                new FluidStack(mSpargeGases.get(0), 50),
+                new FluidStack(mSpargeGases.get(0), 1000),
                 NUCLIDE.LiFBeF2UF4FP.getFluidStack(50),
                 NUCLIDE.Sparged_LiFBeF2UF4FP.getFluidStack(50),
                 new FluidStack[] {
@@ -123,10 +123,10 @@ public class RecipeLoader_LFTR {
                     new FluidStack(mNobleGases.get(4), 10),
                     new FluidStack(mNobleGases.get(5), 10)
                 },
-                new int[] {1000, 1000, 1000, 1000, 1000});
+                new int[] {20000, 20000, 20000, 20000, 20000});
 
         GasSpargingRecipeMap.addRecipe(
-                new FluidStack(mSpargeGases.get(1), 50),
+                new FluidStack(mSpargeGases.get(1), 100),
                 NUCLIDE.LiFThF4.getFluidStack(50),
                 NUCLIDE.Sparged_LiFThF4.getFluidStack(50),
                 new FluidStack[] {
@@ -136,10 +136,10 @@ public class RecipeLoader_LFTR {
                     new FluidStack(mFluorideGases.get(4), 5),
                     new FluidStack(mFluorideGases.get(5), 5)
                 },
-                new int[] {500, 500, 500, 500, 500});
+                new int[] {1000, 1000, 1000, 1000, 1000});
 
         GasSpargingRecipeMap.addRecipe(
-                new FluidStack(mSpargeGases.get(1), 50),
+                new FluidStack(mSpargeGases.get(1), 100),
                 NUCLIDE.LiFBeF2ThF4.getFluidStack(50),
                 NUCLIDE.Sparged_LiFBeF2ThF4.getFluidStack(50),
                 new FluidStack[] {
@@ -149,6 +149,6 @@ public class RecipeLoader_LFTR {
                     new FluidStack(mFluorideGases.get(4), 10),
                     new FluidStack(mFluorideGases.get(5), 10)
                 },
-                new int[] {1000, 1000, 1000, 1000, 1000});
+                new int[] {2000, 2000, 2000, 2000, 2000});
     }
 }

--- a/src/main/java/gtPlusPlus/xmod/gregtech/loaders/recipe/RecipeLoader_NuclearFuelProcessing.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/loaders/recipe/RecipeLoader_NuclearFuelProcessing.java
@@ -240,8 +240,8 @@ public class RecipeLoader_NuclearFuelProcessing {
                 FluidUtils.getFluidStack(NuclearChem.Impure_LiFBeF2, 1000),
                 new FluidStack[] {NUCLIDE.LiFBeF2.getFluidStack(250)},
                 null,
-                120 * 60 * 20,
-                MaterialUtils.getVoltageForTier(3));
+                450 * 20,
+                MaterialUtils.getVoltageForTier(5));
 
         // UF6 -> UF4 reduction
         // UF6 + LiFBeF2 + H2 -> LiFBeF2UF4 + HF
@@ -251,9 +251,9 @@ public class RecipeLoader_NuclearFuelProcessing {
                 new ItemStack[] {ItemUtils.getItemStackOfAmountFromOreDict("cellHydrofluoricAcid", 2), CI.emptyCells(1)
                 },
                 new FluidStack[] {NUCLIDE.LiFBeF2UF4.getFluidStack(3000)},
-                20 * 60 * 10,
-                MaterialUtils.getVoltageForTier(4),
-                6500);
+                300 * 10,
+                MaterialUtils.getVoltageForTier(5),
+                5400);
 
         // LiFBeF2ZrF4U235 - We can't add both ZrF4 and U235 here, so best we leave this disabled.
         /*CORE.RA.addReactorProcessingUnitRecipe(


### PR DESCRIPTION
- Changed a few restrictions to allow this chain to be doable in IV, as intended;
- Changed the EU/t of the 3 fuels to match the usage of 4 buffered dynamos, and reduced the burning time to keep the total energy per L the same;
- Lowered the recipe time of some recipes done in multiblocks;
- Other tooltip and bug fixes.

Some bugs that this chain had should now be fixed. Additionally, the EU/t of the LFTR was significantly increased, as it was designed before buffered hatches were a thing, and as such one of these expensive 7x7 multis would output exactly as much as a single turbine multi with a buffered IV hatch. With this change, Fuel 1 equates to 4 buffered EVs, Fuel 2 to 4 buffered IVs and Fuel 3 to 4 buffered LuVs. This also adds another factor of progression to the chain, as upgrading 4 dynamos is expensive when early in the tier.

The other balance change was in the noble gas output from sparging with Helium, which has increased significantly. Now, Helium can be converted to 5 other, better noble gases (up to Xenon) at a rate of around 100L per 25s for every gas. This is a lot slower than gas siphons on other planets, but it's available earlier and consumes a lot less EU, especially compared to the Xenon siphoning.
