### PR TITLE
Decreased Zyngen minimum casings

### DIFF
--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/GregtechMetaTileEntity_IndustrialAlloySmelter.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/GregtechMetaTileEntity_IndustrialAlloySmelter.java
@@ -113,7 +113,7 @@ public class GregtechMetaTileEntity_IndustrialAlloySmelter
                 .addSeparator()
                 .beginStructureBlock(3, 5, 3, true)
                 .addController("Bottom center")
-                .addCasingInfo("Inconel Reinforced Casings", 10)
+                .addCasingInfo("Inconel Reinforced Casings", 8)
                 .addCasingInfo("Integral Encasement V", 8)
                 .addCasingInfo("Heating Coils", 16)
                 .addInputBus("Any Inconel Reinforced Casing", 1)
@@ -172,7 +172,7 @@ public class GregtechMetaTileEntity_IndustrialAlloySmelter
         mLevel = 0;
         setCoilLevel(HeatingCoilLevel.None);
         return checkPiece(mName, 1, 4, 0)
-                && mCasing >= 10
+                && mCasing >= 8
                 && getCoilLevel() != HeatingCoilLevel.None
                 && (mLevel = getCoilLevel().getTier() + 1) > 0
                 && checkHatch();


### PR DESCRIPTION
With this change you can put all needed molds into one Zyngen (multiblock alloy smelter).