### PR TITLE
Add batch mode to gt++ multis

### DIFF
--- a/src/main/java/gtPlusPlus/xmod/gregtech/api/metatileentity/implementations/base/GregtechMeta_MultiBlockBase.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/api/metatileentity/implementations/base/GregtechMeta_MultiBlockBase.java
@@ -170,7 +170,7 @@ public abstract class GregtechMeta_MultiBlockBase<T extends GT_MetaTileEntity_Ex
     }
 
     protected float batchMultiplier = 1.0f;
-    protected int maxBatchSize = 128;
+    protected static final int MAX_BATCH_SIZE = 128;
 
     public abstract String getMachineType();
 
@@ -973,7 +973,7 @@ public abstract class GregtechMeta_MultiBlockBase<T extends GT_MetaTileEntity_Ex
         if (mUseMultiparallelMode) {
             int extraParallelRecipes = 0;
             for (;
-                    extraParallelRecipes + parallelRecipes < aMaxParallelRecipes * maxBatchSize;
+                    extraParallelRecipes + parallelRecipes < aMaxParallelRecipes * MAX_BATCH_SIZE;
                     extraParallelRecipes++) {
                 if (!tRecipe.isRecipeInputEqual(true, aFluidInputs, aItemInputs)) {
                     break;
@@ -1021,8 +1021,8 @@ public abstract class GregtechMeta_MultiBlockBase<T extends GT_MetaTileEntity_Ex
 
         this.mMaxProgresstime = Math.max(1, this.mMaxProgresstime);
 
-        if (mUseMultiparallelMode && mMaxProgresstime <= maxBatchSize / 2) {
-            mMaxProgresstime = maxBatchSize / 2;
+        if (mUseMultiparallelMode && mMaxProgresstime <= MAX_BATCH_SIZE) {
+            mMaxProgresstime = MAX_BATCH_SIZE;
         }
 
         // Collect fluid outputs

--- a/src/main/java/gtPlusPlus/xmod/gregtech/api/metatileentity/implementations/base/GregtechMeta_MultiBlockBase.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/api/metatileentity/implementations/base/GregtechMeta_MultiBlockBase.java
@@ -941,7 +941,6 @@ public abstract class GregtechMeta_MultiBlockBase<T extends GT_MetaTileEntity_Ex
             return false;
         }
 
-
         // EU discount
         float tRecipeEUt = (tRecipe.mEUt * aEUPercent) / 100.0f;
         float tTotalEUt = 0.0f;
@@ -980,7 +979,6 @@ public abstract class GregtechMeta_MultiBlockBase<T extends GT_MetaTileEntity_Ex
             parallelRecipes += extraParallelRecipes;
         }
 
-
         // -- Try not to fail after this point - inputs have already been consumed! --
 
         // Convert speed bonus to duration multiplier
@@ -988,9 +986,9 @@ public abstract class GregtechMeta_MultiBlockBase<T extends GT_MetaTileEntity_Ex
         aSpeedBonusPercent = Math.max(-99, aSpeedBonusPercent);
         float tTimeFactor = 100.0f / (100.0f + aSpeedBonusPercent);
 
-if (mUseMultiparallelMode){
-    tTimeFactor *= batchMultiplier;
-}
+        if (mUseMultiparallelMode) {
+            tTimeFactor *= batchMultiplier;
+        }
         this.mMaxProgresstime = (int) (tRecipe.mDuration * tTimeFactor);
 
         this.lEUt = (long) Math.ceil(tTotalEUt);

--- a/src/main/java/gtPlusPlus/xmod/gregtech/api/metatileentity/implementations/base/GregtechMeta_MultiBlockBase.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/api/metatileentity/implementations/base/GregtechMeta_MultiBlockBase.java
@@ -941,6 +941,12 @@ public abstract class GregtechMeta_MultiBlockBase<T extends GT_MetaTileEntity_Ex
             return false;
         }
 
+        int batchMultiplier = 1;
+
+         if (mUseMultiparallelMode){
+             batchMultiplier = 128;
+         }
+
         // EU discount
         float tRecipeEUt = (tRecipe.mEUt * aEUPercent) / 100.0f;
         float tTotalEUt = 0.0f;
@@ -954,7 +960,7 @@ public abstract class GregtechMeta_MultiBlockBase<T extends GT_MetaTileEntity_Ex
         log("tRecipeEUt: " + tRecipeEUt);
         // Count recipes to do in parallel, consuming input items and fluids and considering input voltage limits
         for (; parallelRecipes < aMaxParallelRecipes && tTotalEUt < (tEnergy - tRecipeEUt); parallelRecipes++) {
-            if (!tRecipe.isRecipeInputEqual(true, aFluidInputs, aItemInputs)) {
+            if (!tRecipe.isRecipeInputEqual(true, false, batchMultiplier, aFluidInputs, aItemInputs)) {
                 log("Broke at " + parallelRecipes + ".");
                 break;
             }
@@ -973,12 +979,11 @@ public abstract class GregtechMeta_MultiBlockBase<T extends GT_MetaTileEntity_Ex
         // e.g. 100% speed bonus = 200% speed = 100%/200% = 50% recipe duration.
         aSpeedBonusPercent = Math.max(-99, aSpeedBonusPercent);
         float tTimeFactor = 100.0f / (100.0f + aSpeedBonusPercent);
-        if (mUseMultiparallelMode){
-            parallelRecipes *= 128;
-            tTimeFactor *= 128;
-        }
-        int batchMultiplier = 128;
 
+        if (mUseMultiparallelMode) {
+            tTimeFactor *= 128;
+            parallelRecipes *= 128;
+        }
         this.mMaxProgresstime = (int) (tRecipe.mDuration * tTimeFactor);
 
         this.lEUt = (long) Math.ceil(tTotalEUt);
@@ -2156,6 +2161,7 @@ public abstract class GregtechMeta_MultiBlockBase<T extends GT_MetaTileEntity_Ex
     public void saveNBTData(NBTTagCompound aNBT) {
         aNBT.setLong("mTotalRunTime", this.mTotalRunTime);
         aNBT.setBoolean("mVoidExcess", this.mVoidExcess);
+        aNBT.setBoolean("mUseMultiparallelMode", mUseMultiparallelMode);
         super.saveNBTData(aNBT);
     }
 
@@ -2163,6 +2169,7 @@ public abstract class GregtechMeta_MultiBlockBase<T extends GT_MetaTileEntity_Ex
     public void loadNBTData(NBTTagCompound aNBT) {
         this.mTotalRunTime = aNBT.getLong("mTotalRunTime");
         this.mVoidExcess = aNBT.getBoolean("mVoidExcess");
+        this.mUseMultiparallelMode = aNBT.getBoolean("mUseMultiparallelMode");
         super.loadNBTData(aNBT);
     }
 

--- a/src/main/java/gtPlusPlus/xmod/gregtech/api/metatileentity/implementations/base/GregtechMeta_MultiBlockBase.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/api/metatileentity/implementations/base/GregtechMeta_MultiBlockBase.java
@@ -943,9 +943,9 @@ public abstract class GregtechMeta_MultiBlockBase<T extends GT_MetaTileEntity_Ex
 
         int batchMultiplier = 1;
 
-         if (mUseMultiparallelMode){
-             batchMultiplier = 128;
-         }
+        if (mUseMultiparallelMode) {
+            batchMultiplier = 128;
+        }
 
         // EU discount
         float tRecipeEUt = (tRecipe.mEUt * aEUPercent) / 100.0f;
@@ -981,8 +981,8 @@ public abstract class GregtechMeta_MultiBlockBase<T extends GT_MetaTileEntity_Ex
         float tTimeFactor = 100.0f / (100.0f + aSpeedBonusPercent);
 
         if (mUseMultiparallelMode) {
-            tTimeFactor *= 128;
-            parallelRecipes *= 128;
+            tTimeFactor *= batchMultiplier;
+            parallelRecipes *= batchMultiplier;
         }
         this.mMaxProgresstime = (int) (tRecipe.mDuration * tTimeFactor);
 
@@ -1011,10 +1011,9 @@ public abstract class GregtechMeta_MultiBlockBase<T extends GT_MetaTileEntity_Ex
         }
 
         this.mMaxProgresstime = Math.max(1, this.mMaxProgresstime);
-        if (this.mMaxProgresstime <= batchMultiplier && mUseMultiparallelMode){
+        if (this.mMaxProgresstime <= batchMultiplier && mUseMultiparallelMode) {
             this.mMaxProgresstime = batchMultiplier;
         }
-
 
         // Collect fluid outputs
         FluidStack[] tOutputFluids = new FluidStack[tRecipe.mFluidOutputs.length];
@@ -2470,6 +2469,7 @@ public abstract class GregtechMeta_MultiBlockBase<T extends GT_MetaTileEntity_Ex
     }
 
     public boolean mUseMultiparallelMode = false;
+
     @Override
     public boolean onWireCutterRightClick(
             byte aSide, byte aWrenchingSide, EntityPlayer aPlayer, float aX, float aY, float aZ) {

--- a/src/main/java/gtPlusPlus/xmod/gregtech/api/metatileentity/implementations/base/GregtechMeta_MultiBlockBase.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/api/metatileentity/implementations/base/GregtechMeta_MultiBlockBase.java
@@ -973,6 +973,12 @@ public abstract class GregtechMeta_MultiBlockBase<T extends GT_MetaTileEntity_Ex
         // e.g. 100% speed bonus = 200% speed = 100%/200% = 50% recipe duration.
         aSpeedBonusPercent = Math.max(-99, aSpeedBonusPercent);
         float tTimeFactor = 100.0f / (100.0f + aSpeedBonusPercent);
+        if (mUseMultiparallelMode){
+            parallelRecipes *= 128;
+            tTimeFactor *= 128;
+        }
+        int batchMultiplier = 128;
+
         this.mMaxProgresstime = (int) (tRecipe.mDuration * tTimeFactor);
 
         this.lEUt = (long) Math.ceil(tTotalEUt);
@@ -1000,6 +1006,10 @@ public abstract class GregtechMeta_MultiBlockBase<T extends GT_MetaTileEntity_Ex
         }
 
         this.mMaxProgresstime = Math.max(1, this.mMaxProgresstime);
+        if (this.mMaxProgresstime <= batchMultiplier && mUseMultiparallelMode){
+            this.mMaxProgresstime = batchMultiplier;
+        }
+
 
         // Collect fluid outputs
         FluidStack[] tOutputFluids = new FluidStack[tRecipe.mFluidOutputs.length];
@@ -2449,6 +2459,22 @@ public abstract class GregtechMeta_MultiBlockBase<T extends GT_MetaTileEntity_Ex
         mVoidExcess = !mVoidExcess;
         aPlayer.addChatMessage(new ChatComponentTranslation(
                 mVoidExcess ? "interaction.voidexcess.enabled" : "interaction.voidexcess.disabled"));
+        return true;
+    }
+
+    public boolean mUseMultiparallelMode = false;
+    @Override
+    public boolean onWireCutterRightClick(
+            byte aSide, byte aWrenchingSide, EntityPlayer aPlayer, float aX, float aY, float aZ) {
+        if (aPlayer.isSneaking()) {
+            mUseMultiparallelMode = !mUseMultiparallelMode;
+            if (mUseMultiparallelMode) {
+                GT_Utility.sendChatToPlayer(aPlayer, StatCollector.translateToLocal("misc.BatchModeTextOn"));
+            } else {
+                GT_Utility.sendChatToPlayer(aPlayer, StatCollector.translateToLocal("misc.BatchModeTextOff"));
+            }
+            return true;
+        }
         return true;
     }
 

--- a/src/main/java/gtPlusPlus/xmod/gregtech/api/metatileentity/implementations/base/GregtechMeta_MultiBlockBase.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/api/metatileentity/implementations/base/GregtechMeta_MultiBlockBase.java
@@ -1022,8 +1022,9 @@ public abstract class GregtechMeta_MultiBlockBase<T extends GT_MetaTileEntity_Ex
         this.mMaxProgresstime = Math.max(1, this.mMaxProgresstime);
 
         if (mUseMultiparallelMode && mMaxProgresstime <= MAX_BATCH_SIZE) {
-            mMaxProgresstime = MAX_BATCH_SIZE;
+            mMaxProgresstime = (int) batchMultiplier;
         }
+
 
         // Collect fluid outputs
         FluidStack[] tOutputFluids = new FluidStack[tRecipe.mFluidOutputs.length];
@@ -2492,7 +2493,7 @@ public abstract class GregtechMeta_MultiBlockBase<T extends GT_MetaTileEntity_Ex
             }
             return true;
         }
