### PR TITLE
Rocketdyne Structure Fix and Cost Reduction

### DIFF
--- a/src/main/java/gtPlusPlus/xmod/gregtech/api/metatileentity/implementations/base/GregtechMeta_MultiBlockBase.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/api/metatileentity/implementations/base/GregtechMeta_MultiBlockBase.java
@@ -1898,7 +1898,7 @@ public abstract class GregtechMeta_MultiBlockBase<T extends GT_MetaTileEntity_En
 
     public boolean addAirIntakeToMachineList(final IGregTechTileEntity aMetaTileEntity, final int aBaseCasingIndex) {
         if (aMetaTileEntity instanceof GT_MetaTileEntity_Hatch_AirIntake) {
-            return addToMachineList(aMetaTileEntity, aBaseCasingIndex);
+            return addToMachineListInternal(mAirIntakes, aMetaTileEntity, aBaseCasingIndex);
         }
         return false;
     }

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/GregtechMetaTileEntity_LargeRocketEngine.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/GregtechMetaTileEntity_LargeRocketEngine.java
@@ -1,9 +1,10 @@
 package gtPlusPlus.xmod.gregtech.common.tileentities.machines.multi.production;
 
-import static com.gtnewhorizon.structurelib.structure.StructureUtility.*;
+import static com.gtnewhorizon.structurelib.structure.StructureUtility.ofBlock;
+import static com.gtnewhorizon.structurelib.structure.StructureUtility.onElementPass;
+import static com.gtnewhorizon.structurelib.structure.StructureUtility.transpose;
 import static gregtech.api.enums.GT_HatchElement.*;
 import static gregtech.api.util.GT_StructureUtility.buildHatchAdder;
-import static gregtech.api.util.GT_StructureUtility.ofHatchAdder;
 import static gtPlusPlus.xmod.gregtech.api.metatileentity.implementations.base.GregtechMeta_MultiBlockBase.GTPPHatchElement.AirIntake;
 import static gtPlusPlus.xmod.gregtech.api.metatileentity.implementations.base.GregtechMeta_MultiBlockBase.GTPPHatchElement.TTDynamo;
 
@@ -18,9 +19,6 @@ import gregtech.api.interfaces.IIconContainer;
 import gregtech.api.interfaces.metatileentity.IMetaTileEntity;
 import gregtech.api.interfaces.tileentity.IGregTechTileEntity;
 import gregtech.api.metatileentity.implementations.GT_MetaTileEntity_Hatch;
-import gregtech.api.metatileentity.implementations.GT_MetaTileEntity_Hatch_Input;
-import gregtech.api.metatileentity.implementations.GT_MetaTileEntity_Hatch_InputBus;
-import gregtech.api.metatileentity.implementations.GT_MetaTileEntity_Hatch_Maintenance;
 import gregtech.api.util.GTPP_Recipe;
 import gregtech.api.util.GT_Multiblock_Tooltip_Builder;
 import gregtech.api.util.GT_Recipe;
@@ -131,12 +129,12 @@ public class GregtechMetaTileEntity_LargeRocketEngine
                     // side
                     .addElement(
                             'S',
-                            ofChain(
-                                    ofHatchAdder(
-                                            GregtechMetaTileEntity_LargeRocketEngine::addLargeRocketEngineSideList,
-                                            getCasingTextureIndex(),
-                                            1),
-                                    onElementPass(x -> ++x.mCasing, ofBlock(getCasingBlock(), getCasingMeta()))))
+                            buildHatchAdder(GregtechMetaTileEntity_LargeRocketEngine.class)
+                                    .atLeast(ImmutableMap.of(InputBus, 1, InputHatch, 3, Maintenance, 1, AirIntake, 8))
+                                    .casingIndex(getCasingTextureIndex())
+                                    .dot(1)
+                                    .buildAndChain(onElementPass(
+                                            x -> ++x.mCasing, ofBlock(getCasingBlock(), getCasingMeta()))))
                     // top
                     .addElement(
                             'T',
@@ -150,24 +148,6 @@ public class GregtechMetaTileEntity_LargeRocketEngine
                     .build();
         }
         return this.STRUCTURE_DEFINITION;
-    }
-
-    public final boolean addLargeRocketEngineSideList(IGregTechTileEntity aTileEntity, int aBaseCasingIndex) {
-        if (aTileEntity == null) {
-            return false;
-        } else {
-            IMetaTileEntity aMetaTileEntity = aTileEntity.getMetaTileEntity();
-            if (aMetaTileEntity instanceof GT_MetaTileEntity_Hatch_Maintenance) {
-                return addToMachineList(aTileEntity, aBaseCasingIndex);
-            } else if (aMetaTileEntity instanceof GT_MetaTileEntity_Hatch_AirIntake) {
-                return addToMachineList(aTileEntity, aBaseCasingIndex);
-            } else if (aMetaTileEntity instanceof GT_MetaTileEntity_Hatch_Input) {
-                return addToMachineList(aTileEntity, aBaseCasingIndex);
-            } else if (aMetaTileEntity instanceof GT_MetaTileEntity_Hatch_InputBus) {
-                return addToMachineList(aTileEntity, aBaseCasingIndex);
-            }
-        }
-        return false;
     }
 
     @Override

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/GregtechMetaTileEntity_LargeRocketEngine.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/GregtechMetaTileEntity_LargeRocketEngine.java
@@ -1,10 +1,9 @@
 package gtPlusPlus.xmod.gregtech.common.tileentities.machines.multi.production;
 
