### PR TITLE
Add a Null Check to fix server crash

### DIFF
--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/mega/GregTechMetaTileEntity_MegaAlloyBlastSmelter.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/mega/GregTechMetaTileEntity_MegaAlloyBlastSmelter.java
@@ -458,7 +458,7 @@ public class GregTechMetaTileEntity_MegaAlloyBlastSmelter
 
     public double getCoilDiscount(HeatingCoilLevel lvl) {
         // Since there are only 14 tiers (starting from 0), this is what the function is.
-        double unRounded = lvl.getTier() / 130.0D;
+        double unRounded = (lvl != null ? lvl.getTier() : 0) / 130.0D;
         double rounded = Math.floor(unRounded * 1000) / 1000;
 
         return Math.max(0, rounded);


### PR DESCRIPTION
This is to fix a crash when a sensor card is placed in a `IC2NCAdvancedInfoPanel`

See crash report for more details.  https://pastebin.com/gBJEyjW7

We were able to narrow it down to the sensor card and removing the sensor card via nbtexplorer fixed the crash, however we shouldn't have had to do that.