### PR TITLE
fix missing industrial hcl

### DIFF
--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/blocks/fluid/GregtechFluidHandler.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/blocks/fluid/GregtechFluidHandler.java
@@ -99,20 +99,18 @@ public class GregtechFluidHandler {
         generateIC2FluidCell("SulfuricApatite");
 
         // Check for Hydrogen Chloride
-        if (ItemUtils.getItemStackOfAmountFromOreDict("cellHydrogenChloride", 1) == null) {
-            if (FluidUtils.getFluidStack("hydrogenchloride", 1) == null) {
-                FluidUtils.addGtFluid(
-                        "hydrogenChloride",
-                        "Industrial Strength Hydrogen Chloride",
-                        GT_Materials.HydrogenChloride,
-                        4,
-                        75,
-                        GT_OreDictUnificator.get(OrePrefixes.cell, GT_Materials.HydrogenChloride, 1L),
-                        ItemUtils.getEmptyCell(),
-                        1000,
-                        false);
-                generateIC2FluidCell("HydrogenChloride");
-            }
+        if (FluidUtils.getFluidStack("hydrogenchloride", 1) == null) {
+            FluidUtils.addGtFluid(
+                    "hydrogenChloride",
+                    "Industrial Strength Hydrogen Chloride",
+                    GT_Materials.HydrogenChloride,
+                    4,
+                    75,
+                    GT_OreDictUnificator.get(OrePrefixes.cell, GT_Materials.HydrogenChloride, 1L),
+                    ItemUtils.getEmptyCell(),
+                    1000,
+                    false);
+            generateIC2FluidCell("HydrogenChloride");
         }
 
         FluidUtils.addGtFluid(


### PR DESCRIPTION
Fix for: industrial hcl was missing and rare earth II thus unobtainable:

![image](https://user-images.githubusercontent.com/40274384/234936189-73c7186a-ade3-49ab-9a11-0aba00e2a204.png)

caused by https://github.com/GTNewHorizons/GTplusplus/pull/589
