### PR TITLE
Fixes Matter Fabricator controller recipe

### DIFF
--- a/src/main/java/gtPlusPlus/core/recipe/RECIPES_Machines.java
+++ b/src/main/java/gtPlusPlus/core/recipe/RECIPES_Machines.java
@@ -2232,7 +2232,7 @@ public class RECIPES_Machines {
 
                 // Matter Fabricator CPU
                 RecipeUtils.addShapedGregtechRecipe(
-                        CI.getDoublePlate(8, 1),
+                        CI.getPlate(8, 1),
                         GT_OreDictUnificator.get(OrePrefixes.circuit.get(Materials.Superconductor), 1L),
                         CI.getPlate(8, 1),
                         GT_OreDictUnificator.get(OrePrefixes.cableGt04.get(Materials.NaquadahAlloy), 1L),


### PR DESCRIPTION
Now uses single plates consistently, not a random double plate.

Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/11755.