### PR TITLE
Decreased minimum Mixer casings

### DIFF
--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/GregtechMetaTileEntity_IndustrialMixer.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/GregtechMetaTileEntity_IndustrialMixer.java
@@ -89,7 +89,7 @@ public class GregtechMetaTileEntity_IndustrialMixer
                 .addSeparator()
                 .beginStructureBlock(3, 4, 3, false)
                 .addController("Second Layer Center")
-                .addCasingInfo(mCasingName, 16)
+                .addCasingInfo(mCasingName, 6)
                 .addCasingInfo(mCasingName2, 2)
                 .addInputBus("Any Casing", 1)
                 .addOutputBus("Any Casing", 1)
@@ -140,7 +140,7 @@ public class GregtechMetaTileEntity_IndustrialMixer
     @Override
     public boolean checkMachine(IGregTechTileEntity aBaseMetaTileEntity, ItemStack aStack) {
         mCasing = 0;
-        return checkPiece(mName, 1, 2, 0) && mCasing >= 16 && checkHatch();
+        return checkPiece(mName, 1, 2, 0) && mCasing >= 6 && checkHatch();
     }
 
     @Override


### PR DESCRIPTION
With this change you can put all needed circuits, fluids into one mixer, if you dont need to build two 