### PR TITLE
Decreased minimum wiremill casings

### DIFF
--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/GregtechMetaTileEntity_IndustrialWireMill.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/GregtechMetaTileEntity_IndustrialWireMill.java
@@ -70,7 +70,7 @@ public class GregtechMetaTileEntity_IndustrialWireMill
                 .addSeparator()
                 .beginStructureBlock(3, 3, 5, true)
                 .addController("Front Center")
-                .addCasingInfo("Wire Factory Casings", 32)
+                .addCasingInfo("Wire Factory Casings", 20)
                 .addInputBus("Any Casing", 1)
                 .addOutputBus("Any Casing", 1)
                 .addEnergyHatch("Any Casing", 1)
@@ -116,7 +116,7 @@ public class GregtechMetaTileEntity_IndustrialWireMill
     @Override
     public boolean checkMachine(IGregTechTileEntity aBaseMetaTileEntity, ItemStack aStack) {
         mCasing = 0;
-        return checkPiece(mName, 1, 1, 0) && mCasing >= 32 && checkHatch();
+        return checkPiece(mName, 1, 1, 0) && mCasing >= 20 && checkHatch();
     }
 
     @Override


### PR DESCRIPTION
Decreased minimum wiremill casings from 32 to 20
With this amount you can insert all needed circuits into one wiremill, if you dont need to make two for increasing speed.