### PR TITLE
Fix Amount of Infinite Mutation Catalyst Output

### DIFF
--- a/src/main/java/gtPlusPlus/core/item/chemistry/GenericChem.java
+++ b/src/main/java/gtPlusPlus/core/item/chemistry/GenericChem.java
@@ -912,7 +912,7 @@ public class GenericChem extends ItemPackage {
                     Materials.Naquadria.getDust(10)
                 },
                 GT_Values.NF,
-                ItemUtils.getSimpleStack(GenericChem.mInfiniteMutationCatalyst, 1),
+                ItemUtils.getSimpleStack(GenericChem.mInfiniteMutationCatalyst, 5),
                 5 * 20,
                 1966080);
     }


### PR DESCRIPTION
- Changed output from 1 to 5 catalysts, to match the input of 5 carriers.

Closes [#11595](https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/11595).