-import static com.gtnewhorizon.structurelib.structure.StructureUtility.ofBlock;
-import static com.gtnewhorizon.structurelib.structure.StructureUtility.onElementPass;
-import static com.gtnewhorizon.structurelib.structure.StructureUtility.transpose;
+import static com.gtnewhorizon.structurelib.structure.StructureUtility.*;
 import static gregtech.api.enums.GT_HatchElement.*;
 import static gregtech.api.util.GT_StructureUtility.buildHatchAdder;
+import static gregtech.api.util.GT_StructureUtility.ofHatchAdder;
 import static gtPlusPlus.xmod.gregtech.api.metatileentity.implementations.base.GregtechMeta_MultiBlockBase.GTPPHatchElement.AirIntake;
 import static gtPlusPlus.xmod.gregtech.api.metatileentity.implementations.base.GregtechMeta_MultiBlockBase.GTPPHatchElement.TTDynamo;
 
@@ -19,6 +18,9 @@ import gregtech.api.interfaces.IIconContainer;
 import gregtech.api.interfaces.metatileentity.IMetaTileEntity;
 import gregtech.api.interfaces.tileentity.IGregTechTileEntity;
 import gregtech.api.metatileentity.implementations.GT_MetaTileEntity_Hatch;
+import gregtech.api.metatileentity.implementations.GT_MetaTileEntity_Hatch_Input;
+import gregtech.api.metatileentity.implementations.GT_MetaTileEntity_Hatch_InputBus;
+import gregtech.api.metatileentity.implementations.GT_MetaTileEntity_Hatch_Maintenance;
 import gregtech.api.util.GTPP_Recipe;
 import gregtech.api.util.GT_Multiblock_Tooltip_Builder;
 import gregtech.api.util.GT_Recipe;
@@ -127,14 +129,9 @@ public class GregtechMetaTileEntity_LargeRocketEngine
                     .addElement('C', ofBlock(getCasingBlock(), getCasingMeta()))
                     .addElement('I', ofBlock(getGearboxBlock(), getGearboxMeta()))
                     // side
-                    .addElement(
-                            'S',
-                            buildHatchAdder(GregtechMetaTileEntity_LargeRocketEngine.class)
-                                    .atLeast(ImmutableMap.of(InputBus, 1, InputHatch, 3, Maintenance, 1, AirIntake, 8))
-                                    .casingIndex(getCasingTextureIndex())
-                                    .dot(1)
-                                    .buildAndChain(onElementPass(
-                                            x -> ++x.mCasing, ofBlock(getCasingBlock(), getCasingMeta()))))
+                    .addElement('S',
+                            ofChain(ofHatchAdder(GregtechMetaTileEntity_LargeRocketEngine::addLargeRocketEngineSideList, getCasingTextureIndex(), 1),
+                            onElementPass(x -> ++x.mCasing, ofBlock(getCasingBlock(), getCasingMeta()))))
                     // top
                     .addElement(
                             'T',
@@ -148,6 +145,28 @@ public class GregtechMetaTileEntity_LargeRocketEngine
                     .build();
         }
         return this.STRUCTURE_DEFINITION;
+    }
+
+    public final boolean addLargeRocketEngineSideList(IGregTechTileEntity aTileEntity, int aBaseCasingIndex) {
+        if (aTileEntity == null) {
+            return false;
+        }
+        else {
+            IMetaTileEntity aMetaTileEntity = aTileEntity.getMetaTileEntity();
+            if (aMetaTileEntity instanceof GT_MetaTileEntity_Hatch_Maintenance) {
+                return addToMachineList(aTileEntity, aBaseCasingIndex);
+            }
+            else if (aMetaTileEntity instanceof GT_MetaTileEntity_Hatch_AirIntake) {
+                return addToMachineList(aTileEntity, aBaseCasingIndex);
+            }
+            else if (aMetaTileEntity instanceof GT_MetaTileEntity_Hatch_Input) {
+                return addToMachineList(aTileEntity, aBaseCasingIndex);
+            }
+            else if (aMetaTileEntity instanceof GT_MetaTileEntity_Hatch_InputBus) {
+                return addToMachineList(aTileEntity, aBaseCasingIndex);
+            }
+        }
+        return false;
     }
 
     @Override

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/GregtechMetaTileEntity_LargeRocketEngine.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/GregtechMetaTileEntity_LargeRocketEngine.java
@@ -129,9 +129,14 @@ public class GregtechMetaTileEntity_LargeRocketEngine
                     .addElement('C', ofBlock(getCasingBlock(), getCasingMeta()))
                     .addElement('I', ofBlock(getGearboxBlock(), getGearboxMeta()))
                     // side
