### PR TITLE
fix crop harvester energy drain and non-last optimal level crops

### DIFF
--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/basic/GT_MetaTileEntity_CropHarvestor.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/basic/GT_MetaTileEntity_CropHarvestor.java
@@ -240,7 +240,7 @@ public class GT_MetaTileEntity_CropHarvestor extends GT_MetaTileEntity_BasicTank
 
             if (this.mModeAlternative) processSecondaryFunctions(tCrop);
 
-            if (!aCrop.canGrow(tCrop) && aCrop.canBeHarvested(tCrop)) {
+            if (aCrop.canBeHarvested(tCrop) && tCrop.getSize() == aCrop.getOptimalHavestSize(tCrop)) {
                 if (!getBaseMetaTileEntity().decreaseStoredEnergyUnits(powerUsage(), true)) continue;
                 ItemStack[] aHarvest = tCrop.harvest_automated(true);
                 if (aHarvest == null) continue;


### PR DESCRIPTION
This PR fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/12856 and possibly https://github.com/GTNewHorizons/GTplusplus/issues/125
Before this change the crop harvester checked if a crop couldn't grow anymore before attempting to harvest it. That meant if someone used the crop harvester to water/fertilize a manual oreberries farm without metal blocks underneath, the harvester would constantly try and fail to harvest them while draining energy very quickly. 
The harvester also straight up just couldn't harvest eating plants at all since they are unharvestable in their last growth stage

After the change:
- Crop harvester doesn't drain energy trying to harvest premature oreberries
- Crop harvester now correctly checks for optimal harvest level and properly harvests eating plants
- Other plants like potatoes with non-last optimal harvest levels also get harvested during their optimal harvest stages