### PR TITLE
Increase capacity and production rate of the reservoir hatch

### DIFF
--- a/src/main/java/gtPlusPlus/xmod/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_Hatch_Reservoir.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_Hatch_Reservoir.java
@@ -41,7 +41,7 @@ public class GT_MetaTileEntity_Hatch_Reservoir extends GT_MetaTileEntity_Hatch_F
 
     @Override
     public int getAmountOfFluidToGenerate() {
-        return 100000000;
+        return 1000000000;
     }
 
     @Override
@@ -51,7 +51,7 @@ public class GT_MetaTileEntity_Hatch_Reservoir extends GT_MetaTileEntity_Hatch_F
 
     @Override
     public int getCapacity() {
-        return 100000000;
+        return 2000000000;
     }
 
     @Override


### PR DESCRIPTION
Some chemical reactor recipe when done in a MCR would be able to use more than 100ML water every 5 seconds, the increase makes sure that the reservoir hatch always keeps up