### PR TITLE
Fix input seperation on mixer

### DIFF
--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/GregtechMetaTileEntity_IndustrialMixer.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/GregtechMetaTileEntity_IndustrialMixer.java
@@ -15,6 +15,7 @@ import gregtech.api.enums.TAE;
 import gregtech.api.interfaces.IIconContainer;
 import gregtech.api.interfaces.metatileentity.IMetaTileEntity;
 import gregtech.api.interfaces.tileentity.IGregTechTileEntity;
+import gregtech.api.metatileentity.implementations.GT_MetaTileEntity_Hatch_InputBus;
 import gregtech.api.util.GT_Multiblock_Tooltip_Builder;
 import gregtech.api.util.GT_Recipe;
 import gregtech.api.util.GT_Utility;
@@ -23,6 +24,7 @@ import gtPlusPlus.core.lib.CORE;
 import gtPlusPlus.xmod.gregtech.api.metatileentity.implementations.base.GregtechMeta_MultiBlockBase;
 import gtPlusPlus.xmod.gregtech.common.blocks.textures.TexturesGtBlock;
 import net.minecraft.item.ItemStack;
+import net.minecraftforge.fluids.FluidStack;
 
 public class GregtechMetaTileEntity_IndustrialMixer
         extends GregtechMeta_MultiBlockBase<GregtechMetaTileEntity_IndustrialMixer> implements ISurvivalConstructable {
@@ -155,7 +157,13 @@ public class GregtechMetaTileEntity_IndustrialMixer
 
     @Override
     public boolean checkRecipe(final ItemStack aStack) {
-        return checkRecipeGeneric(getMaxParallelRecipes(), getEuDiscountForParallelism(), 250, 10000);
+        for (GT_MetaTileEntity_Hatch_InputBus tBus : mInputBusses) {
+            if (checkRecipeGeneric(tBus.mInventory, getStoredFluids().toArray(new FluidStack[0]), getMaxParallelRecipes(), getEuDiscountForParallelism(), 250, 10000)) {
+                return true;
+            }
+        }
+
+        return checkRecipeGeneric(new ItemStack[0], getStoredFluids().toArray(new FluidStack[0]), getMaxParallelRecipes(), getEuDiscountForParallelism(), 250, 10000);
     }
 
     @Override

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/GregtechMetaTileEntity_IndustrialMixer.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/GregtechMetaTileEntity_IndustrialMixer.java
@@ -158,12 +158,24 @@ public class GregtechMetaTileEntity_IndustrialMixer
     @Override
     public boolean checkRecipe(final ItemStack aStack) {
         for (GT_MetaTileEntity_Hatch_InputBus tBus : mInputBusses) {
-            if (checkRecipeGeneric(tBus.mInventory, getStoredFluids().toArray(new FluidStack[0]), getMaxParallelRecipes(), getEuDiscountForParallelism(), 250, 10000)) {
+            if (checkRecipeGeneric(
+                    tBus.mInventory,
+                    getStoredFluids().toArray(new FluidStack[0]),
+                    getMaxParallelRecipes(),
+                    getEuDiscountForParallelism(),
+                    250,
+                    10000)) {
                 return true;
             }
         }
 
-        return checkRecipeGeneric(new ItemStack[0], getStoredFluids().toArray(new FluidStack[0]), getMaxParallelRecipes(), getEuDiscountForParallelism(), 250, 10000);
+        return checkRecipeGeneric(
+                new ItemStack[0],
+                getStoredFluids().toArray(new FluidStack[0]),
+                getMaxParallelRecipes(),
+                getEuDiscountForParallelism(),
+                250,
+                10000);
     }
 
     @Override


### PR DESCRIPTION
Added back logic that has input seperation, while still allowing having no input busses at all
Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/11446