-        return true;
+        return false;
     }
 
     public boolean isValidBlockForStructure(

--- a/src/main/java/gtPlusPlus/xmod/gregtech/api/metatileentity/implementations/base/GregtechMeta_MultiBlockBase.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/api/metatileentity/implementations/base/GregtechMeta_MultiBlockBase.java
@@ -1011,9 +1011,6 @@ public abstract class GregtechMeta_MultiBlockBase<T extends GT_MetaTileEntity_Ex
         }
 
         this.mMaxProgresstime = Math.max(1, this.mMaxProgresstime);
-        if (this.mMaxProgresstime <= batchMultiplier && mUseMultiparallelMode) {
-            this.mMaxProgresstime = batchMultiplier;
-        }
 
         // Collect fluid outputs
         FluidStack[] tOutputFluids = new FluidStack[tRecipe.mFluidOutputs.length];

--- a/src/main/java/gtPlusPlus/xmod/gregtech/api/metatileentity/implementations/base/GregtechMeta_MultiBlockBase.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/api/metatileentity/implementations/base/GregtechMeta_MultiBlockBase.java
@@ -990,9 +990,6 @@ public abstract class GregtechMeta_MultiBlockBase<T extends GT_MetaTileEntity_Ex
         aSpeedBonusPercent = Math.max(-99, aSpeedBonusPercent);
         float tTimeFactor = 100.0f / (100.0f + aSpeedBonusPercent);
 
