### PR TITLE
fix adv muffler not consuming muffler when used with a newer(ish) gt5

### DIFF
--- a/src/main/java/gtPlusPlus/xmod/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_Hatch_Muffler_Adv.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_Hatch_Muffler_Adv.java
@@ -103,7 +103,8 @@ public class GT_MetaTileEntity_Hatch_Muffler_Adv extends GT_MetaTileEntity_Hatch
         return false;
     }
 
-    public boolean polluteEnvironment() {
+    @Override
+    public boolean polluteEnvironment(MetaTileEntity unused) {
         if (airCheck() && damageAirFilter()) {
             int aEmission = this.calculatePollutionReduction(10000);
             PollutionUtils.addPollution(this.getBaseMetaTileEntity(), aEmission);


### PR DESCRIPTION
Fix https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/12577

The original GT5 migration did it wrong, but given it has been 2 years since then it'd be better we migrate addons instead.