### PR TITLE
Revert the Nerf to Algae Farm Casing Cost

### DIFF
--- a/src/main/java/gtPlusPlus/core/recipe/RECIPES_Machines.java
+++ b/src/main/java/gtPlusPlus/core/recipe/RECIPES_Machines.java
@@ -1068,15 +1068,15 @@ public class RECIPES_Machines {
                 new ItemStack[] {
                     CI.getNumberedBioCircuit(21),
                     CI.getTieredGTPPMachineCasing(0, 4),
-                    CI.getTieredComponentOfMaterial(Materials.Iron, OrePrefixes.rod, 12),
+                    CI.getTieredComponentOfMaterial(Materials.Aluminium, OrePrefixes.rod, 12),
                     CI.getTieredComponentOfMaterial(Materials.Wood, OrePrefixes.plate, 32),
-                    CI.getTieredComponentOfMaterial(Materials.Bronze, OrePrefixes.bolt, 16),
+                    CI.getTieredComponentOfMaterial(Materials.Steel, OrePrefixes.bolt, 16),
                     CI.getTieredComponentOfMaterial(Materials.Redstone, OrePrefixes.dust, 32),
                 },
                 ALLOY.POTIN.getFluidStack(2 * (144 * 4)),
                 GregtechItemList.AlgaeFarm_Controller.get(1),
                 60 * 20,
-                MaterialUtils.getVoltageForTier(1));
+                MaterialUtils.getVoltageForTier(2));
     }
 
     private static void distillus() {
@@ -2254,17 +2254,16 @@ public class RECIPES_Machines {
                 GT_Values.RA.addAssemblerRecipe(
                         new ItemStack[] {
                             GT_Utility.getIntegratedCircuit(2),
-                            ALLOY.INCONEL_625.getFrameBox(1),
-                            ALLOY.HASTELLOY_X.getComponentByPrefix(OrePrefixes.pipeTiny, 1),
-                            ItemList.Electric_Pump_EV.get(2),
-                            ItemList.HV_Coil.get(4),
-                            ItemList.IC2_Plantball.get(8),
-                            GT_OreDictUnificator.get(OrePrefixes.plank, Materials.Wood, 6),
+                            ALLOY.TUMBAGA.getFrameBox(1),
+                            ALLOY.TUMBAGA.getComponentByPrefix(OrePrefixes.pipeTiny, 1),
+                            ItemList.MV_Coil.get(1),
+                            ItemList.IC2_Plantball.get(4),
+                            GT_OreDictUnificator.get(OrePrefixes.plank, Materials.Wood, 8),
                         },
-                        GT_ModHandler.getDistilledWater(8000),
+                        GT_ModHandler.getDistilledWater(2000),
                         RECIPE_TreeFarmFrame,
-                        60,
-                        1960);
+                        200,
+                        64);
             }
 
             if (CORE.ConfigSwitches.enableMachine_Tesseracts) {


### PR DESCRIPTION
- Changed the Algae Farm casing tier to the low tier it was supposed to be at, this time at MV and with no dirt. The casing is shared with the TGS, which was the reason for the nerf, but the controller can gate that multi;
- Adjusted the controller recipe for the Farm to also be MV.

The Algae Farm is meant to be MV, but the new casing cost is far too expensive for it.

Closes [#11450](https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/11450).