### PR TITLE
Fix XL plasma turbine consuming way too much plasma

### DIFF
--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/turbines/GT_MTE_LargeTurbine_Plasma.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/turbines/GT_MTE_LargeTurbine_Plasma.java
@@ -183,7 +183,7 @@ public class GT_MTE_LargeTurbine_Plasma extends GregtechMetaTileEntity_LargerTur
     @Override
     int fluidIntoPower(ArrayList<FluidStack> aFluids, long aOptFlow, int aBaseEff, float[] flowMultipliers) {
         if (aFluids.size() >= 1) {
-            aOptFlow *= 800; // CHANGED THINGS HERE, check recipe runs once per 20 ticks
+            aOptFlow *= 40; // CHANGED THINGS HERE, check recipe runs once per 20 ticks
             int tEU = 0;
 
             int actualOptimalFlow = 0;
@@ -225,7 +225,7 @@ public class GT_MTE_LargeTurbine_Plasma extends GregtechMetaTileEntity_LargerTur
                 }
             }
             if (totalFlow <= 0) return 0;
-            tEU = GT_Utility.safeInt((long) ((fuelValue / 20D) * (double) totalFlow));
+            tEU = GT_Utility.safeInt((long) ((fuelValue) * (double) totalFlow));
 
             if (totalFlow == actualOptimalFlow) {
                 tEU = GT_Utility.safeInt((long) (aBaseEff / 10000D * tEU));


### PR DESCRIPTION
Decreased consumption by 20 since it uses the sec value per tick