### PR TITLE
PSS incorrect loss fixed

### DIFF
--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/storage/GregtechMetaTileEntity_PowerSubStationController.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/storage/GregtechMetaTileEntity_PowerSubStationController.java
@@ -638,8 +638,9 @@ public class GregtechMetaTileEntity_PowerSubStationController
     private long computeEnergyTax() {
         float mTax = mAverageEuUsage * (ENERGY_TAX / 100f);
 
-        // Increase tax up to 2x if machine is not fully repaired (does not actually work at the moment, mEfficiency is always 0)
-        //mTax = mTax * (1f + (10000f - mEfficiency) / 10000f);
+        // Increase tax up to 2x if machine is not fully repaired (does not actually work at the moment, mEfficiency is
+        // always 0)
+        // mTax = mTax * (1f + (10000f - mEfficiency) / 10000f);
 
         return MathUtils.roundToClosestLong(mTax);
     }

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/storage/GregtechMetaTileEntity_PowerSubStationController.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/storage/GregtechMetaTileEntity_PowerSubStationController.java
@@ -638,8 +638,8 @@ public class GregtechMetaTileEntity_PowerSubStationController
     private long computeEnergyTax() {
         float mTax = mAverageEuUsage * (ENERGY_TAX / 100f);
 
-        // Increase tax up to 2x if machine is not fully repaired
-        mTax = mTax * (1f + (10000f - mEfficiency) / 10000f);
+        // Increase tax up to 2x if machine is not fully repaired (does not actually work at the moment, mEfficiency is always 0)
+        //mTax = mTax * (1f + (10000f - mEfficiency) / 10000f);
 
         return MathUtils.roundToClosestLong(mTax);
     }


### PR DESCRIPTION
Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/11764.

Can't use the efficiency for the loss when that funcionality is not actually in use. It's just always 0 at the moment and really not relevant for this multi.

For some background: 5% was indeed the intended value https://github.com/GTNewHorizons/GTplusplus/pull/156