### PR TITLE
Don't require a min of output busses on sifter

### DIFF
--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/GregtechMetaTileEntity_IndustrialSifter.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/GregtechMetaTileEntity_IndustrialSifter.java
@@ -66,7 +66,7 @@ public class GregtechMetaTileEntity_IndustrialSifter
                 .addInfo("Only uses 75% of the EU/t normally required").addInfo("Processes four items per voltage tier")
                 .addPollutionAmount(getPollutionPerSecond(null)).addSeparator().beginStructureBlock(5, 3, 5, false)
                 .addController("Bottom Center").addCasingInfo("Sieve Grate", 18).addCasingInfo("Sieve Casings", 35)
-                .addInputBus("Any Casing", 1).addOutputBus("Any Casing (x4)", 1).addInputHatch("Any Casing", 1)
+                .addInputBus("Any Casing", 1).addOutputBus("Any Casing", 1).addInputHatch("Any Casing", 1)
                 .addOutputHatch("Any Casing", 1).addEnergyHatch("Any Casing", 1).addMaintenanceHatch("Any Casing", 1)
                 .addMufflerHatch("Any Casing", 1).toolTipFinisher(CORE.GT_Tooltip_Builder.get());
         return tt;

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/GregtechMetaTileEntity_IndustrialSifter.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/GregtechMetaTileEntity_IndustrialSifter.java
@@ -107,7 +107,7 @@ public class GregtechMetaTileEntity_IndustrialSifter
     @Override
     public boolean checkMachine(IGregTechTileEntity aBaseMetaTileEntity, ItemStack aStack) {
         mCasing = 0;
-        return checkPiece(mName, 2, 2, 0) && mCasing >= 35 && mOutputBusses.size() >= 4 && checkHatch();
+        return checkPiece(mName, 2, 2, 0) && mCasing >= 35 && checkHatch();
     }
 
     @Override


### PR DESCRIPTION
Unnecessary bloat, since ME output bus exists.