-        if (mUseMultiparallelMode) {
-            tTimeFactor *= batchMultiplier;
-        }
         this.mMaxProgresstime = (int) (tRecipe.mDuration * tTimeFactor);
 
         this.lEUt = (long) Math.ceil(tTotalEUt);
@@ -1021,8 +1018,8 @@ public abstract class GregtechMeta_MultiBlockBase<T extends GT_MetaTileEntity_Ex
 
         this.mMaxProgresstime = Math.max(1, this.mMaxProgresstime);
 
-        if (mUseMultiparallelMode && mMaxProgresstime <= MAX_BATCH_SIZE) {
-            mMaxProgresstime = (int) batchMultiplier;
+        if (mUseMultiparallelMode) {
+            mMaxProgresstime = (int) Math.ceil(mMaxProgresstime * batchMultiplier);
         }
 
 

--- a/src/main/java/gtPlusPlus/xmod/gregtech/api/metatileentity/implementations/base/GregtechMeta_MultiBlockBase.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/api/metatileentity/implementations/base/GregtechMeta_MultiBlockBase.java
@@ -169,6 +169,9 @@ public abstract class GregtechMeta_MultiBlockBase<T extends GT_MetaTileEntity_Ex
         return this.mTotalRunTime;
     }
 
+    protected float batchMultiplier = 1.0f;
+    protected int maxBatchSize = 128;
+
     public abstract String getMachineType();
 
     public String getMachineTooltip() {
@@ -967,10 +970,11 @@ public abstract class GregtechMeta_MultiBlockBase<T extends GT_MetaTileEntity_Ex
             return false;
         }
 
