### PR TITLE
Change Runite element

### DIFF
--- a/src/main/java/gtPlusPlus/core/material/ELEMENT.java
+++ b/src/main/java/gtPlusPlus/core/material/ELEMENT.java
@@ -925,7 +925,7 @@ public final class ELEMENT {
                 73,
                 87,
                 true,
-                "§",
+                "Rt*",
                 0); // Not a GT Inherited Material
         public static final Material DRAGON_METAL = new Material(
                 "Dragonblood",


### PR DESCRIPTION
Since § is a color code in minecraft, it can't be used here, but seriously, this material needs some kind of use.