### PR TITLE
Add Sifting Recipe to Thorium for Radium

### DIFF
--- a/src/main/java/gtPlusPlus/xmod/gregtech/loaders/recipe/RecipeLoader_Nuclear.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/loaders/recipe/RecipeLoader_Nuclear.java
@@ -616,12 +616,12 @@ public class RecipeLoader_Nuclear {
         GT_Values.RA.addSifterRecipe(
                 ItemUtils.getItemStackOfAmountFromOreDict("crushedPurifiedThorium", 1),
                 new ItemStack[] {
-                        ItemUtils.getItemStackOfAmountFromOreDict("dustThorium", 1),
-                        ItemUtils.getItemStackOfAmountFromOreDict("dustLead", 1),
-                        ItemUtils.getItemStackOfAmountFromOreDict("dustRadium226", 1),
-                        ItemUtils.getItemStackOfAmountFromOreDict("dustRadium226", 1),
-                        ItemUtils.getItemStackOfAmountFromOreDict("dustRadium226", 1),
-                        ItemUtils.getItemStackOfAmountFromOreDict("dustRadium226", 1)
+                    ItemUtils.getItemStackOfAmountFromOreDict("dustThorium", 1),
+                    ItemUtils.getItemStackOfAmountFromOreDict("dustLead", 1),
+                    ItemUtils.getItemStackOfAmountFromOreDict("dustRadium226", 1),
+                    ItemUtils.getItemStackOfAmountFromOreDict("dustRadium226", 1),
+                    ItemUtils.getItemStackOfAmountFromOreDict("dustRadium226", 1),
+                    ItemUtils.getItemStackOfAmountFromOreDict("dustRadium226", 1)
                 },
                 new int[] {10000, 500, 300, 200, 100, 100},
                 20 * 30,
@@ -654,7 +654,7 @@ public class RecipeLoader_Nuclear {
                 new int[] {10000, 556, 500, 250, 250, 250},
                 20 * 30,
                 500);
-        
+
         GT_Values.RA.addSifterRecipe(
                 ItemUtils.getItemStackOfAmountFromOreDict("crushedPurifiedPitchblende", 1),
                 new ItemStack[] {

--- a/src/main/java/gtPlusPlus/xmod/gregtech/loaders/recipe/RecipeLoader_Nuclear.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/loaders/recipe/RecipeLoader_Nuclear.java
@@ -614,6 +614,20 @@ public class RecipeLoader_Nuclear {
 
         // Radium
         GT_Values.RA.addSifterRecipe(
+                ItemUtils.getItemStackOfAmountFromOreDict("crushedPurifiedThorium", 1),
+                new ItemStack[] {
+                        ItemUtils.getItemStackOfAmountFromOreDict("dustThorium", 1),
+                        ItemUtils.getItemStackOfAmountFromOreDict("dustLead", 1),
+                        ItemUtils.getItemStackOfAmountFromOreDict("dustRadium226", 1),
+                        ItemUtils.getItemStackOfAmountFromOreDict("dustRadium226", 1),
+                        ItemUtils.getItemStackOfAmountFromOreDict("dustRadium226", 1),
+                        ItemUtils.getItemStackOfAmountFromOreDict("dustRadium226", 1)
+                },
+                new int[] {10000, 500, 300, 200, 100, 100},
+                20 * 30,
+                500);
+
+        GT_Values.RA.addSifterRecipe(
                 ItemUtils.getItemStackOfAmountFromOreDict("crushedPurifiedUranium", 1),
                 new ItemStack[] {
                     ItemUtils.getItemStackOfAmountFromOreDict("dustUranium", 1),
@@ -626,6 +640,7 @@ public class RecipeLoader_Nuclear {
                 new int[] {10000, 556, 1000, 500, 500, 500},
                 20 * 30,
                 500);
+
         GT_Values.RA.addSifterRecipe(
                 ItemUtils.getItemStackOfAmountFromOreDict("crushedPurifiedUraninite", 1),
                 new ItemStack[] {
@@ -639,6 +654,7 @@ public class RecipeLoader_Nuclear {
                 new int[] {10000, 556, 500, 250, 250, 250},
                 20 * 30,
                 500);
+        
         GT_Values.RA.addSifterRecipe(
                 ItemUtils.getItemStackOfAmountFromOreDict("crushedPurifiedPitchblende", 1),
                 new ItemStack[] {


### PR DESCRIPTION
This PR adds a Sifter recipe for Thorium similar to those for Uranium, Uraninite and Pitchblende, which output Radium-226 for the purpose of decaying and processing into Radon. This recipe has a lower chance for Radium outputs than any of the other 3.

The purpose of this change is to allow Radon to be more easily accessible before getting to t2 planets, which will become much harder with a change I'm planning to add LuV circuits to the rocket recipe.