### PR TITLE
Made super bus recipe time not tier dependend

### DIFF
--- a/src/main/java/gtPlusPlus/core/recipe/RECIPES_Machines.java
+++ b/src/main/java/gtPlusPlus/core/recipe/RECIPES_Machines.java
@@ -4253,7 +4253,7 @@ public class RECIPES_Machines {
                     },
                     CI.getAlternativeTieredFluid(i, 144 * 8),
                     mSuperBusesInput[i].get(1),
-                    20 * 30 * 2 * i,
+                    20 * 30 * 2,
                     (int) GT_Values.V[i]);
         }
         // Output Buses
@@ -4269,7 +4269,7 @@ public class RECIPES_Machines {
                     },
                     CI.getTertiaryTieredFluid(i, 144 * 8),
                     mSuperBusesOutput[i].get(1),
-                    20 * 30 * 2 * i,
+                    20 * 30 * 2,
                     (int) GT_Values.V[i]);
         }
     }


### PR DESCRIPTION
Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/11353
Imo a valid recipe change request, the voltage tier already increases so the time can stay the same.