### PR TITLE
Make sure the backpack is properly secured while it's open

### DIFF
--- a/src/main/java/gtPlusPlus/core/container/Container_BackpackBase.java
+++ b/src/main/java/gtPlusPlus/core/container/Container_BackpackBase.java
@@ -7,6 +7,7 @@ import net.minecraft.inventory.Slot;
 import net.minecraft.item.ItemStack;
 
 import gtPlusPlus.core.inventories.BaseInventoryBackpack;
+import gtPlusPlus.core.slots.SlotBlockedInv;
 import gtPlusPlus.core.slots.SlotItemBackpackInv;
 
 public class Container_BackpackBase extends Container {
@@ -63,7 +64,11 @@ public class Container_BackpackBase extends Container {
 
         // PLAYER ACTION BAR - uses default locations for standard action bar texture file
         for (i = 0; i < 9; ++i) {
-            this.addSlotToContainer(new Slot(inventoryPlayer, i, 8 + (i * 18), 142));
+            if (i == par1Player.inventory.currentItem) {
+                this.addSlotToContainer(new SlotBlockedInv(inventoryPlayer, i, 8 + (i * 18), 142));
+            } else {
+                this.addSlotToContainer(new Slot(inventoryPlayer, i, 8 + (i * 18), 142));
+            }
         }
     }
 
@@ -164,6 +169,16 @@ public class Container_BackpackBase extends Container {
         if ((slot >= 0) && (this.getSlot(slot) != null) && (this.getSlot(slot).getStack() == player.getHeldItem())) {
             return null;
         }
+
+        // Keybind for moving from hotbar slot to hovered slot, make we don't move the currently held backpack.
+        if (flag == 2 && button >= 0 && button < 9) {
+            int hotbarIndex = HOTBAR_START + button;
+            Slot hotbarSlot = getSlot(hotbarIndex);
+            if (hotbarSlot instanceof SlotBlockedInv) {
+                return null;
+            }
+        }
+
         return super.slotClick(slot, button, flag, player);
     }
 }

--- a/src/main/java/gtPlusPlus/core/inventories/BaseInventoryBackpack.java
+++ b/src/main/java/gtPlusPlus/core/inventories/BaseInventoryBackpack.java
@@ -28,7 +28,7 @@ public class BaseInventoryBackpack implements IInventory {
     protected String uniqueID;
 
     /**
-     * @param itemstack - the ItemStack to which this inventory belongs
+     * @param stack - the ItemStack to which this inventory belongs
      */
     public BaseInventoryBackpack(final ItemStack stack) {
         this.invItem = stack;

--- a/src/main/java/gtPlusPlus/core/slots/SlotBlockedInv.java
+++ b/src/main/java/gtPlusPlus/core/slots/SlotBlockedInv.java
@@ -1,0 +1,39 @@
+package gtPlusPlus.core.slots;
+
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.inventory.IInventory;
+import net.minecraft.inventory.Slot;
+import net.minecraft.item.ItemStack;
+
+public class SlotBlockedInv extends Slot {
+
+    public SlotBlockedInv(IInventory inv, int index, int xPos, int yPos) {
+        super(inv, index, xPos, yPos);
+    }
+
+    @Override
+    public boolean isItemValid(ItemStack stack) {
+        return false;
+    }
+
+    @Override
+    public boolean canTakeStack(EntityPlayer player) {
+        return false;
+    }
+
+    @Override
+    public void putStack(ItemStack itemStack) {}
+
+    @Override
+    public void onPickupFromSlot(EntityPlayer player, ItemStack itemStack) {}
+
+    @Override
+    public boolean getHasStack() {
+        return false;
+    }
+
+    @Override
+    public ItemStack decrStackSize(int i) {
+        return null;
+    }
+}


### PR DESCRIPTION
This has been prompted by the change in https://github.com/GTNewHorizons/IFU/pull/13 which was originally based on the GT++ Backpack. Turns out this is not sufficient--using the vanilla method of moving one of the hotbar slots using the hotbar shortcut keys, the player is still able to move the Backpack while its inventory is open.