### PR TITLE
add a line in tricorder to say the mode of the multi machine

### DIFF
--- a/src/main/java/gtPlusPlus/xmod/gregtech/api/metatileentity/implementations/base/GregtechMeta_MultiBlockBase.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/api/metatileentity/implementations/base/GregtechMeta_MultiBlockBase.java
@@ -182,7 +182,6 @@ public abstract class GregtechMeta_MultiBlockBase<T extends GT_MetaTileEntity_En
     @Override
     public String[] getInfoData() {
         ArrayList<String> mInfo = new ArrayList<>();
-        // try {
         if (!this.getMetaName().equals("")) {
             mInfo.add(this.getMetaName());
         }
@@ -283,10 +282,6 @@ public abstract class GregtechMeta_MultiBlockBase<T extends GT_MetaTileEntity_En
 
         String[] mInfo2 = mInfo.toArray(new String[mInfo.size()]);
         return mInfo2;
-        // } catch (Throwable t) {
-        //    t.printStackTrace();
-        // }
-        // return new String[] {};
     }
 
     public int getPollutionReductionForAllMufflers() {

--- a/src/main/java/gtPlusPlus/xmod/gregtech/api/metatileentity/implementations/base/GregtechMeta_MultiBlockBase.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/api/metatileentity/implementations/base/GregtechMeta_MultiBlockBase.java
@@ -180,9 +180,9 @@ public abstract class GregtechMeta_MultiBlockBase<T extends GT_MetaTileEntity_En
     }
 
     @Override
