### PR TITLE
Fix fluid-extraction recipes for Redstone Alloy are incorrectly overwritten

### DIFF
--- a/src/main/java/gtPlusPlus/core/item/ModItems.java
+++ b/src/main/java/gtPlusPlus/core/item/ModItems.java
@@ -1210,18 +1210,6 @@ public final class ModItems {
             GT_OreDictUnificator.registerOre(
                     "blockVibrantAlloy", ItemUtils.getItemStackOfAmountFromOreDict("blockPhasedGold", 1));
 
-            CORE.RA.addFluidExtractionRecipe(
-                    MaterialEIO.REDSTONE_ALLOY.getPlate(1), MaterialEIO.REDSTONE_ALLOY.getFluidStack(144), 16, 4 * 9);
-            CORE.RA.addFluidExtractionRecipe(
-                    MaterialEIO.REDSTONE_ALLOY.getIngot(1), MaterialEIO.REDSTONE_ALLOY.getFluidStack(144), 16, 4 * 9);
-            CORE.RA.addFluidExtractionRecipe(
-                    MaterialEIO.REDSTONE_ALLOY.getNugget(1), MaterialEIO.REDSTONE_ALLOY.getFluidStack(16), 16, 4);
-            CORE.RA.addFluidExtractionRecipe(
-                    MaterialEIO.REDSTONE_ALLOY.getBlock(1),
-                    MaterialEIO.REDSTONE_ALLOY.getFluidStack(1294),
-                    16,
-                    4 * 9 * 9);
-
         } else {
             /*Logger.WARNING("EnderIO not Found - Generating our own Resources.");
             MaterialGenerator.generate(MaterialEIO.CONDUCTIVE_IRON);


### PR DESCRIPTION
They're automatically added anyway
Close https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/9092