### PR TITLE
Buff some of the late tier recipes

### DIFF
--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/GregtechMetaTileEntity_QuantumForceTransformer.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/GregtechMetaTileEntity_QuantumForceTransformer.java
@@ -490,6 +490,7 @@ public class GregtechMetaTileEntity_QuantumForceTransformer
                 .addInfo("All inputs go on the bottom, all outputs go on the top")
                 .addInfo("Put a circuit in the controller to specify the focused output")
                 .addInfo("Check NEI to see the order of outputs, and which circuit number you need.")
+                .addInfo("If separate input busses are enabled put the circuit in the circuit slot of the bus")
                 .addInfo("Uses FocusTier*4*sqrt(parallels) Neptunium Plasma if focusing")
                 .addInfo("Can use FocusTier*4*sqrt(parallels) Fermium Plasma for additional chance output")
                 .addInfo("This multi gets improved when all casings of some types are upgraded")
@@ -697,8 +698,9 @@ public class GregtechMetaTileEntity_QuantumForceTransformer
                         tInputList.add(tBus.getStackInSlot(i));
                     }
                 }
+                
                 ItemStack[] tInputs = tInputList.toArray(new ItemStack[0]);
-                if (processRecipe(tInputs, tFluidList, getRecipeMap(), aStack)) return true;
+                if (processRecipe(tInputs, tFluidList, getRecipeMap(), tBus.mInventory[tBus.getCircuitSlot()])) return true;
                 else tInputList.clear();
             }
         } else {
@@ -1122,84 +1124,84 @@ public class GregtechMetaTileEntity_QuantumForceTransformer
         Tessellator tes = Tessellator.instance;
         switch (side) {
             case 0:
-                tes.addVertexWithUV(x + 3 - 0.5, y    , z + 7, maxU, maxV);
-                tes.addVertexWithUV(x + 3 - 0.5, y + 4, z + 7, maxU, minV);
-                tes.addVertexWithUV(x - 3 + 0.5, y + 4, z + 7, minU, minV);
-                tes.addVertexWithUV(x - 3 + 0.5, y    , z + 7, minU, maxV);
-                tes.addVertexWithUV(x - 3 + 0.5, y    , z + 7, minU, maxV);
-                tes.addVertexWithUV(x - 3 + 0.5, y + 4, z + 7, minU, minV);
-                tes.addVertexWithUV(x + 3 - 0.5, y + 4, z + 7, maxU, minV);
-                tes.addVertexWithUV(x + 3 - 0.5, y    , z + 7, maxU, maxV);
+                tes.addVertexWithUV(x + 3, y    , z + 7, maxU, maxV);
+                tes.addVertexWithUV(x + 3, y + 4, z + 7, maxU, minV);
+                tes.addVertexWithUV(x - 3, y + 4, z + 7, minU, minV);
+                tes.addVertexWithUV(x - 3, y    , z + 7, minU, maxV);
+                tes.addVertexWithUV(x - 3, y    , z + 7, minU, maxV);
+                tes.addVertexWithUV(x - 3, y + 4, z + 7, minU, minV);
+                tes.addVertexWithUV(x + 3, y + 4, z + 7, maxU, minV);
+                tes.addVertexWithUV(x + 3, y    , z + 7, maxU, maxV);
                 break;
             case 1:
-                tes.addVertexWithUV(x + 7, y    , z + 4 - 0.5, maxU, maxV);
-                tes.addVertexWithUV(x + 7, y + 4, z + 4 - 0.5, maxU, minV);
-                tes.addVertexWithUV(x + 7, y + 4, z - 4 + 0.5, minU, minV);
-                tes.addVertexWithUV(x + 7, y    , z - 4 + 0.5, minU, maxV);
-                tes.addVertexWithUV(x + 7, y    , z - 4 + 0.5, minU, maxV);
-                tes.addVertexWithUV(x + 7, y + 4, z - 4 + 0.5, minU, minV);
-                tes.addVertexWithUV(x + 7, y + 4, z + 4 - 0.5, maxU, minV);
-                tes.addVertexWithUV(x + 7, y    , z + 4 - 0.5, maxU, maxV);
+                tes.addVertexWithUV(x + 7, y    , z + 4, maxU, maxV);
+                tes.addVertexWithUV(x + 7, y + 4, z + 4, maxU, minV);
+                tes.addVertexWithUV(x + 7, y + 4, z - 4, minU, minV);
+                tes.addVertexWithUV(x + 7, y    , z - 4, minU, maxV);
+                tes.addVertexWithUV(x + 7, y    , z - 4, minU, maxV);
+                tes.addVertexWithUV(x + 7, y + 4, z - 4, minU, minV);
+                tes.addVertexWithUV(x + 7, y + 4, z + 4, maxU, minV);
+                tes.addVertexWithUV(x + 7, y    , z + 4, maxU, maxV);
                 break;
             case 2:
-                tes.addVertexWithUV(x + 3 + 0.5, y    , z - 7, maxU, maxV);
-                tes.addVertexWithUV(x + 3 + 0.5, y + 4, z - 7, maxU, minV);
-                tes.addVertexWithUV(x - 3 - 0.5, y + 4, z - 7, minU, minV);
-                tes.addVertexWithUV(x - 3 - 0.5, y    , z - 7, minU, maxV);
-                tes.addVertexWithUV(x - 3 - 0.5, y    , z - 7, minU, maxV);
-                tes.addVertexWithUV(x - 3 - 0.5, y + 4, z - 7, minU, minV);
-                tes.addVertexWithUV(x + 3 + 0.5, y + 4, z - 7, maxU, minV);
-                tes.addVertexWithUV(x + 3 + 0.5, y    , z - 7, maxU, maxV);
+                tes.addVertexWithUV(x + 3, y    , z - 7, maxU, maxV);
+                tes.addVertexWithUV(x + 3, y + 4, z - 7, maxU, minV);
+                tes.addVertexWithUV(x - 3, y + 4, z - 7, minU, minV);
+                tes.addVertexWithUV(x - 3, y    , z - 7, minU, maxV);
+                tes.addVertexWithUV(x - 3, y    , z - 7, minU, maxV);
+                tes.addVertexWithUV(x - 3, y + 4, z - 7, minU, minV);
+                tes.addVertexWithUV(x + 3, y + 4, z - 7, maxU, minV);
+                tes.addVertexWithUV(x + 3, y    , z - 7, maxU, maxV);
                 break;
             case 3:
-                tes.addVertexWithUV(x - 7, y    , z + 4 - 0.5, maxU, maxV);
-                tes.addVertexWithUV(x - 7, y + 4, z + 4 - 0.5, maxU, minV);
-                tes.addVertexWithUV(x - 7, y + 4, z - 4 + 0.5, minU, minV);
-                tes.addVertexWithUV(x - 7, y    , z - 4 + 0.5, minU, maxV);
-                tes.addVertexWithUV(x - 7, y    , z - 4 + 0.5, minU, maxV);
-                tes.addVertexWithUV(x - 7, y + 4, z - 4 + 0.5, minU, minV);
-                tes.addVertexWithUV(x - 7, y + 4, z + 4 - 0.5, maxU, minV);
-                tes.addVertexWithUV(x - 7, y    , z + 4 - 0.5, maxU, maxV); 
+                tes.addVertexWithUV(x - 7, y    , z + 4, maxU, maxV);
+                tes.addVertexWithUV(x - 7, y + 4, z + 4, maxU, minV);
+                tes.addVertexWithUV(x - 7, y + 4, z - 4, minU, minV);
+                tes.addVertexWithUV(x - 7, y    , z - 4, minU, maxV);
+                tes.addVertexWithUV(x - 7, y    , z - 4, minU, maxV);
+                tes.addVertexWithUV(x - 7, y + 4, z - 4, minU, minV);
+                tes.addVertexWithUV(x - 7, y + 4, z + 4, maxU, minV);
+                tes.addVertexWithUV(x - 7, y    , z + 4, maxU, maxV); 
                 break;
             case 4:
-                tes.addVertexWithUV(x - 3 - 0.5, y    , z + 7      , maxU, maxV);
-                tes.addVertexWithUV(x - 3 - 0.5, y + 4, z + 7      , maxU, minV);
-                tes.addVertexWithUV(x - 7      , y + 4, z + 4 + 0.5, minU, minV);
-                tes.addVertexWithUV(x - 7      , y    , z + 4 + 0.5, minU, maxV);
-                tes.addVertexWithUV(x - 7      , y    , z + 4 + 0.5, minU, maxV);
-                tes.addVertexWithUV(x - 7      , y + 4, z + 4 + 0.5, minU, minV);
-                tes.addVertexWithUV(x - 3 - 0.5, y + 4, z + 7      , maxU, minV);
-                tes.addVertexWithUV(x - 3 - 0.5, y    , z + 7      , maxU, maxV);
+                tes.addVertexWithUV(x - 3, y    , z + 7, maxU, maxV);
+                tes.addVertexWithUV(x - 3, y + 4, z + 7, maxU, minV);
+                tes.addVertexWithUV(x - 7, y + 4, z + 4, minU, minV);
+                tes.addVertexWithUV(x - 7, y    , z + 4, minU, maxV);
+                tes.addVertexWithUV(x - 7, y    , z + 4, minU, maxV);
+                tes.addVertexWithUV(x - 7, y + 4, z + 4, minU, minV);
+                tes.addVertexWithUV(x - 3, y + 4, z + 7, maxU, minV);
+                tes.addVertexWithUV(x - 3, y    , z + 7, maxU, maxV);
                 break;
             case 5:
-                tes.addVertexWithUV(x - 3 - 0.5, y    , z - 7      , maxU, maxV);
-                tes.addVertexWithUV(x - 3 - 0.5, y + 4, z - 7      , maxU, minV);
-                tes.addVertexWithUV(x - 7      , y + 4, z - 4 - 0.5, minU, minV);
-                tes.addVertexWithUV(x - 7      , y    , z - 4 - 0.5, minU, maxV);
-                tes.addVertexWithUV(x - 7      , y    , z - 4 - 0.5, minU, maxV);
-                tes.addVertexWithUV(x - 7      , y + 4, z - 4 - 0.5, minU, minV);
-                tes.addVertexWithUV(x - 3 - 0.5, y + 4, z - 7      , maxU, minV);
-                tes.addVertexWithUV(x - 3 - 0.5, y    , z - 7      , maxU, maxV);
+                tes.addVertexWithUV(x - 3, y    , z - 7, maxU, maxV);
+                tes.addVertexWithUV(x - 3, y + 4, z - 7, maxU, minV);
+                tes.addVertexWithUV(x - 7, y + 4, z - 4, minU, minV);
+                tes.addVertexWithUV(x - 7, y    , z - 4, minU, maxV);
+                tes.addVertexWithUV(x - 7, y    , z - 4, minU, maxV);
+                tes.addVertexWithUV(x - 7, y + 4, z - 4, minU, minV);
+                tes.addVertexWithUV(x - 3, y + 4, z - 7, maxU, minV);
+                tes.addVertexWithUV(x - 3, y    , z - 7, maxU, maxV);
                 break;
             case 6:
-                tes.addVertexWithUV(x + 3 + 0.5, y    , z + 7      , maxU, maxV);
-                tes.addVertexWithUV(x + 3 + 0.5, y + 4, z + 7      , maxU, minV);
-                tes.addVertexWithUV(x + 7      , y + 4, z + 4 + 0.5, minU, minV);
-                tes.addVertexWithUV(x + 7      , y    , z + 4 + 0.5, minU, maxV);
-                tes.addVertexWithUV(x + 7      , y    , z + 4 + 0.5, minU, maxV);
-                tes.addVertexWithUV(x + 7      , y + 4, z + 4 + 0.5, minU, minV);
-                tes.addVertexWithUV(x + 3 + 0.5, y + 4, z + 7      , maxU, minV);
-                tes.addVertexWithUV(x + 3 + 0.5, y    , z + 7      , maxU, maxV);
+                tes.addVertexWithUV(x + 3, y    , z + 7, maxU, maxV);
+                tes.addVertexWithUV(x + 3, y + 4, z + 7, maxU, minV);
+                tes.addVertexWithUV(x + 7, y + 4, z + 4, minU, minV);
+                tes.addVertexWithUV(x + 7, y    , z + 4, minU, maxV);
+                tes.addVertexWithUV(x + 7, y    , z + 4, minU, maxV);
+                tes.addVertexWithUV(x + 7, y + 4, z + 4, minU, minV);
+                tes.addVertexWithUV(x + 3, y + 4, z + 7, maxU, minV);
+                tes.addVertexWithUV(x + 3, y    , z + 7, maxU, maxV);
                 break;
             case 7:
-                tes.addVertexWithUV(x + 3 + 0.5, y    , z - 7      , maxU, maxV);
-                tes.addVertexWithUV(x + 3 + 0.5, y + 4, z - 7      , maxU, minV);
-                tes.addVertexWithUV(x + 7      , y + 4, z - 4 - 0.5, minU, minV);
-                tes.addVertexWithUV(x + 7      , y    , z - 4 - 0.5, minU, maxV);
-                tes.addVertexWithUV(x + 7      , y    , z - 4 - 0.5, minU, maxV);
-                tes.addVertexWithUV(x + 7      , y + 4, z - 4 - 0.5, minU, minV);
-                tes.addVertexWithUV(x + 3 + 0.5, y + 4, z - 7      , maxU, minV);
-                tes.addVertexWithUV(x + 3 + 0.5, y    , z - 7      , maxU, maxV);
+                tes.addVertexWithUV(x + 3, y    , z - 7, maxU, maxV);
+                tes.addVertexWithUV(x + 3, y + 4, z - 7, maxU, minV);
+                tes.addVertexWithUV(x + 7, y + 4, z - 4, minU, minV);
+                tes.addVertexWithUV(x + 7, y    , z - 4, minU, maxV);
+                tes.addVertexWithUV(x + 7, y    , z - 4, minU, maxV);
+                tes.addVertexWithUV(x + 7, y + 4, z - 4, minU, minV);
+                tes.addVertexWithUV(x + 3, y + 4, z - 7, maxU, minV);
+                tes.addVertexWithUV(x + 3, y    , z - 7, maxU, maxV);
                 break;
         }
     }

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/GregtechMetaTileEntity_QuantumForceTransformer.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/GregtechMetaTileEntity_QuantumForceTransformer.java
@@ -698,10 +698,11 @@ public class GregtechMetaTileEntity_QuantumForceTransformer
                         tInputList.add(tBus.getStackInSlot(i));
                     }
                 }
