### PR TITLE
Fix Sterile Farm Casing Recipe (No Tumbaga Pipe)

### DIFF
--- a/src/main/java/gtPlusPlus/core/recipe/RECIPES_Machines.java
+++ b/src/main/java/gtPlusPlus/core/recipe/RECIPES_Machines.java
@@ -2255,7 +2255,7 @@ public class RECIPES_Machines {
                         new ItemStack[] {
                             GT_Utility.getIntegratedCircuit(2),
                             ALLOY.TUMBAGA.getFrameBox(1),
-                            ALLOY.TUMBAGA.getComponentByPrefix(OrePrefixes.pipeTiny, 1),
+                            ItemUtils.getItemStackOfAmountFromOreDict("pipeTinySteel", 1),
                             ItemList.MV_Coil.get(1),
                             ItemList.IC2_Plantball.get(4),
                             GT_OreDictUnificator.get(OrePrefixes.plank, Materials.Wood, 8),


### PR DESCRIPTION
I made a mistake and didn't even check if Tumbaga pipes existed. Fixed now.

Closes [#11629](https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/11629).