### PR TITLE
Fix QFT Parallel not calculated correctly

### DIFF
--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/GregtechMetaTileEntity_QuantumForceTransformer.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/GregtechMetaTileEntity_QuantumForceTransformer.java
@@ -36,6 +36,7 @@ import net.minecraft.block.Block;
 import net.minecraft.client.renderer.RenderBlocks;
 import net.minecraft.client.renderer.Tessellator;
 import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.EnumChatFormatting;
@@ -811,20 +812,22 @@ public class GregtechMetaTileEntity_QuantumForceTransformer
                                     tFluidOutputs.add(
                                             mat.getFluid(tRecipe.getOutput(i).stackSize * 1000 * mCurrentParallel));
                                 } else {
-                                    ItemStack aItem = tRecipe.getOutput(i);
-                                    tItemOutputs.add(
-                                            GT_Utility.copyAmountUnsafe(aItem.stackSize * mCurrentParallel, aItem));
+                                    Item aItem = tRecipe.getOutput(i).getItem();
+                                    int aItemDamage = tRecipe.getOutput(i).getItemDamage();
+                                    int aStackSize = tRecipe.getOutput(i).stackSize;
+                                    tItemOutputs.add(new ItemStack(aItem, aStackSize * mCurrentParallel, aItemDamage));
                                 }
                             } else {
-                                ItemStack aItem = tRecipe.getOutput(i);
-                                tItemOutputs.add(
-                                        GT_Utility.copyAmountUnsafe(aItem.stackSize * mCurrentParallel, aItem));
+                                Item aItem = tRecipe.getOutput(i).getItem();
+                                int aItemDamage = tRecipe.getOutput(i).getItemDamage();
+                                int aStackSize = tRecipe.getOutput(i).stackSize;
+                                tItemOutputs.add(new ItemStack(aItem, aStackSize * mCurrentParallel, aItemDamage));
                             }
                         } else {
-                            FluidStack aFluid = tRecipe.getFluidOutput(i - tRecipe.mOutputs.length)
-                                    .copy();
-                            aFluid.amount *= mCurrentParallel;
-                            tFluidOutputs.add(aFluid);
+                            Fluid aFluid = tRecipe.getFluidOutput(i - tRecipe.mOutputs.length)
+                                    .getFluid();
+                            int aAmount = tRecipe.getFluidOutput(i - tRecipe.mOutputs.length).amount;
+                            tFluidOutputs.add(new FluidStack(aFluid, aAmount * mCurrentParallel));
                         }
                     }
                 }

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/GregtechMetaTileEntity_QuantumForceTransformer.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/GregtechMetaTileEntity_QuantumForceTransformer.java
@@ -712,9 +712,8 @@ public class GregtechMetaTileEntity_QuantumForceTransformer
 
     private boolean processRecipe(
             ItemStack[] aItemInputs, FluidStack[] aFluidInputs, GT_Recipe.GT_Recipe_Map aRecipeMap, ItemStack aStack) {
-        int hatches = getExoticAndNormalEnergyHatchList().size();
         long tVoltage = getMaxInputVoltage();
-        long tAmps = (long) Math.floor(getMaxInputAmps() * 0.80) / hatches;
+        long tAmps = (long) Math.floor(getMaxInputAmps() * 0.80);
         long tTotalEUt = tVoltage * tAmps;
         byte tTier = (byte) Math.max(1, GT_Utility.getTier(tVoltage));
         GT_Recipe tRecipe = aRecipeMap

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/GregtechMetaTileEntity_QuantumForceTransformer.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/GregtechMetaTileEntity_QuantumForceTransformer.java
@@ -1092,7 +1092,6 @@ public class GregtechMetaTileEntity_QuantumForceTransformer
         if (zEUt > zMaxInputVoltage) {
             zTime = Integer.MAX_VALUE - 1;
             zEUt = Long.MAX_VALUE - 1;
-            return;
         }
         while (zEUt << 2 < zMaxInputVoltage) {
             zEUt = zEUt << 2;

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/GregtechMetaTileEntity_QuantumForceTransformer.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/GregtechMetaTileEntity_QuantumForceTransformer.java
@@ -36,7 +36,6 @@ import net.minecraft.block.Block;
 import net.minecraft.client.renderer.RenderBlocks;
 import net.minecraft.client.renderer.Tessellator;
 import net.minecraft.entity.player.EntityPlayer;
-import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.EnumChatFormatting;
@@ -713,9 +712,9 @@ public class GregtechMetaTileEntity_QuantumForceTransformer
 
     private boolean processRecipe(
             ItemStack[] aItemInputs, FluidStack[] aFluidInputs, GT_Recipe.GT_Recipe_Map aRecipeMap, ItemStack aStack) {
-        long tVoltage =
-                getMaxInputVoltage() / getExoticAndNormalEnergyHatchList().size();
-        long tAmps = (long) Math.floor(getMaxInputAmps() * 0.80);
+        int hatches = getExoticAndNormalEnergyHatchList().size();
+        long tVoltage = getMaxInputVoltage();
+        long tAmps = (long) Math.floor(getMaxInputAmps() * 0.80) / hatches;
         long tTotalEUt = tVoltage * tAmps;
         byte tTier = (byte) Math.max(1, GT_Utility.getTier(tVoltage));
         GT_Recipe tRecipe = aRecipeMap
@@ -812,22 +811,18 @@ public class GregtechMetaTileEntity_QuantumForceTransformer
                                     tFluidOutputs.add(
                                             mat.getFluid(tRecipe.getOutput(i).stackSize * 1000 * mCurrentParallel));
                                 } else {
-                                    Item aItem = tRecipe.getOutput(i).getItem();
-                                    int aItemDamage = tRecipe.getOutput(i).getItemDamage();
-                                    int aStackSize = tRecipe.getOutput(i).stackSize;
-                                    tItemOutputs.add(new ItemStack(aItem, aStackSize * mCurrentParallel, aItemDamage));
+                                    ItemStack aItem = tRecipe.getOutput(i);
+                                    tItemOutputs.add(
+                                            GT_Utility.copyAmountUnsafe(aItem.stackSize * mCurrentParallel, aItem));
                                 }
                             } else {
-                                Item aItem = tRecipe.getOutput(i).getItem();
-                                int aItemDamage = tRecipe.getOutput(i).getItemDamage();
-                                int aStackSize = tRecipe.getOutput(i).stackSize;
-                                tItemOutputs.add(new ItemStack(aItem, aStackSize * mCurrentParallel, aItemDamage));
+                                ItemStack aItem = tRecipe.getOutput(i);
+                                tItemOutputs.add(
+                                        GT_Utility.copyAmountUnsafe(aItem.stackSize * mCurrentParallel, aItem));
                             }
                         } else {
-                            Fluid aFluid = tRecipe.getFluidOutput(i - tRecipe.mOutputs.length)
-                                    .getFluid();
-                            int aAmount = tRecipe.getFluidOutput(i - tRecipe.mOutputs.length).amount;
-                            tFluidOutputs.add(new FluidStack(aFluid, aAmount * mCurrentParallel));
+                            FluidStack aFluid = tRecipe.getFluidOutput(i - tRecipe.mOutputs.length);
+                            tFluidOutputs.add(new FluidStack(aFluid, aFluid.amount * mCurrentParallel));
                         }
                     }
                 }

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/GregtechMetaTileEntity_QuantumForceTransformer.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/GregtechMetaTileEntity_QuantumForceTransformer.java
@@ -712,8 +712,10 @@ public class GregtechMetaTileEntity_QuantumForceTransformer
 
     private boolean processRecipe(
             ItemStack[] aItemInputs, FluidStack[] aFluidInputs, GT_Recipe.GT_Recipe_Map aRecipeMap, ItemStack aStack) {
-        long tVoltage = getMaxInputVoltage();
-        long tAmps = (long) Math.floor(getMaxInputAmps() * 0.80);
+        int hatches = getExoticAndNormalEnergyHatchList().size();
+        long tVoltage = getMaxInputVoltage() / hatches;
+        // Need to check weather the hatches used are TT ones or not as TT hatches can request 20% more amps
+        long tAmps = (long) Math.floor(mExoticEnergyHatches.isEmpty() ? getMaxInputAmps() : getMaxInputAmps() * 0.80);
         long tTotalEUt = tVoltage * tAmps;
         byte tTier = (byte) Math.max(1, GT_Utility.getTier(tVoltage));
         GT_Recipe tRecipe = aRecipeMap
@@ -1087,12 +1089,21 @@ public class GregtechMetaTileEntity_QuantumForceTransformer
         long zMaxInputVoltage = maxInputVoltage / 100L * 95L;
         long zTime = aDuration;
         long zEUt = aEUt;
+        if (zEUt > zMaxInputVoltage) {
+            zTime = Integer.MAX_VALUE - 1;
+            zEUt = Long.MAX_VALUE - 1;
+            return;
+        }
         while (zEUt << 2 < zMaxInputVoltage) {
             zEUt = zEUt << 2;
             zTime = zTime >> (perfectOC ? 2 : 1);
             if (zTime <= 0) {
                 break;
             }
+        }
+        if (zEUt > zMaxInputVoltage) {
+            zEUt = zEUt >> 2;
+            zTime = zTime << (perfectOC ? 2 : 1);
         }
         if (zTime <= 0) {
             zTime = 1;


### PR DESCRIPTION
GT_Utility.copyAmountUnsafe wasn't copying it correctly and applying the new stacksize.
Just multiplying the amount in the fluid stack wasn't enough apparently and broke if the qft had more than 1 parallel