-                
+
                 ItemStack[] tInputs = tInputList.toArray(new ItemStack[0]);
-                if (processRecipe(tInputs, tFluidList, getRecipeMap(), tBus.mInventory[tBus.getCircuitSlot()])) return true;
-                else tInputList.clear();
+                if (processRecipe(tInputs, tFluidList, getRecipeMap(), tBus.mInventory[tBus.getCircuitSlot()])) {
+                    return true;
+                } else tInputList.clear();
             }
         } else {
             ItemStack[] tInputList = getStoredInputs().toArray(new ItemStack[0]);

--- a/src/main/java/gtPlusPlus/xmod/gregtech/loaders/recipe/RecipeLoader_ChemicalSkips.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/loaders/recipe/RecipeLoader_ChemicalSkips.java
@@ -45,7 +45,7 @@ public class RecipeLoader_ChemicalSkips {
 
     private static void quantumTransformerRecipes() {
         ItemStack stemcells = GT_Utility.copyAmountUnsafe(64 * 32, ItemList.Circuit_Chip_Stemcell.get(1));
-        ItemStack biocells = GT_Utility.copyAmountUnsafe(64 *32, ItemList.Circuit_Chip_Biocell.get(1));
+        ItemStack biocells = GT_Utility.copyAmountUnsafe(64 * 32, ItemList.Circuit_Chip_Biocell.get(1));
         // Platline
         CORE.RA.addQuantumTransformerRecipe(
                 new ItemStack[] {

--- a/src/main/java/gtPlusPlus/xmod/gregtech/loaders/recipe/RecipeLoader_ChemicalSkips.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/loaders/recipe/RecipeLoader_ChemicalSkips.java
@@ -7,6 +7,7 @@ import com.github.technus.tectech.thing.block.QuantumGlassBlock;
 import gregtech.api.enums.*;
 import gregtech.api.util.GT_ModHandler;
 import gregtech.api.util.GT_OreDictUnificator;
+import gregtech.api.util.GT_Utility;
 import gregtech.common.items.CombType;
 import gregtech.loaders.misc.GT_Bees;
 import gtPlusPlus.core.item.chemistry.GenericChem;
@@ -43,6 +44,8 @@ public class RecipeLoader_ChemicalSkips {
     // HSS-G for Tier 2, HSS-S for Tier 3 and HSS-E for Tier 4)
 
     private static void quantumTransformerRecipes() {
+        ItemStack stemcells = GT_Utility.copyAmountUnsafe(64 * 32, ItemList.Circuit_Chip_Stemcell.get(1));
+        ItemStack biocells = GT_Utility.copyAmountUnsafe(64 *32, ItemList.Circuit_Chip_Biocell.get(1));
         // Platline
         CORE.RA.addQuantumTransformerRecipe(
                 new ItemStack[] {
@@ -185,11 +188,30 @@ public class RecipeLoader_ChemicalSkips {
                     Materials.Cerium.getDust(64),
                     Materials.Gadolinium.getDust(64),
                     Materials.Samarium.getDust(64),
-                    GT_ModHandler.getModItem("bartworks", "gt.bwMetaGenerateddust", 64L, 11000), // Hafnium
+                    GT_ModHandler.getModItem("bartworks", "gt.bwMetaGenerateddust", 64L, 11002), // Hafnia
                     GT_ModHandler.getModItem("bartworks", "gt.bwMetaGenerateddust", 64L, 11007), // Zirconium
                     ItemList.SuperconductorComposite.get(1)
                 },
                 new int[] {1667, 1667, 1667, 1667, 1667, 1667},
+                20 * 20,
+                (int) GT_Values.VP[9],
+                2);
+
+        // Bastline
+        CORE.RA.addQuantumTransformerRecipe(
+                new ItemStack[] {
+                    Materials.Bastnasite.getDust(32), ItemUtils.getSimpleStack(GenericChem.mRareEarthGroupCatalyst, 0)
+                },
+                null,
+                null,
+                new ItemStack[] {
+                    Materials.Holmium.getDust(64),
+                    Materials.Cerium.getDust(64),
+                    Materials.Samarium.getDust(64),
+                    Materials.Gadolinium.getDust(64),
+                    Materials.Lanthanum.getDust(64)
+                },
+                new int[] {2000, 2000, 2000, 2000, 2000},
                 20 * 20,
                 (int) GT_Values.VP[9],
                 2);
@@ -207,10 +229,10 @@ public class RecipeLoader_ChemicalSkips {
                     Materials.GrowthMediumRaw.getFluid(1000 * 1024),
                     Materials.GrowthMediumSterilized.getFluid(1000 * 512)
                 },
-                new ItemStack[] {ItemList.Circuit_Chip_Stemcell.get(64)},
+                new ItemStack[] {stemcells},
                 new int[] {3333, 3333, 3333},
                 20 * 20,
-                (int) GT_Values.VP[11],
+                (int) GT_Values.VP[10],
                 3);
 
         // Lategame Plastics (Missing Radox Polymer and Heavy Radox)
@@ -265,10 +287,10 @@ public class RecipeLoader_ChemicalSkips {
                     Materials.BioMediumSterilized.getFluid(1000 * 256),
                     Materials.BioMediumRaw.getFluid(1000 * 512)
                 },
-                new ItemStack[] {ItemList.Circuit_Chip_Biocell.get(64)},
+                new ItemStack[] {biocells},
                 new int[] {2500, 2500, 2500, 2500},
                 20 * 20,
-                (int) GT_Values.VP[10],
+                (int) GT_Values.VP[11],
                 4);
     }
 


### PR DESCRIPTION
With some experience now using the recipes, the ones for stem cells and bio cells were not good enough in some of their outputs making said outputs worthless to their other methods. With this change they will be able to output more per recipe and make them worthwhile to have a focus on.

Adding bastline to skipped lines.

Change out hafnium with hafnia as hafnia has more uses currently.

Fixes a bug with the force field render having holes inside of it