### PR TITLE
Separate Wire Factory Buses by Default

### DIFF
--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/GregtechMetaTileEntity_IndustrialWireMill.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/GregtechMetaTileEntity_IndustrialWireMill.java
@@ -38,7 +38,7 @@ public class GregtechMetaTileEntity_IndustrialWireMill
 
     private int mCasing;
     private static IStructureDefinition<GregtechMetaTileEntity_IndustrialWireMill> STRUCTURE_DEFINITION = null;
-    private boolean isBussesSeparate;
+    private boolean isBussesSeparate = true;
 
     public GregtechMetaTileEntity_IndustrialWireMill(final int aID, final String aName, final String aNameRegional) {
         super(aID, aName, aNameRegional);


### PR DESCRIPTION
Uses the regular NBT saving/loading system for memorizing whether input buses are separated or not, but it was not active by default when it should have been.

Closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/12368.