-    public final String[] getInfoData() {
+    public String[] getInfoData() {
         ArrayList<String> mInfo = new ArrayList<>();
-        try {
+        //try {
             if (!this.getMetaName().equals("")) {
                 mInfo.add(this.getMetaName());
             }
@@ -284,10 +284,10 @@ public abstract class GregtechMeta_MultiBlockBase<T extends GT_MetaTileEntity_En
 
             String[] mInfo2 = mInfo.toArray(new String[mInfo.size()]);
             return mInfo2;
-        } catch (Throwable t) {
-            t.printStackTrace();
-        }
-        return new String[] {};
+        //} catch (Throwable t) {
+        //    t.printStackTrace();
+        //}
+        //return new String[] {};
     }
 
     public int getPollutionReductionForAllMufflers() {

--- a/src/main/java/gtPlusPlus/xmod/gregtech/api/metatileentity/implementations/base/GregtechMeta_MultiBlockBase.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/api/metatileentity/implementations/base/GregtechMeta_MultiBlockBase.java
@@ -182,112 +182,111 @@ public abstract class GregtechMeta_MultiBlockBase<T extends GT_MetaTileEntity_En
     @Override
     public String[] getInfoData() {
         ArrayList<String> mInfo = new ArrayList<>();
-        //try {
-            if (!this.getMetaName().equals("")) {
-                mInfo.add(this.getMetaName());
+        // try {
+        if (!this.getMetaName().equals("")) {
+            mInfo.add(this.getMetaName());
+        }
+
+        String[] extra = getExtraInfoData();
+
+        if (extra == null) {
+            extra = new String[0];
+        }
+        if (extra.length > 0) {
+            for (String s : extra) {
+                mInfo.add(s);
             }
+        }
 
-            String[] extra = getExtraInfoData();
+        long seconds = (this.mTotalRunTime / 20);
+        int weeks = (int) (TimeUnit.SECONDS.toDays(seconds) / 7);
+        int days = (int) (TimeUnit.SECONDS.toDays(seconds) - 7 * weeks);
+        long hours = TimeUnit.SECONDS.toHours(seconds) - TimeUnit.DAYS.toHours(days) - TimeUnit.DAYS.toHours(7 * weeks);
+        long minutes = TimeUnit.SECONDS.toMinutes(seconds) - (TimeUnit.SECONDS.toHours(seconds) * 60);
+        long second = TimeUnit.SECONDS.toSeconds(seconds) - (TimeUnit.SECONDS.toMinutes(seconds) * 60);
 
-            if (extra == null) {
-                extra = new String[0];
-            }
-            if (extra.length > 0) {
-                for (String s : extra) {
-                    mInfo.add(s);
-                }
-            }
+        mInfo.add(getMachineTooltip());
 
-            long seconds = (this.mTotalRunTime / 20);
-            int weeks = (int) (TimeUnit.SECONDS.toDays(seconds) / 7);
-            int days = (int) (TimeUnit.SECONDS.toDays(seconds) - 7 * weeks);
-            long hours =
-                    TimeUnit.SECONDS.toHours(seconds) - TimeUnit.DAYS.toHours(days) - TimeUnit.DAYS.toHours(7 * weeks);
-            long minutes = TimeUnit.SECONDS.toMinutes(seconds) - (TimeUnit.SECONDS.toHours(seconds) * 60);
-            long second = TimeUnit.SECONDS.toSeconds(seconds) - (TimeUnit.SECONDS.toMinutes(seconds) * 60);
+        // Lets borrow the GTNH handling
 
-            mInfo.add(getMachineTooltip());
+        mInfo.add(StatCollector.translateToLocal("GTPP.multiblock.progress") + ": " + EnumChatFormatting.GREEN
+                + Integer.toString(mProgresstime / 20) + EnumChatFormatting.RESET + " s / "
+                + EnumChatFormatting.YELLOW
+                + Integer.toString(mMaxProgresstime / 20) + EnumChatFormatting.RESET + " s");
 
-            // Lets borrow the GTNH handling
+        if (!this.mAllEnergyHatches.isEmpty()) {
+            long storedEnergy = getStoredEnergyInAllEnergyHatches();
+            long maxEnergy = getMaxEnergyStorageOfAllEnergyHatches();
+            mInfo.add(StatCollector.translateToLocal("GTPP.multiblock.energy") + ":");
+            mInfo.add(StatCollector.translateToLocal("" + EnumChatFormatting.GREEN + Long.toString(storedEnergy)
+                    + EnumChatFormatting.RESET + " EU / " + EnumChatFormatting.YELLOW + Long.toString(maxEnergy)
+                    + EnumChatFormatting.RESET + " EU"));
 
-            mInfo.add(StatCollector.translateToLocal("GTPP.multiblock.progress") + ": " + EnumChatFormatting.GREEN
-                    + Integer.toString(mProgresstime / 20) + EnumChatFormatting.RESET + " s / "
-                    + EnumChatFormatting.YELLOW
-                    + Integer.toString(mMaxProgresstime / 20) + EnumChatFormatting.RESET + " s");
+            mInfo.add(StatCollector.translateToLocal("GTPP.multiblock.mei") + ":");
+            mInfo.add(StatCollector.translateToLocal("" + EnumChatFormatting.YELLOW
+                    + Long.toString(getMaxInputVoltage()) + EnumChatFormatting.RESET + " EU/t(*2A) "
+                    + StatCollector.translateToLocal("GTPP.machines.tier") + ": " + EnumChatFormatting.YELLOW
+                    + GT_Values.VN[GT_Utility.getTier(getMaxInputVoltage())] + EnumChatFormatting.RESET));
+            ;
+        }
+        if (!this.mAllDynamoHatches.isEmpty()) {
+            long storedEnergy = getStoredEnergyInAllDynamoHatches();
+            long maxEnergy = getMaxEnergyStorageOfAllDynamoHatches();
+            mInfo.add(StatCollector.translateToLocal("GTPP.multiblock.energy") + " In Dynamos:");
+            mInfo.add(StatCollector.translateToLocal("" + EnumChatFormatting.GREEN + Long.toString(storedEnergy)
+                    + EnumChatFormatting.RESET + " EU / " + EnumChatFormatting.YELLOW + Long.toString(maxEnergy)
+                    + EnumChatFormatting.RESET + " EU"));
+        }
 
-            if (!this.mAllEnergyHatches.isEmpty()) {
-                long storedEnergy = getStoredEnergyInAllEnergyHatches();
-                long maxEnergy = getMaxEnergyStorageOfAllEnergyHatches();
-                mInfo.add(StatCollector.translateToLocal("GTPP.multiblock.energy") + ":");
-                mInfo.add(StatCollector.translateToLocal("" + EnumChatFormatting.GREEN + Long.toString(storedEnergy)
-                        + EnumChatFormatting.RESET + " EU / " + EnumChatFormatting.YELLOW + Long.toString(maxEnergy)
-                        + EnumChatFormatting.RESET + " EU"));
+        if (-mEUt > 0) {
+            mInfo.add(StatCollector.translateToLocal("GTPP.multiblock.usage") + ":");
+            mInfo.add(StatCollector.translateToLocal(
+                    "" + EnumChatFormatting.RED + Integer.toString(-mEUt) + EnumChatFormatting.RESET + " EU/t"));
+        } else {
+            mInfo.add(StatCollector.translateToLocal("GTPP.multiblock.generation") + ":");
+            mInfo.add(StatCollector.translateToLocal(
+                    "" + EnumChatFormatting.GREEN + Integer.toString(mEUt) + EnumChatFormatting.RESET + " EU/t"));
+        }
 
-                mInfo.add(StatCollector.translateToLocal("GTPP.multiblock.mei") + ":");
-                mInfo.add(StatCollector.translateToLocal("" + EnumChatFormatting.YELLOW
-                        + Long.toString(getMaxInputVoltage()) + EnumChatFormatting.RESET + " EU/t(*2A) "
-                        + StatCollector.translateToLocal("GTPP.machines.tier") + ": " + EnumChatFormatting.YELLOW
-                        + GT_Values.VN[GT_Utility.getTier(getMaxInputVoltage())] + EnumChatFormatting.RESET));
-                ;
-            }
-            if (!this.mAllDynamoHatches.isEmpty()) {
-                long storedEnergy = getStoredEnergyInAllDynamoHatches();
-                long maxEnergy = getMaxEnergyStorageOfAllDynamoHatches();
-                mInfo.add(StatCollector.translateToLocal("GTPP.multiblock.energy") + " In Dynamos:");
-                mInfo.add(StatCollector.translateToLocal("" + EnumChatFormatting.GREEN + Long.toString(storedEnergy)
-                        + EnumChatFormatting.RESET + " EU / " + EnumChatFormatting.YELLOW + Long.toString(maxEnergy)
-                        + EnumChatFormatting.RESET + " EU"));
-            }
+        mInfo.add(StatCollector.translateToLocal("GTPP.multiblock.problems") + ": " + EnumChatFormatting.RED
+                + (getIdealStatus() - getRepairStatus()) + EnumChatFormatting.RESET + " "
+                + StatCollector.translateToLocal("GTPP.multiblock.efficiency") + ": " + EnumChatFormatting.YELLOW
+                + Float.toString(mEfficiency / 100.0F) + EnumChatFormatting.RESET + " %");
 
-            if (-mEUt > 0) {
-                mInfo.add(StatCollector.translateToLocal("GTPP.multiblock.usage") + ":");
-                mInfo.add(StatCollector.translateToLocal(
-                        "" + EnumChatFormatting.RED + Integer.toString(-mEUt) + EnumChatFormatting.RESET + " EU/t"));
-            } else {
-                mInfo.add(StatCollector.translateToLocal("GTPP.multiblock.generation") + ":");
-                mInfo.add(StatCollector.translateToLocal(
-                        "" + EnumChatFormatting.GREEN + Integer.toString(mEUt) + EnumChatFormatting.RESET + " EU/t"));
-            }
+        if (this.getPollutionPerSecond(null) > 0) {
+            int mPollutionReduction = getPollutionReductionForAllMufflers();
+            mInfo.add(StatCollector.translateToLocal("GTPP.multiblock.pollution") + ": " + EnumChatFormatting.RED
+                    + this.getPollutionPerSecond(null) + EnumChatFormatting.RESET + "/sec");
+            mInfo.add(StatCollector.translateToLocal("GTPP.multiblock.pollutionreduced") + ": "
+                    + EnumChatFormatting.GREEN + mPollutionReduction + EnumChatFormatting.RESET + " %");
+        }
 
-            mInfo.add(StatCollector.translateToLocal("GTPP.multiblock.problems") + ": " + EnumChatFormatting.RED
-                    + (getIdealStatus() - getRepairStatus()) + EnumChatFormatting.RESET + " "
-                    + StatCollector.translateToLocal("GTPP.multiblock.efficiency") + ": " + EnumChatFormatting.YELLOW
-                    + Float.toString(mEfficiency / 100.0F) + EnumChatFormatting.RESET + " %");
+        if (this.mControlCoreBus.size() > 0) {
+            int tTier = this.getControlCoreTier();
+            mInfo.add(StatCollector.translateToLocal("GTPP.CC.machinetier") + ": " + EnumChatFormatting.GREEN + tTier
+                    + EnumChatFormatting.RESET);
+        }
 
-            if (this.getPollutionPerSecond(null) > 0) {
-                int mPollutionReduction = getPollutionReductionForAllMufflers();
-                mInfo.add(StatCollector.translateToLocal("GTPP.multiblock.pollution") + ": " + EnumChatFormatting.RED
-                        + this.getPollutionPerSecond(null) + EnumChatFormatting.RESET + "/sec");
-                mInfo.add(StatCollector.translateToLocal("GTPP.multiblock.pollutionreduced") + ": "
-                        + EnumChatFormatting.GREEN + mPollutionReduction + EnumChatFormatting.RESET + " %");
-            }
+        mInfo.add(StatCollector.translateToLocal("GTPP.CC.discount") + ": " + EnumChatFormatting.GREEN
+                + (getEuDiscountForParallelism()) + EnumChatFormatting.RESET + "%");
 
-            if (this.mControlCoreBus.size() > 0) {
-                int tTier = this.getControlCoreTier();
-                mInfo.add(StatCollector.translateToLocal("GTPP.CC.machinetier") + ": " + EnumChatFormatting.GREEN
-                        + tTier + EnumChatFormatting.RESET);
-            }
+        mInfo.add(StatCollector.translateToLocal("GTPP.CC.parallel") + ": " + EnumChatFormatting.GREEN
+                + (getMaxParallelRecipes()) + EnumChatFormatting.RESET);
 
-            mInfo.add(StatCollector.translateToLocal("GTPP.CC.discount") + ": " + EnumChatFormatting.GREEN
-                    + (getEuDiscountForParallelism()) + EnumChatFormatting.RESET + "%");
+        mInfo.add("Total Time Since Built: " + EnumChatFormatting.DARK_GREEN + Integer.toString(weeks)
+                + EnumChatFormatting.RESET + " Weeks, " + EnumChatFormatting.DARK_GREEN + Integer.toString(days)
+                + EnumChatFormatting.RESET + " Days, ");
+        mInfo.add(EnumChatFormatting.DARK_GREEN + Long.toString(hours) + EnumChatFormatting.RESET + " Hours, "
+                + EnumChatFormatting.DARK_GREEN + Long.toString(minutes) + EnumChatFormatting.RESET + " Minutes, "
+                + EnumChatFormatting.DARK_GREEN + Long.toString(second) + EnumChatFormatting.RESET + " Seconds.");
+        mInfo.add("Total Time in ticks: " + EnumChatFormatting.DARK_GREEN + Long.toString(this.mTotalRunTime));
 
-            mInfo.add(StatCollector.translateToLocal("GTPP.CC.parallel") + ": " + EnumChatFormatting.GREEN
-                    + (getMaxParallelRecipes()) + EnumChatFormatting.RESET);
-
-            mInfo.add("Total Time Since Built: " + EnumChatFormatting.DARK_GREEN + Integer.toString(weeks)
-                    + EnumChatFormatting.RESET + " Weeks, " + EnumChatFormatting.DARK_GREEN + Integer.toString(days)
-                    + EnumChatFormatting.RESET + " Days, ");
-            mInfo.add(EnumChatFormatting.DARK_GREEN + Long.toString(hours) + EnumChatFormatting.RESET + " Hours, "
-                    + EnumChatFormatting.DARK_GREEN + Long.toString(minutes) + EnumChatFormatting.RESET + " Minutes, "
-                    + EnumChatFormatting.DARK_GREEN + Long.toString(second) + EnumChatFormatting.RESET + " Seconds.");
-            mInfo.add("Total Time in ticks: " + EnumChatFormatting.DARK_GREEN + Long.toString(this.mTotalRunTime));
-
-            String[] mInfo2 = mInfo.toArray(new String[mInfo.size()]);
-            return mInfo2;
-        //} catch (Throwable t) {
+        String[] mInfo2 = mInfo.toArray(new String[mInfo.size()]);
+        return mInfo2;
+        // } catch (Throwable t) {
         //    t.printStackTrace();
-        //}
-        //return new String[] {};
+        // }
+        // return new String[] {};
     }
 
     public int getPollutionReductionForAllMufflers() {

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/GregtechMetaTileEntity_IndustrialMultiMachine.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/GregtechMetaTileEntity_IndustrialMultiMachine.java
@@ -26,11 +26,13 @@ import gtPlusPlus.core.util.minecraft.PlayerUtils;
 import gtPlusPlus.xmod.gregtech.api.metatileentity.implementations.base.GregtechMeta_MultiBlockBase;
 import gtPlusPlus.xmod.gregtech.common.blocks.textures.TexturesGtBlock;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.EnumChatFormatting;
+import net.minecraft.util.StatCollector;
 import net.minecraftforge.fluids.FluidStack;
 import org.apache.commons.lang3.ArrayUtils;
 
@@ -501,6 +503,22 @@ public class GregtechMetaTileEntity_IndustrialMultiMachine
                 (mInternalMode == 0 ? "Metal" : mInternalMode == 1 ? "Fluid" : mInternalMode == 2 ? "Misc." : "null");
         PlayerUtils.messagePlayer(aPlayer, "Multi-Machine is now in " + mModeString + " mode.");
         mLastRecipe = null;
+    }
+
+    @Override
+    public String[] getInfoData(){
+        String[] data = super.getInfoData();
+        ArrayList<String> mInfo = new ArrayList<>(Arrays.asList(data));
+        String mode;
+        if (mInternalMode == 0) {
+            mode = StatCollector.translateToLocal("GTPP.multiblock.multimachine.metal");
+        } else if (mInternalMode == 1) {
+            mode = StatCollector.translateToLocal("GTPP.multiblock.multimachine.fluid");
+        } else {
+            mode = StatCollector.translateToLocal("GTPP.multiblock.multimachine.misc");
+        }
+        mInfo.add(mode);
+        return mInfo.toArray(new String[mInfo.size()]);
     }
 
     @Override

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/GregtechMetaTileEntity_IndustrialMultiMachine.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/GregtechMetaTileEntity_IndustrialMultiMachine.java
@@ -506,7 +506,7 @@ public class GregtechMetaTileEntity_IndustrialMultiMachine
     }
 
     @Override
-    public String[] getInfoData(){
+    public String[] getInfoData() {
         String[] data = super.getInfoData();
         ArrayList<String> mInfo = new ArrayList<>(Arrays.asList(data));
         String mode;

--- a/src/main/resources/assets/gregtech/lang/en_US.lang
+++ b/src/main/resources/assets/gregtech/lang/en_US.lang
@@ -18,8 +18,9 @@ GTPP.multiblock.usage=Probably uses
 GTPP.multiblock.generation=Probably generates
 GTPP.multiblock.specialvalue=Special Value
 GTPP.multiblock.duration=Duration
-
-
+GTPP.multiblock.multimachine.metal=Metal Mode. Does compressor (circuit 20), lathe (circuit 21) and electromagnetic polarizer (circuit 22).
+GTPP.multiblock.multimachine.fluid=Fluid Mode. Does fermenter (circuit 20), fluid extractor (circuit 21) and extractor (circuit 22).
+GTPP.multiblock.multimachine.misc=Metal Mode. Does precision laser engraver (circuit 20), autoclave (circuit 21) and fluid solidifier (circuit 22).
 
 GTPP.CC.machinetier=Control Core Tier
 GTPP.CC.discount=EU Discount


### PR DESCRIPTION
this is handy for those like me who have a non neglectible amount of Large Processing Factories and who forgot in what mode they were.

Now there is a line like this: 
![image](https://user-images.githubusercontent.com/12850933/210444486-51bb548a-f5e4-4b92-9171-b65685cc8715.png)