-        float batchMultiplier = 1.0f;
         if (mUseMultiparallelMode) {
             int extraParallelRecipes = 0;
-            for (; extraParallelRecipes + parallelRecipes < aMaxParallelRecipes * 128; extraParallelRecipes++) {
+            for (;
+                    extraParallelRecipes + parallelRecipes < aMaxParallelRecipes * maxBatchSize;
+                    extraParallelRecipes++) {
                 if (!tRecipe.isRecipeInputEqual(true, aFluidInputs, aItemInputs)) {
                     break;
                 }
@@ -1016,6 +1020,10 @@ public abstract class GregtechMeta_MultiBlockBase<T extends GT_MetaTileEntity_Ex
         }
 
         this.mMaxProgresstime = Math.max(1, this.mMaxProgresstime);
+
+        if (mUseMultiparallelMode && mMaxProgresstime <= maxBatchSize / 2) {
+            mMaxProgresstime = maxBatchSize / 2;
+        }
 
         // Collect fluid outputs
         FluidStack[] tOutputFluids = new FluidStack[tRecipe.mFluidOutputs.length];
@@ -2470,7 +2478,7 @@ public abstract class GregtechMeta_MultiBlockBase<T extends GT_MetaTileEntity_Ex
         return true;
     }
 
-    public boolean mUseMultiparallelMode = false;
+    protected boolean mUseMultiparallelMode = false;
 
     @Override
     public boolean onWireCutterRightClick(

--- a/src/main/java/gtPlusPlus/xmod/gregtech/api/metatileentity/implementations/base/GregtechMeta_MultiBlockBase.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/api/metatileentity/implementations/base/GregtechMeta_MultiBlockBase.java
@@ -1022,7 +1022,6 @@ public abstract class GregtechMeta_MultiBlockBase<T extends GT_MetaTileEntity_Ex
             mMaxProgresstime = (int) Math.ceil(mMaxProgresstime * batchMultiplier);
         }
 
-
         // Collect fluid outputs
         FluidStack[] tOutputFluids = new FluidStack[tRecipe.mFluidOutputs.length];
         for (int h = 0; h < tRecipe.mFluidOutputs.length; h++) {

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/misc/GMTE_AmazonPackager.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/misc/GMTE_AmazonPackager.java
@@ -330,9 +330,6 @@ public class GMTE_AmazonPackager extends GregtechMeta_MultiBlockBase<GMTE_Amazon
         aSpeedBonusPercent = Math.max(-99, aSpeedBonusPercent);
         float tTimeFactor = 100.0f / (100.0f + aSpeedBonusPercent);
 
-        if (mUseMultiparallelMode) {
-            tTimeFactor *= batchMultiplier;
-        }
         this.mMaxProgresstime = (int) (tRecipe.mDuration * tTimeFactor);
         this.lEUt = (long) Math.ceil(tTotalEUt);
 
@@ -357,8 +354,8 @@ public class GMTE_AmazonPackager extends GregtechMeta_MultiBlockBase<GMTE_Amazon
 
         this.mMaxProgresstime = Math.max(1, this.mMaxProgresstime);
 
-        if (mUseMultiparallelMode && mMaxProgresstime <= MAX_BATCH_SIZE) {
-            mMaxProgresstime = (int) batchMultiplier;
+        if (mUseMultiparallelMode) {
+            mMaxProgresstime = (int) Math.ceil(mMaxProgresstime * batchMultiplier);
         }
 
         // Collect fluid outputs

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/misc/GMTE_AmazonPackager.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/misc/GMTE_AmazonPackager.java
@@ -358,7 +358,7 @@ public class GMTE_AmazonPackager extends GregtechMeta_MultiBlockBase<GMTE_Amazon
         this.mMaxProgresstime = Math.max(1, this.mMaxProgresstime);
 
         if (mUseMultiparallelMode && mMaxProgresstime <= MAX_BATCH_SIZE) {
-            mMaxProgresstime = MAX_BATCH_SIZE;
+            mMaxProgresstime = (int) batchMultiplier;
         }
 
         // Collect fluid outputs

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/misc/GMTE_AmazonPackager.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/misc/GMTE_AmazonPackager.java
@@ -310,10 +310,11 @@ public class GMTE_AmazonPackager extends GregtechMeta_MultiBlockBase<GMTE_Amazon
             return false;
         }
 
-        float batchMultiplier = 1.0f;
         if (mUseMultiparallelMode) {
             int extraParallelRecipes = 0;
-            for (; extraParallelRecipes + parallelRecipes < aMaxParallelRecipes * 128; extraParallelRecipes++) {
+            for (;
+                    extraParallelRecipes + parallelRecipes < aMaxParallelRecipes * maxBatchSize;
+                    extraParallelRecipes++) {
                 if (!tRecipe.isRecipeInputEqual(true, aFluidInputs, aItemInputs)) {
                     break;
                 }
@@ -355,6 +356,10 @@ public class GMTE_AmazonPackager extends GregtechMeta_MultiBlockBase<GMTE_Amazon
         }
 
         this.mMaxProgresstime = Math.max(1, this.mMaxProgresstime);
+
+        if (mUseMultiparallelMode && mMaxProgresstime <= maxBatchSize / 2) {
+            mMaxProgresstime = maxBatchSize / 2;
+        }
 
         // Collect fluid outputs
         FluidStack[] tOutputFluids = new FluidStack[tRecipe.mFluidOutputs.length];

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/misc/GMTE_AmazonPackager.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/misc/GMTE_AmazonPackager.java
@@ -313,7 +313,7 @@ public class GMTE_AmazonPackager extends GregtechMeta_MultiBlockBase<GMTE_Amazon
         if (mUseMultiparallelMode) {
             int extraParallelRecipes = 0;
             for (;
-                    extraParallelRecipes + parallelRecipes < aMaxParallelRecipes * maxBatchSize;
+                    extraParallelRecipes + parallelRecipes < aMaxParallelRecipes * MAX_BATCH_SIZE;
                     extraParallelRecipes++) {
                 if (!tRecipe.isRecipeInputEqual(true, aFluidInputs, aItemInputs)) {
                     break;
@@ -357,8 +357,8 @@ public class GMTE_AmazonPackager extends GregtechMeta_MultiBlockBase<GMTE_Amazon
 
         this.mMaxProgresstime = Math.max(1, this.mMaxProgresstime);
 
-        if (mUseMultiparallelMode && mMaxProgresstime <= maxBatchSize / 2) {
-            mMaxProgresstime = maxBatchSize / 2;
+        if (mUseMultiparallelMode && mMaxProgresstime <= MAX_BATCH_SIZE) {
+            mMaxProgresstime = MAX_BATCH_SIZE;
         }
 
         // Collect fluid outputs

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/GregtechMetaTileEntity_IndustrialMixer.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/GregtechMetaTileEntity_IndustrialMixer.java
@@ -233,8 +233,7 @@ public class GregtechMetaTileEntity_IndustrialMixer
     }
 
     @Override
-    public void onModeChangeByScrewdriver(
-            byte aSide, EntityPlayer aPlayer, float aX, float aY, float aZ) {
+    public void onModeChangeByScrewdriver(byte aSide, EntityPlayer aPlayer, float aX, float aY, float aZ) {
         isBussesSeparate = !isBussesSeparate;
         GT_Utility.sendChatToPlayer(
                 aPlayer, StatCollector.translateToLocal("GT5U.machines.separatebus") + " " + isBussesSeparate);

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/GregtechMetaTileEntity_IndustrialMixer.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/GregtechMetaTileEntity_IndustrialMixer.java
@@ -233,12 +233,11 @@ public class GregtechMetaTileEntity_IndustrialMixer
     }
 
     @Override
-    public boolean onWireCutterRightClick(
-            byte aSide, byte aWrenchingSide, EntityPlayer aPlayer, float aX, float aY, float aZ) {
+    public void onModeChangeByScrewdriver(
+            byte aSide, EntityPlayer aPlayer, float aX, float aY, float aZ) {
         isBussesSeparate = !isBussesSeparate;
         GT_Utility.sendChatToPlayer(
                 aPlayer, StatCollector.translateToLocal("GT5U.machines.separatebus") + " " + isBussesSeparate);
-        return true;
     }
 
     @Override

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/GregtechMetaTileEntity_IndustrialMultiMachine.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/GregtechMetaTileEntity_IndustrialMultiMachine.java
@@ -396,10 +396,11 @@ public class GregtechMetaTileEntity_IndustrialMultiMachine
             return false;
         }
 
-        float batchMultiplier = 1.0f;
         if (mUseMultiparallelMode) {
             int extraParallelRecipes = 0;
-            for (; extraParallelRecipes + parallelRecipes < aMaxParallelRecipes * 128; extraParallelRecipes++) {
+            for (;
+                    extraParallelRecipes + parallelRecipes < aMaxParallelRecipes * maxBatchSize;
+                    extraParallelRecipes++) {
                 if (!tRecipe.isRecipeInputEqual(true, aFluidInputs, aItemInputs)) {
                     break;
                 }
@@ -441,6 +442,10 @@ public class GregtechMetaTileEntity_IndustrialMultiMachine
         }
 
         this.mMaxProgresstime = Math.max(1, this.mMaxProgresstime);
+
+        if (mUseMultiparallelMode && mMaxProgresstime <= maxBatchSize / 2) {
+            mMaxProgresstime = maxBatchSize / 2;
+        }
 
         // Collect fluid outputs
         FluidStack[] tOutputFluids = new FluidStack[tRecipe.mFluidOutputs.length];

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/GregtechMetaTileEntity_IndustrialMultiMachine.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/GregtechMetaTileEntity_IndustrialMultiMachine.java
@@ -399,7 +399,7 @@ public class GregtechMetaTileEntity_IndustrialMultiMachine
         if (mUseMultiparallelMode) {
             int extraParallelRecipes = 0;
             for (;
-                    extraParallelRecipes + parallelRecipes < aMaxParallelRecipes * maxBatchSize;
+                    extraParallelRecipes + parallelRecipes < aMaxParallelRecipes * MAX_BATCH_SIZE;
                     extraParallelRecipes++) {
                 if (!tRecipe.isRecipeInputEqual(true, aFluidInputs, aItemInputs)) {
                     break;
@@ -443,8 +443,8 @@ public class GregtechMetaTileEntity_IndustrialMultiMachine
 
         this.mMaxProgresstime = Math.max(1, this.mMaxProgresstime);
 
-        if (mUseMultiparallelMode && mMaxProgresstime <= maxBatchSize / 2) {
-            mMaxProgresstime = maxBatchSize / 2;
+        if (mUseMultiparallelMode && mMaxProgresstime <= MAX_BATCH_SIZE) {
+            mMaxProgresstime = MAX_BATCH_SIZE;
         }
 
         // Collect fluid outputs

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/GregtechMetaTileEntity_IndustrialMultiMachine.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/GregtechMetaTileEntity_IndustrialMultiMachine.java
@@ -396,12 +396,28 @@ public class GregtechMetaTileEntity_IndustrialMultiMachine
             return false;
         }
 
+        float batchMultiplier = 1.0f;
+        if (mUseMultiparallelMode) {
+            int extraParallelRecipes = 0;
+            for (; extraParallelRecipes + parallelRecipes < aMaxParallelRecipes * 128; extraParallelRecipes++) {
+                if (!tRecipe.isRecipeInputEqual(true, aFluidInputs, aItemInputs)) {
+                    break;
+                }
+            }
+            batchMultiplier = 1.0f + (float) extraParallelRecipes / aMaxParallelRecipes;
+            parallelRecipes += extraParallelRecipes;
+        }
+
         // -- Try not to fail after this point - inputs have already been consumed! --
 
         // Convert speed bonus to duration multiplier
         // e.g. 100% speed bonus = 200% speed = 100%/200% = 50% recipe duration.
         aSpeedBonusPercent = Math.max(-99, aSpeedBonusPercent);
         float tTimeFactor = 100.0f / (100.0f + aSpeedBonusPercent);
+
+        if (mUseMultiparallelMode) {
+            tTimeFactor *= batchMultiplier;
+        }
         this.mMaxProgresstime = (int) (tRecipe.mDuration * tTimeFactor);
 
         this.lEUt = (long) Math.ceil(tTotalEUt);

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/GregtechMetaTileEntity_IndustrialMultiMachine.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/GregtechMetaTileEntity_IndustrialMultiMachine.java
@@ -416,9 +416,6 @@ public class GregtechMetaTileEntity_IndustrialMultiMachine
         aSpeedBonusPercent = Math.max(-99, aSpeedBonusPercent);
         float tTimeFactor = 100.0f / (100.0f + aSpeedBonusPercent);
 
-        if (mUseMultiparallelMode) {
-            tTimeFactor *= batchMultiplier;
-        }
         this.mMaxProgresstime = (int) (tRecipe.mDuration * tTimeFactor);
 
         this.lEUt = (long) Math.ceil(tTotalEUt);
@@ -443,8 +440,8 @@ public class GregtechMetaTileEntity_IndustrialMultiMachine
 
         this.mMaxProgresstime = Math.max(1, this.mMaxProgresstime);
 
-        if (mUseMultiparallelMode && mMaxProgresstime <= MAX_BATCH_SIZE) {
-            mMaxProgresstime = (int) batchMultiplier;
+        if (mUseMultiparallelMode) {
+            mMaxProgresstime = (int) Math.ceil(mMaxProgresstime * batchMultiplier);
         }
 
         // Collect fluid outputs

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/GregtechMetaTileEntity_IndustrialMultiMachine.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/GregtechMetaTileEntity_IndustrialMultiMachine.java
@@ -444,7 +444,7 @@ public class GregtechMetaTileEntity_IndustrialMultiMachine
         this.mMaxProgresstime = Math.max(1, this.mMaxProgresstime);
 
         if (mUseMultiparallelMode && mMaxProgresstime <= MAX_BATCH_SIZE) {
-            mMaxProgresstime = MAX_BATCH_SIZE;
+            mMaxProgresstime = (int) batchMultiplier;
         }
 
         // Collect fluid outputs

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/GregtechMTE_ElementalDuplicator.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/GregtechMTE_ElementalDuplicator.java
@@ -448,7 +448,7 @@ public class GregtechMTE_ElementalDuplicator extends GregtechMeta_MultiBlockBase
         if (mUseMultiparallelMode) {
             int extraParallelRecipes = 0;
             for (;
-                    extraParallelRecipes + parallelRecipes < aMaxParallelRecipes * maxBatchSize;
+                    extraParallelRecipes + parallelRecipes < aMaxParallelRecipes * MAX_BATCH_SIZE;
                     extraParallelRecipes++) {
                 if (!tRecipe.isRecipeInputEqual(true, aFluidInputs, aItemInputs)) {
                     break;
@@ -491,8 +491,8 @@ public class GregtechMTE_ElementalDuplicator extends GregtechMeta_MultiBlockBase
 
         this.mMaxProgresstime = Math.max(1, this.mMaxProgresstime);
 
-        if (mUseMultiparallelMode && mMaxProgresstime <= maxBatchSize / 2) {
-            mMaxProgresstime = maxBatchSize / 2;
+        if (mUseMultiparallelMode && mMaxProgresstime <= MAX_BATCH_SIZE) {
+            mMaxProgresstime = MAX_BATCH_SIZE;
         }
 
         // Collect fluid outputs

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/GregtechMTE_ElementalDuplicator.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/GregtechMTE_ElementalDuplicator.java
@@ -465,9 +465,6 @@ public class GregtechMTE_ElementalDuplicator extends GregtechMeta_MultiBlockBase
         aSpeedBonusPercent = Math.max(-99, aSpeedBonusPercent);
         float tTimeFactor = 100.0f / (100.0f + aSpeedBonusPercent);
 
-        if (mUseMultiparallelMode) {
-            tTimeFactor *= batchMultiplier;
-        }
         this.mMaxProgresstime = (int) (tRecipe.mDuration * tTimeFactor);
         this.lEUt = (long) Math.ceil(tTotalEUt);
 
@@ -491,8 +488,8 @@ public class GregtechMTE_ElementalDuplicator extends GregtechMeta_MultiBlockBase
 
         this.mMaxProgresstime = Math.max(1, this.mMaxProgresstime);
 
-        if (mUseMultiparallelMode && mMaxProgresstime <= MAX_BATCH_SIZE) {
-            mMaxProgresstime = (int) batchMultiplier;
+        if (mUseMultiparallelMode) {
+            mMaxProgresstime = (int) Math.ceil(mMaxProgresstime * batchMultiplier);
         }
 
         // Collect fluid outputs

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/GregtechMTE_ElementalDuplicator.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/GregtechMTE_ElementalDuplicator.java
@@ -445,10 +445,11 @@ public class GregtechMTE_ElementalDuplicator extends GregtechMeta_MultiBlockBase
             return false;
         }
 
-        float batchMultiplier = 1.0f;
         if (mUseMultiparallelMode) {
             int extraParallelRecipes = 0;
-            for (; extraParallelRecipes + parallelRecipes < aMaxParallelRecipes * 128; extraParallelRecipes++) {
+            for (;
+                    extraParallelRecipes + parallelRecipes < aMaxParallelRecipes * maxBatchSize;
+                    extraParallelRecipes++) {
                 if (!tRecipe.isRecipeInputEqual(true, aFluidInputs, aItemInputs)) {
                     break;
                 }
@@ -489,6 +490,10 @@ public class GregtechMTE_ElementalDuplicator extends GregtechMeta_MultiBlockBase
         }
 
         this.mMaxProgresstime = Math.max(1, this.mMaxProgresstime);
+
+        if (mUseMultiparallelMode && mMaxProgresstime <= maxBatchSize / 2) {
+            mMaxProgresstime = maxBatchSize / 2;
+        }
 
         // Collect fluid outputs
         FluidStack[] tOutputFluids = new FluidStack[tRecipe.mFluidOutputs.length];

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/GregtechMTE_ElementalDuplicator.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/GregtechMTE_ElementalDuplicator.java
@@ -492,7 +492,7 @@ public class GregtechMTE_ElementalDuplicator extends GregtechMeta_MultiBlockBase
         this.mMaxProgresstime = Math.max(1, this.mMaxProgresstime);
 
         if (mUseMultiparallelMode && mMaxProgresstime <= MAX_BATCH_SIZE) {
-            mMaxProgresstime = MAX_BATCH_SIZE;
+            mMaxProgresstime = (int) batchMultiplier;
         }
 
         // Collect fluid outputs

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/GregtechMTE_ElementalDuplicator.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/GregtechMTE_ElementalDuplicator.java
@@ -445,14 +445,29 @@ public class GregtechMTE_ElementalDuplicator extends GregtechMeta_MultiBlockBase
             return false;
         }
 
+        float batchMultiplier = 1.0f;
+        if (mUseMultiparallelMode) {
+            int extraParallelRecipes = 0;
+            for (; extraParallelRecipes + parallelRecipes < aMaxParallelRecipes * 128; extraParallelRecipes++) {
+                if (!tRecipe.isRecipeInputEqual(true, aFluidInputs, aItemInputs)) {
+                    break;
+                }
+            }
+            batchMultiplier = 1.0f + (float) extraParallelRecipes / aMaxParallelRecipes;
+            parallelRecipes += extraParallelRecipes;
+        }
+
         // -- Try not to fail after this point - inputs have already been consumed! --
 
         // Convert speed bonus to duration multiplier
         // e.g. 100% speed bonus = 200% speed = 100%/200% = 50% recipe duration.
         aSpeedBonusPercent = Math.max(-99, aSpeedBonusPercent);
         float tTimeFactor = 100.0f / (100.0f + aSpeedBonusPercent);
-        this.mMaxProgresstime = (int) (tRecipe.mDuration * tTimeFactor);
 
+        if (mUseMultiparallelMode) {
+            tTimeFactor *= batchMultiplier;
+        }
+        this.mMaxProgresstime = (int) (tRecipe.mDuration * tTimeFactor);
         this.lEUt = (long) Math.ceil(tTotalEUt);
 
         this.mEfficiency = (10000 - (getIdealStatus() - getRepairStatus()) * 1000);

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/GregtechMetaTileEntity_AlloyBlastSmelter.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/GregtechMetaTileEntity_AlloyBlastSmelter.java
@@ -296,8 +296,7 @@ public class GregtechMetaTileEntity_AlloyBlastSmelter
     }
 
     @Override
-    public void onModeChangeByScrewdriver(
-            byte aSide, EntityPlayer aPlayer, float aX, float aY, float aZ) {
+    public void onModeChangeByScrewdriver(byte aSide, EntityPlayer aPlayer, float aX, float aY, float aZ) {
         isBussesSeparate = !isBussesSeparate;
         GT_Utility.sendChatToPlayer(
                 aPlayer, StatCollector.translateToLocal("GT5U.machines.separatebus") + " " + isBussesSeparate);

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/GregtechMetaTileEntity_AlloyBlastSmelter.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/GregtechMetaTileEntity_AlloyBlastSmelter.java
@@ -296,12 +296,11 @@ public class GregtechMetaTileEntity_AlloyBlastSmelter
     }
 
     @Override
-    public boolean onWireCutterRightClick(
-            byte aSide, byte aWrenchingSide, EntityPlayer aPlayer, float aX, float aY, float aZ) {
+    public void onModeChangeByScrewdriver(
+            byte aSide, EntityPlayer aPlayer, float aX, float aY, float aZ) {
         isBussesSeparate = !isBussesSeparate;
         GT_Utility.sendChatToPlayer(
                 aPlayer, StatCollector.translateToLocal("GT5U.machines.separatebus") + " " + isBussesSeparate);
-        return true;
     }
 
     @Override

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/GregtechMetaTileEntity_MassFabricator.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/GregtechMetaTileEntity_MassFabricator.java
@@ -499,7 +499,7 @@ public class GregtechMetaTileEntity_MassFabricator
         if (mUseMultiparallelMode) {
             int extraParallelRecipes = 0;
             for (;
-                    extraParallelRecipes + parallelRecipes < aMaxParallelRecipes * maxBatchSize;
+                    extraParallelRecipes + parallelRecipes < aMaxParallelRecipes * MAX_BATCH_SIZE;
                     extraParallelRecipes++) {
                 if (!tRecipe.isRecipeInputEqual(true, aFluidInputs, aItemInputs)) {
                     break;
@@ -542,8 +542,8 @@ public class GregtechMetaTileEntity_MassFabricator
 
         this.mMaxProgresstime = Math.max(1, this.mMaxProgresstime);
 
-        if (mUseMultiparallelMode && mMaxProgresstime <= maxBatchSize / 2) {
-            mMaxProgresstime = maxBatchSize / 2;
+        if (mUseMultiparallelMode && mMaxProgresstime <= MAX_BATCH_SIZE) {
+            mMaxProgresstime = MAX_BATCH_SIZE;
         }
 
         // Collect fluid outputs

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/GregtechMetaTileEntity_MassFabricator.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/GregtechMetaTileEntity_MassFabricator.java
@@ -329,6 +329,19 @@ public class GregtechMetaTileEntity_MassFabricator
         }
         log("Broke at " + parallelRecipes + ".");
         if (parallelRecipes > 0) {
+
+            float batchMultiplier = 1.0f;
+            if (mUseMultiparallelMode) {
+                int extraParallelRecipes = 0;
+                for (; extraParallelRecipes + parallelRecipes < aMaxParallelRecipes * 128; extraParallelRecipes++) {
+                    if (!tRecipe.isRecipeInputEqual(true, aFluidInputs, aItemInputs)) {
+                        break;
+                    }
+                }
+                batchMultiplier = 1.0f + (float) extraParallelRecipes / aMaxParallelRecipes;
+                parallelRecipes += extraParallelRecipes;
+            }
+
             // -- Try not to fail after this point - inputs have already been
             // consumed! --
 
@@ -337,6 +350,9 @@ public class GregtechMetaTileEntity_MassFabricator
             // duration.
             aSpeedBonusPercent = Math.max(-99, aSpeedBonusPercent);
             float tTimeFactor = 100.0f / (100.0f + aSpeedBonusPercent);
+            if (mUseMultiparallelMode) {
+                tTimeFactor *= batchMultiplier;
+            }
             this.mMaxProgresstime = (int) (tRecipe.mDuration * tTimeFactor);
             this.lEUt = (long) Math.ceil(tTotalEUt);
             this.mEfficiency = (10000 - (getIdealStatus() - getRepairStatus()) * 1000);
@@ -480,12 +496,27 @@ public class GregtechMetaTileEntity_MassFabricator
             return false;
         }
 
+        float batchMultiplier = 1.0f;
+        if (mUseMultiparallelMode) {
+            int extraParallelRecipes = 0;
+            for (; extraParallelRecipes + parallelRecipes < aMaxParallelRecipes * 128; extraParallelRecipes++) {
+                if (!tRecipe.isRecipeInputEqual(true, aFluidInputs, aItemInputs)) {
+                    break;
+                }
+            }
+            batchMultiplier = 1.0f + (float) extraParallelRecipes / aMaxParallelRecipes;
+            parallelRecipes += extraParallelRecipes;
+        }
+
         // -- Try not to fail after this point - inputs have already been consumed! --
 
         // Convert speed bonus to duration multiplier
         // e.g. 100% speed bonus = 200% speed = 100%/200% = 50% recipe duration.
         aSpeedBonusPercent = Math.max(-99, aSpeedBonusPercent);
         float tTimeFactor = 100.0f / (100.0f + aSpeedBonusPercent);
+        if (mUseMultiparallelMode) {
+            tTimeFactor *= batchMultiplier;
+        }
         this.mMaxProgresstime = (int) (tRecipe.mDuration * tTimeFactor);
 
         this.lEUt = (long) Math.ceil(tTotalEUt);

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/GregtechMetaTileEntity_MassFabricator.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/GregtechMetaTileEntity_MassFabricator.java
@@ -543,7 +543,7 @@ public class GregtechMetaTileEntity_MassFabricator
         this.mMaxProgresstime = Math.max(1, this.mMaxProgresstime);
 
         if (mUseMultiparallelMode && mMaxProgresstime <= MAX_BATCH_SIZE) {
-            mMaxProgresstime = MAX_BATCH_SIZE;
+            mMaxProgresstime = (int) batchMultiplier;
         }
 
         // Collect fluid outputs

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/GregtechMetaTileEntity_MassFabricator.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/GregtechMetaTileEntity_MassFabricator.java
@@ -496,10 +496,11 @@ public class GregtechMetaTileEntity_MassFabricator
             return false;
         }
 
-        float batchMultiplier = 1.0f;
         if (mUseMultiparallelMode) {
             int extraParallelRecipes = 0;
-            for (; extraParallelRecipes + parallelRecipes < aMaxParallelRecipes * 128; extraParallelRecipes++) {
+            for (;
+                    extraParallelRecipes + parallelRecipes < aMaxParallelRecipes * maxBatchSize;
+                    extraParallelRecipes++) {
                 if (!tRecipe.isRecipeInputEqual(true, aFluidInputs, aItemInputs)) {
                     break;
                 }
@@ -540,6 +541,10 @@ public class GregtechMetaTileEntity_MassFabricator
         }
 
         this.mMaxProgresstime = Math.max(1, this.mMaxProgresstime);
+
+        if (mUseMultiparallelMode && mMaxProgresstime <= maxBatchSize / 2) {
+            mMaxProgresstime = maxBatchSize / 2;
+        }
 
         // Collect fluid outputs
         FluidStack[] tOutputFluids = new FluidStack[tRecipe.mFluidOutputs.length];

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/GregtechMetaTileEntity_MassFabricator.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/GregtechMetaTileEntity_MassFabricator.java
@@ -515,9 +515,7 @@ public class GregtechMetaTileEntity_MassFabricator
         // e.g. 100% speed bonus = 200% speed = 100%/200% = 50% recipe duration.
         aSpeedBonusPercent = Math.max(-99, aSpeedBonusPercent);
         float tTimeFactor = 100.0f / (100.0f + aSpeedBonusPercent);
-        if (mUseMultiparallelMode) {
-            tTimeFactor *= batchMultiplier;
-        }
+
         this.mMaxProgresstime = (int) (tRecipe.mDuration * tTimeFactor);
 
         this.lEUt = (long) Math.ceil(tTotalEUt);
@@ -542,8 +540,8 @@ public class GregtechMetaTileEntity_MassFabricator
 
         this.mMaxProgresstime = Math.max(1, this.mMaxProgresstime);
 
-        if (mUseMultiparallelMode && mMaxProgresstime <= MAX_BATCH_SIZE) {
-            mMaxProgresstime = (int) batchMultiplier;
+        if (mUseMultiparallelMode) {
+            mMaxProgresstime = (int) Math.ceil(mMaxProgresstime * batchMultiplier);
         }
 
         // Collect fluid outputs

--- a/src/main/java/gtPlusPlus/xmod/gregtech/loaders/recipe/RecipeLoader_ChemicalSkips.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/loaders/recipe/RecipeLoader_ChemicalSkips.java
@@ -319,7 +319,7 @@ public class RecipeLoader_ChemicalSkips {
                     Materials.Osmiridium.getDust(64),
                     Materials.Carbon.getNanite(64)
                 },
-                ELEMENT.STANDALONE.HYPOGEN.getFluidStack(1440),
+                ELEMENT.STANDALONE.HYPOGEN.getFluidStack(360),
                 ItemUtils.getSimpleStack(GenericChem.mPlatinumGroupCatalyst, 1),
                 60 * 20,
                 (int) GT_Values.VP[9]);
@@ -332,7 +332,7 @@ public class RecipeLoader_ChemicalSkips {
                     Materials.Polytetrafluoroethylene.getDust(64),
                     Materials.Carbon.getNanite(64)
                 },
-                ELEMENT.STANDALONE.HYPOGEN.getFluidStack(1440),
+                ELEMENT.STANDALONE.HYPOGEN.getFluidStack(360),
                 ItemUtils.getSimpleStack(GenericChem.mPlasticPolymerCatalyst, 1),
                 60 * 20,
                 (int) GT_Values.VP[9]);
@@ -345,7 +345,7 @@ public class RecipeLoader_ChemicalSkips {
                     Materials.StyreneButadieneRubber.getDust(64),
                     Materials.Carbon.getNanite(64)
                 },
-                ELEMENT.STANDALONE.HYPOGEN.getFluidStack(1440),
+                ELEMENT.STANDALONE.HYPOGEN.getFluidStack(360),
                 ItemUtils.getSimpleStack(GenericChem.mRubberPolymerCatalyst, 1),
                 60 * 20,
                 (int) GT_Values.VP[9]);
@@ -358,7 +358,7 @@ public class RecipeLoader_ChemicalSkips {
                     MISC_MATERIALS.ETHYL_CYANOACRYLATE.getCell(64),
                     Materials.Carbon.getNanite(64)
                 },
-                ELEMENT.STANDALONE.HYPOGEN.getFluidStack(1440),
+                ELEMENT.STANDALONE.HYPOGEN.getFluidStack(360),
                 ItemUtils.getSimpleStack(GenericChem.mAdhesionPromoterCatalyst, 1),
                 60 * 20,
                 (int) GT_Values.VP[9]);
@@ -371,7 +371,7 @@ public class RecipeLoader_ChemicalSkips {
                     Materials.Indium.getDust(64),
                     Materials.Carbon.getNanite(64)
                 },
-                ELEMENT.STANDALONE.HYPOGEN.getFluidStack(1440),
+                ELEMENT.STANDALONE.HYPOGEN.getFluidStack(360),
                 ItemUtils.getSimpleStack(GenericChem.mTitaTungstenIndiumCatalyst, 1),
                 60 * 20,
                 (int) GT_Values.VP[9]);
@@ -384,7 +384,7 @@ public class RecipeLoader_ChemicalSkips {
                     ELEMENT.getInstance().PLUTONIUM241.getDust(64),
                     Materials.Carbon.getNanite(64)
                 },
-                ELEMENT.STANDALONE.HYPOGEN.getFluidStack(1440),
+                ELEMENT.STANDALONE.HYPOGEN.getFluidStack(360),
                 ItemUtils.getSimpleStack(GenericChem.mRadioactivityCatalyst, 1),
                 60 * 20,
                 (int) GT_Values.VP[9]);
@@ -483,8 +483,8 @@ public class RecipeLoader_ChemicalSkips {
                 new FluidStack[] {
                     Materials.Thulium.getMolten(144 * 10),
                     Materials.ExcitedDTCC.getFluid(5000),
-                    new FluidStack(ELEMENT.getInstance().NEPTUNIUM.getPlasma(), 1000 * 10),
-                    new FluidStack(ELEMENT.getInstance().FERMIUM.getPlasma(), 1000 * 10)
+                    new FluidStack(ELEMENT.getInstance().NEPTUNIUM.getPlasma(), 500),
+                    new FluidStack(ELEMENT.getInstance().FERMIUM.getPlasma(), 500)
                 },
                 GregtechItemList.NeutronPulseManipulator.get(1),
                 60 * 20,
@@ -508,8 +508,8 @@ public class RecipeLoader_ChemicalSkips {
                 new FluidStack[] {
                     Materials.Thulium.getMolten(144 * 12),
                     Materials.ExcitedDTPC.getFluid(5000),
-                    new FluidStack(ELEMENT.getInstance().NEPTUNIUM.getPlasma(), 1200 * 10),
-                    new FluidStack(ELEMENT.getInstance().FERMIUM.getPlasma(), 1200 * 10)
+                    new FluidStack(ELEMENT.getInstance().NEPTUNIUM.getPlasma(), 2500),
+                    new FluidStack(ELEMENT.getInstance().FERMIUM.getPlasma(), 2500)
                 },
                 GregtechItemList.CosmicFabricManipulator.get(1),
                 75 * 20,
@@ -533,8 +533,8 @@ public class RecipeLoader_ChemicalSkips {
                 new FluidStack[] {
                     Materials.Thulium.getMolten(144 * 15),
                     Materials.ExcitedDTRC.getFluid(5000),
-                    new FluidStack(ELEMENT.getInstance().NEPTUNIUM.getPlasma(), 1500 * 10),
-                    new FluidStack(ELEMENT.getInstance().FERMIUM.getPlasma(), 1500 * 10)
+                    new FluidStack(ELEMENT.getInstance().NEPTUNIUM.getPlasma(), 1000 * 10),
+                    new FluidStack(ELEMENT.getInstance().FERMIUM.getPlasma(), 1000 * 10)
                 },
                 GregtechItemList.InfinityInfusedManipulator.get(1),
                 90 * 20,

--- a/src/main/resources/assets/miscutils/lang/en_US.lang
+++ b/src/main/resources/assets/miscutils/lang/en_US.lang
@@ -22,6 +22,10 @@ death.attack.plasmabolt=%s died by burning hot plasma.
 death.attack.plasmabolt.player=%1$s was killed by %2$s using plasma.
 death.attack.gtpp.grinder=%s was ground into nothingness by an IsaMill.
 
+//Batch mode chat message
+misc.BatchModeTextOn=Batch recipes
+misc.BatchModeTextOff=Don't batch recipes
+
 //Alternative Materials
 item.itemPlateBatteryAlloy.name=Plate of Battery Alloy
 item.itemIngotBatteryAlloy.name=Ingot of Battery Alloy

--- a/src/main/resources/assets/miscutils/lang/en_US.lang
+++ b/src/main/resources/assets/miscutils/lang/en_US.lang
@@ -23,7 +23,7 @@ death.attack.plasmabolt.player=%1$s was killed by %2$s using plasma.
 death.attack.gtpp.grinder=%s was ground into nothingness by an IsaMill.
 
 //Batch mode chat message
-misc.BatchModeTextOn=Batch recipes
+misc.BatchModeTextOn=Batch recipes (ME output bus recommended, will void excess outputs!)
 misc.BatchModeTextOff=Don't batch recipes
 
 //Alternative Materials


### PR DESCRIPTION
Adds the batch mode functionality to gt++ multis. 
gt++ lag can get quite bad when processing fast recipes, batch mode can help reduce that lag

Here's a before and after comparison using a gt++ bending machine
![image](https://user-images.githubusercontent.com/93287602/211177625-f007c054-470f-4d4c-bf42-a28c9b216d9c.png)
![image](https://user-images.githubusercontent.com/93287602/211177630-cb7bf319-537a-4e34-ae35-08ba8ab8d25c.png)