-                    .addElement('S',
-                            ofChain(ofHatchAdder(GregtechMetaTileEntity_LargeRocketEngine::addLargeRocketEngineSideList, getCasingTextureIndex(), 1),
-                            onElementPass(x -> ++x.mCasing, ofBlock(getCasingBlock(), getCasingMeta()))))
+                    .addElement(
+                            'S',
+                            ofChain(
+                                    ofHatchAdder(
+                                            GregtechMetaTileEntity_LargeRocketEngine::addLargeRocketEngineSideList,
+                                            getCasingTextureIndex(),
+                                            1),
+                                    onElementPass(x -> ++x.mCasing, ofBlock(getCasingBlock(), getCasingMeta()))))
                     // top
                     .addElement(
                             'T',
@@ -150,19 +155,15 @@ public class GregtechMetaTileEntity_LargeRocketEngine
     public final boolean addLargeRocketEngineSideList(IGregTechTileEntity aTileEntity, int aBaseCasingIndex) {
         if (aTileEntity == null) {
             return false;
-        }
-        else {
+        } else {
             IMetaTileEntity aMetaTileEntity = aTileEntity.getMetaTileEntity();
             if (aMetaTileEntity instanceof GT_MetaTileEntity_Hatch_Maintenance) {
                 return addToMachineList(aTileEntity, aBaseCasingIndex);
-            }
-            else if (aMetaTileEntity instanceof GT_MetaTileEntity_Hatch_AirIntake) {
+            } else if (aMetaTileEntity instanceof GT_MetaTileEntity_Hatch_AirIntake) {
                 return addToMachineList(aTileEntity, aBaseCasingIndex);
-            }
-            else if (aMetaTileEntity instanceof GT_MetaTileEntity_Hatch_Input) {
+            } else if (aMetaTileEntity instanceof GT_MetaTileEntity_Hatch_Input) {
                 return addToMachineList(aTileEntity, aBaseCasingIndex);
-            }
-            else if (aMetaTileEntity instanceof GT_MetaTileEntity_Hatch_InputBus) {
+            } else if (aMetaTileEntity instanceof GT_MetaTileEntity_Hatch_InputBus) {
                 return addToMachineList(aTileEntity, aBaseCasingIndex);
             }
         }

--- a/src/main/java/gtPlusPlus/xmod/gregtech/registration/gregtech/GregtechRocketFuelGenerator.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/registration/gregtech/GregtechRocketFuelGenerator.java
@@ -57,11 +57,13 @@ public class GregtechRocketFuelGenerator {
             "RFR",
             "PWP",
             'R',
-            OrePrefixes.pipeLarge.get(Materials.TungstenSteel),
+            OrePrefixes.pipeLarge.get(Materials.Titanium),
             'F',
             ItemList.Casing_RobustTungstenSteel,
             'P',
-            ALLOY.NITINOL_60.getGear(1)
+            ALLOY.NITINOL_60.getGear(1),
+            'W',
+            OrePrefixes.stickLong.get(Materials.Titanium)
         });
 
         GregtechItemList.Rocket_Engine_EV.set(new GregtechMetaTileEntityRocketFuelGenerator(

--- a/src/main/java/gtPlusPlus/xmod/gregtech/registration/gregtech/GregtechRocketFuelGenerator.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/registration/gregtech/GregtechRocketFuelGenerator.java
@@ -57,13 +57,13 @@ public class GregtechRocketFuelGenerator {
             "RFR",
             "PWP",
             'R',
-            OrePrefixes.pipeLarge.get(Materials.Titanium),
+            OrePrefixes.pipeMedium.get(Materials.TungstenSteel),
             'F',
             ItemList.Casing_RobustTungstenSteel,
             'P',
             ALLOY.NITINOL_60.getGear(1),
             'W',
-            OrePrefixes.stickLong.get(Materials.Titanium)
+            OrePrefixes.stickLong.get(Materials.TungstenSteel)
         });
 
         GregtechItemList.Rocket_Engine_EV.set(new GregtechMetaTileEntityRocketFuelGenerator(


### PR DESCRIPTION
- Fixed Air Intake Hatches not being detected by the controller;
- Reduced the amount of Tungstensteel needed by replacing some with Titanium.

The Rocketdyne was unable to form, because of the survival construct PR which removed a method essential for it to count the amount of Air Intake Hatches. I brought that method back.

Additionally, the multi needs a minimum of 64 Turbodyne Casings, but each one costs 20 Tungstensteel Ingots, so building this would cost 20 stacks of TSS just for these casings, adding to the rest of the items needed. To make it cheaper, I replaced the pipes with Titanium ones and added a Long Titanium Rod in the previously empty slot, which means it now costs 6 TSS stacks and 13 Titanium stacks, plus the other materials, to make these casings.