### PR TITLE
Fix removed CustomName init call causing an NPE

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,4 @@
-//version: 1677142954
+//version: 1678003329
 /*
  DO NOT CHANGE THIS FILE!
  Also, you may replace this file at any time if there is an update available.
@@ -73,7 +73,7 @@ plugins {
     id 'com.diffplug.spotless' version '6.7.2' apply false
     id 'com.modrinth.minotaur' version '2.+' apply false
     id 'com.matthewprenger.cursegradle' version '1.4.0' apply false
-    id 'com.gtnewhorizons.retrofuturagradle' version '1.2.2'
+    id 'com.gtnewhorizons.retrofuturagradle' version '1.2.3'
 }
 boolean settingsupdated = verifySettingsGradle()
 settingsupdated = verifyGitAttributes() || settingsupdated
@@ -153,7 +153,7 @@ java {
         } else {
             languageVersion.set(projectJavaVersion)
         }
-        vendor.set(JvmVendorSpec.ADOPTIUM)
+        vendor.set(JvmVendorSpec.AZUL)
     }
     if (!noPublishedSources) {
         withSourcesJar()
@@ -222,7 +222,7 @@ if (enableModernJavaSyntax.toBoolean()) {
 
         javaCompiler.set(javaToolchains.compilerFor {
             languageVersion.set(JavaLanguageVersion.of(17))
-            vendor.set(JvmVendorSpec.ADOPTIUM)
+            vendor.set(JvmVendorSpec.AZUL)
         })
     }
 }
@@ -695,13 +695,13 @@ ext.java17PatchDependenciesCfg = configurations.create("java17PatchDependencies"
 }
 
 dependencies {
-    def lwjgl3ifyVersion = '1.1.28'
+    def lwjgl3ifyVersion = '1.1.35'
     def asmVersion = '9.4'
     if (modId != 'lwjgl3ify') {
         java17Dependencies("com.github.GTNewHorizons:lwjgl3ify:${lwjgl3ifyVersion}")
     }
     if (modId != 'hodgepodge') {
-        java17Dependencies('com.github.GTNewHorizons:Hodgepodge:2.0.35')
+        java17Dependencies('com.github.GTNewHorizons:Hodgepodge:2.0.40')
     }
 
     java17PatchDependencies('net.minecraft:launchwrapper:1.15') {transitive = false}
@@ -718,8 +718,8 @@ dependencies {
 ext.java17JvmArgs = [
     // Java 9+ support
     "--illegal-access=warn",
-    "-Dfile.encoding=UTF-8",
     "-Djava.security.manager=allow",
+    "-Dfile.encoding=UTF-8",
     "--add-opens", "java.base/jdk.internal.loader=ALL-UNNAMED",
     "--add-opens", "java.base/java.net=ALL-UNNAMED",
     "--add-opens", "java.base/java.nio=ALL-UNNAMED",
@@ -730,6 +730,7 @@ ext.java17JvmArgs = [
     "--add-opens", "java.base/java.util=ALL-UNNAMED",
     "--add-opens", "java.base/jdk.internal.reflect=ALL-UNNAMED",
     "--add-opens", "java.base/sun.nio.ch=ALL-UNNAMED",
+    "--add-opens", "jdk.naming.dns/com.sun.jndi.dns=ALL-UNNAMED,java.naming",
     "--add-opens", "java.desktop/sun.awt.image=ALL-UNNAMED",
     "--add-modules", "jdk.dynalink",
     "--add-opens", "jdk.dynalink/jdk.dynalink.beans=ALL-UNNAMED",

--- a/src/main/java/gtPlusPlus/core/common/CommonProxy.java
+++ b/src/main/java/gtPlusPlus/core/common/CommonProxy.java
@@ -44,6 +44,7 @@ import gtPlusPlus.preloader.CORE_Preloader;
 import gtPlusPlus.xmod.eio.handler.HandlerTooltip_EIO;
 import gtPlusPlus.xmod.galacticraft.handler.HandlerTooltip_GC;
 import gtPlusPlus.xmod.gregtech.api.util.SpecialBehaviourTooltipHandler;
+import gtPlusPlus.xmod.ic2.CustomInternalName;
 
 public class CommonProxy {
 
@@ -66,6 +67,7 @@ public class CommonProxy {
         }
 
         AddToCreativeTab.initialiseTabs();
+        CustomInternalName.init();
 
         // Moved from Init after Debug Loading.
         // 29/01/18 - Alkalus


### PR DESCRIPTION
The call was removed together with the gt5u enum extensions, but this one targets ic2 and must still run