### PR TITLE
added chisel input busses

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,4 @@
-//version: 1684139283
+//version: 1684218858
 /*
  DO NOT CHANGE THIS FILE!
  Also, you may replace this file at any time if there is an update available.
@@ -730,7 +730,7 @@ dependencies {
         java17Dependencies("com.github.GTNewHorizons:lwjgl3ify:${lwjgl3ifyVersion}")
     }
     if (modId != 'hodgepodge') {
-        java17Dependencies('com.github.GTNewHorizons:Hodgepodge:2.2.8')
+        java17Dependencies('com.github.GTNewHorizons:Hodgepodge:2.2.13')
     }
 
     java17PatchDependencies('net.minecraft:launchwrapper:1.15') {transitive = false}

--- a/src/main/java/gtPlusPlus/core/recipe/RECIPES_Machines.java
+++ b/src/main/java/gtPlusPlus/core/recipe/RECIPES_Machines.java
@@ -3568,7 +3568,7 @@ public class RECIPES_Machines {
                     CI.getAlternativeTieredFluid(i, 144 * 2),
                     mChiselBuses[i],
                     20 * 30 * 2,
-                    (int) GT_Values.V[i + 1]);
+                    (int) GT_Values.VP[i + 1]);
         }
     }
 

--- a/src/main/java/gtPlusPlus/core/recipe/RECIPES_Machines.java
+++ b/src/main/java/gtPlusPlus/core/recipe/RECIPES_Machines.java
@@ -262,6 +262,7 @@ public class RECIPES_Machines {
         rockBreaker();
         thermicFluidHeater();
         advHeatExchanger();
+        chiselBuses();
 
         gt4FarmManager();
         gt4Redstone();
@@ -3547,6 +3548,27 @@ public class RECIPES_Machines {
                     mSuperBusesOutput[i].get(1),
                     20 * 30 * 2,
                     (int) GT_Values.V[i]);
+        }
+    }
+
+    private static void chiselBuses() {
+        ItemStack[] mSuperBusesInput = new ItemStack[] { ItemList.Hatch_Input_Bus_HV.get(1),
+                GregtechItemList.Hatch_SuperBus_Input_LV.get(1), GregtechItemList.Hatch_SuperBus_Input_MV.get(1),
+                GregtechItemList.Hatch_SuperBus_Input_HV.get(1), };
+
+        ItemStack[] mChiselBuses = new ItemStack[] { GregtechItemList.GT_MetaTileEntity_ChiselBus_I.get(1),
+                GregtechItemList.GT_MetaTileEntity_ChiselBus_II.get(1),
+                GregtechItemList.GT_MetaTileEntity_ChiselBus_III.get(1),
+                GregtechItemList.GT_MetaTileEntity_ChiselBus_IV.get(1), };
+
+        for (int i = 0; i < 4; i++) {
+            CORE.RA.addSixSlotAssemblingRecipe(
+                    new ItemStack[] { CI.getNumberedCircuit(17), mSuperBusesInput[i], CI.getSensor(i, 1),
+                            CI.getRobotArm(i, 2), CI.getBolt(i, 16), ItemUtils.getSimpleStack(Blocks.chest) },
+                    CI.getAlternativeTieredFluid(i, 144 * 2),
+                    mChiselBuses[i],
+                    20 * 30 * 2,
+                    (int) GT_Values.V[i + 1]);
         }
     }
 

--- a/src/main/java/gtPlusPlus/xmod/gregtech/api/enums/GregtechItemList.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/api/enums/GregtechItemList.java
@@ -613,6 +613,12 @@ public enum GregtechItemList implements GregtechItemContainer {
     Hatch_SuperBus_Output_UV,
     Hatch_SuperBus_Output_MAX,
 
+    // Chisel Buses for Industrial Chisel
+    GT_MetaTileEntity_ChiselBus_I,
+    GT_MetaTileEntity_ChiselBus_II,
+    GT_MetaTileEntity_ChiselBus_III,
+    GT_MetaTileEntity_ChiselBus_IV,
+
     // ----------------------------------------------------------------------------
 
     /**

--- a/src/main/java/gtPlusPlus/xmod/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_ChiselBus.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_ChiselBus.java
@@ -1,0 +1,74 @@
+package gtPlusPlus.xmod.gregtech.api.metatileentity.implementations;
+
+import net.minecraft.util.EnumChatFormatting;
+
+import com.gtnewhorizons.modularui.api.screen.ModularWindow;
+import com.gtnewhorizons.modularui.api.screen.UIBuildContext;
+import com.gtnewhorizons.modularui.common.widget.Scrollable;
+import com.gtnewhorizons.modularui.common.widget.SlotWidget;
+
+import gregtech.api.interfaces.ITexture;
+import gregtech.api.interfaces.modularui.IAddUIWidgets;
+import gregtech.api.interfaces.tileentity.IGregTechTileEntity;
+import gregtech.api.metatileentity.MetaTileEntity;
+import gregtech.api.metatileentity.implementations.GT_MetaTileEntity_Hatch_InputBus;
+import gregtech.api.util.extensions.ArrayExt;
+
+public class GT_MetaTileEntity_ChiselBus extends GT_MetaTileEntity_Hatch_InputBus implements IAddUIWidgets {
+
+    public GT_MetaTileEntity_ChiselBus(int id, String name, String nameRegional, int tier) {
+        super(id, name, nameRegional, tier);
+    }
+
+    public GT_MetaTileEntity_ChiselBus(String aName, int aTier, String[] aDescription, ITexture[][][] aTextures) {
+        super(aName, aTier, getSlots(aTier), aDescription, aTextures);
+    }
+
+    @Override
+    public boolean isValidSlot(int aIndex) {
+        return aIndex < getSlots(this.mTier);
+    }
+
+    public static int getSlots(int aTier) {
+        return (1 + aTier) * 16 + 1;
+    }
+
+    @Override
+    public MetaTileEntity newMetaEntity(IGregTechTileEntity aTileEntity) {
+        return new GT_MetaTileEntity_ChiselBus(this.mName, this.mTier, ArrayExt.of(this.mDescription), this.mTextures);
+    }
+
+    @Override
+    public boolean allowSelectCircuit() {
+        return false;
+    }
+
+    @Override
+    public String[] getDescription() {
+        return new String[] { "Item Input Bus for Industrial Chisel", getSlots(this.mTier) - 1 + " + 1 " + " Slots",
+                "Added by: " + EnumChatFormatting.AQUA
+                        + "Quetz4l"
+                        + " - "
+                        + EnumChatFormatting.RED
+                        + "[GT++]"
+                        + EnumChatFormatting.RESET };
+    }
+
+    @Override
+    public void addUIWidgets(ModularWindow.Builder builder, UIBuildContext buildContext) {
+        int slotIndex = 0;
+        final Scrollable scrollable = new Scrollable().setVerticalScroll();
+        for (int row = 0; row * 4 < inventoryHandler.getSlots() - 1; row++) {
+            int columnsToMake = Math.min(inventoryHandler.getSlots() - row * 4, 4);
+            for (int column = 0; column < columnsToMake; column++) {
+                scrollable.widget(
+                        new SlotWidget(inventoryHandler, slotIndex++).setPos(column * 18, row * 18).setSize(18, 18));
+
+            }
+        }
+
+        builder.widget(scrollable.setSize(18 * 4 + 4, 18 * 4).setPos(52, 7)); // main slots
+        builder.widget(new SlotWidget(inventoryHandler, slotIndex).setPos(18, 18).setSize(18, 18)); // slot for target
+    }
+
+}

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/GregtechMetaTileEntity_IndustrialChisel.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/GregtechMetaTileEntity_IndustrialChisel.java
@@ -25,6 +25,7 @@ import com.gtnewhorizon.structurelib.structure.StructureDefinition;
 import gregtech.api.interfaces.IIconContainer;
 import gregtech.api.interfaces.metatileentity.IMetaTileEntity;
 import gregtech.api.interfaces.tileentity.IGregTechTileEntity;
+import gregtech.api.metatileentity.implementations.GT_MetaTileEntity_Hatch_InputBus;
 import gregtech.api.util.GTPP_Recipe;
 import gregtech.api.util.GT_Multiblock_Tooltip_Builder;
 import gregtech.api.util.GT_OverclockCalculator;
@@ -34,6 +35,7 @@ import gregtech.api.util.GT_Utility;
 import gtPlusPlus.core.block.ModBlocks;
 import gtPlusPlus.core.lib.CORE;
 import gtPlusPlus.core.util.minecraft.ItemUtils;
+import gtPlusPlus.xmod.gregtech.api.metatileentity.implementations.GT_MetaTileEntity_ChiselBus;
 import gtPlusPlus.xmod.gregtech.api.metatileentity.implementations.base.GregtechMeta_MultiBlockBase;
 import gtPlusPlus.xmod.gregtech.common.blocks.textures.TexturesGtBlock;
 import team.chisel.carving.Carving;
@@ -42,6 +44,8 @@ public class GregtechMetaTileEntity_IndustrialChisel
         extends GregtechMeta_MultiBlockBase<GregtechMetaTileEntity_IndustrialChisel> implements ISurvivalConstructable {
 
     private int mCasing;
+
+    private ItemStack target;
     private static IStructureDefinition<GregtechMetaTileEntity_IndustrialChisel> STRUCTURE_DEFINITION = null;
     private ItemStack mInputCache;
     private ItemStack mOutputCache;
@@ -69,7 +73,8 @@ public class GregtechMetaTileEntity_IndustrialChisel
     protected GT_Multiblock_Tooltip_Builder createTooltip() {
         GT_Multiblock_Tooltip_Builder tt = new GT_Multiblock_Tooltip_Builder();
         tt.addMachineType(getMachineType()).addInfo("Factory Grade Auto Chisel")
-                .addInfo("Target block goes in GUI slot").addInfo("If no target provided, first chisel result is used")
+                .addInfo("Target block goes in Controller slot for common Input Buses")
+                .addInfo("You can also set a target block in each Chisel Input Bus and use them as an Input Bus")
                 .addInfo("Speed: +200% | EU Usage: 75% | Parallel: Tier x 16")
                 .addPollutionAmount(getPollutionPerSecond(null)).addSeparator().beginStructureBlock(3, 3, 3, true)
                 .addController("Front center").addCasingInfo("Sturdy Printer Casing", 10).addInputBus("Any casing", 1)
@@ -81,12 +86,17 @@ public class GregtechMetaTileEntity_IndustrialChisel
     @Override
     public IStructureDefinition<GregtechMetaTileEntity_IndustrialChisel> getStructureDefinition() {
         if (STRUCTURE_DEFINITION == null) {
-            STRUCTURE_DEFINITION = StructureDefinition.<GregtechMetaTileEntity_IndustrialChisel>builder()
-                    .addShape(
+            STRUCTURE_DEFINITION = StructureDefinition
+                    .<GregtechMetaTileEntity_IndustrialChisel>builder().addShape(
                             mName,
                             transpose(
-                                    new String[][] { { "CCC", "CCC", "CCC" }, { "C~C", "C-C", "CCC" },
-                                            { "CCC", "CCC", "CCC" }, }))
+                                    // spotless:off
+                                    new String[][] {
+                                            { "CCC", "CCC", "CCC" },
+                                            { "C~C", "C-C", "CCC" },
+                                            { "CCC", "CCC", "CCC" },
+                                    }))
+                                    // spotless:on
                     .addElement(
                             'C',
                             buildHatchAdder(GregtechMetaTileEntity_IndustrialChisel.class)
@@ -184,7 +194,7 @@ public class GregtechMetaTileEntity_IndustrialChisel
     }
 
     private static ItemStack getChiselOutput(ItemStack aInput, ItemStack aTarget) {
-        ItemStack tOutput = null;
+        ItemStack tOutput;
         if (aTarget != null && canBeMadeFrom(aInput, aTarget)) {
             tOutput = aTarget;
         } else if (aTarget != null && !canBeMadeFrom(aInput, aTarget)) {
@@ -195,10 +205,10 @@ public class GregtechMetaTileEntity_IndustrialChisel
         return tOutput;
     }
 
-    private GTPP_Recipe generateChiselRecipe(ItemStack aInput, ItemStack aTarget) {
-        boolean tIsCached = hasValidCache(aInput, aTarget, true);
+    private GTPP_Recipe generateChiselRecipe(ItemStack aInput) {
+        boolean tIsCached = hasValidCache(aInput, this.target, true);
         if (tIsCached || aInput != null && hasChiselResults(aInput)) {
-            ItemStack tOutput = tIsCached ? mOutputCache.copy() : getChiselOutput(aInput, aTarget);
+            ItemStack tOutput = tIsCached ? mOutputCache.copy() : getChiselOutput(aInput, this.target);
             if (tOutput != null) {
                 if (mCachedRecipe != null && GT_Utility.areStacksEqual(aInput, mInputCache)
                         && GT_Utility.areStacksEqual(tOutput, mOutputCache)) {
@@ -225,74 +235,103 @@ public class GregtechMetaTileEntity_IndustrialChisel
         return null;
     }
 
+    private GT_Recipe getRecipe() {
+        ArrayList<GT_MetaTileEntity_Hatch_InputBus> busses = this.mInputBusses;
+        GT_Recipe tRecipe;
+
+        for (GT_MetaTileEntity_Hatch_InputBus bus : busses) {
+            ItemStack[] busInventory = bus.mInventory;
+            ItemStack itemsInSlot;
+
+            if (bus instanceof GT_MetaTileEntity_ChiselBus) { // Chisel buses
+                if (busInventory[bus.getSizeInventory() - 1] == null) continue;
+                this.target = busInventory[bus.getSizeInventory() - 1];
+
+                for (int i = bus.getSizeInventory() - 2; i >= 0; i--) {
+                    itemsInSlot = busInventory[i];
+                    if (itemsInSlot != null) {
+                        tRecipe = generateChiselRecipe(itemsInSlot);
+                        if (tRecipe != null) {
+                            return tRecipe;
+                        }
+                    }
+                }
+            } else {
+                target = this.getGUIItemStack(); // Common buses
+                for (int i = bus.getSizeInventory() - 1; i >= 0; i--) {
+                    itemsInSlot = busInventory[i];
+                    if (itemsInSlot != null) {
+                        tRecipe = generateChiselRecipe(itemsInSlot);
+                        if (tRecipe != null) {
+                            return tRecipe;
+                        }
+                    }
+                }
+            }
+
+        }
+        return null;
+    }
+
     @Override
     public boolean checkRecipe(final ItemStack aStack) {
+        GT_Recipe tRecipe = getRecipe();
+        if (tRecipe == null) return false;
+
         ArrayList<ItemStack> aItems = this.getStoredInputs();
-        if (!aItems.isEmpty()) {
 
-            GT_Recipe tRecipe = generateChiselRecipe(aItems.get(0), this.getGUIItemStack());
+        // Based on the Processing Array. A bit overkill, but very flexible.
+        ItemStack[] aItemInputs = aItems.toArray(new ItemStack[aItems.size()]);
 
-            if (tRecipe == null) {
-                return false;
-            }
+        // Reset outputs and progress stats
+        this.lEUt = 0;
+        this.mMaxProgresstime = 0;
+        this.mOutputItems = new ItemStack[] {};
+        this.mOutputFluids = new FluidStack[] {};
+        long tEnergy = getMaxInputEnergy();
 
-            // Based on the Processing Array. A bit overkill, but very flexible.
-            ItemStack[] aItemInputs = aItems.toArray(new ItemStack[aItems.size()]);
-            FluidStack[] aFluidInputs = new FluidStack[] {};
+        // Remember last recipe - an optimization for findRecipe()
+        this.mLastRecipe = tRecipe;
 
-            // Reset outputs and progress stats
-            this.lEUt = 0;
-            this.mMaxProgresstime = 0;
-            this.mOutputItems = new ItemStack[] {};
-            this.mOutputFluids = new FluidStack[] {};
+        int aMaxParallelRecipes = getMaxParallelRecipes();
+        int aEUPercent = getEuDiscountForParallelism();
+        int aSpeedBonusPercent = 200;
 
-            long tVoltage = getMaxInputVoltage();
-            long tEnergy = getMaxInputEnergy();
-            // Remember last recipe - an optimization for findRecipe()
-            this.mLastRecipe = tRecipe;
-
-            int aMaxParallelRecipes = getMaxParallelRecipes();
-            int aEUPercent = getEuDiscountForParallelism();
-            int aSpeedBonusPercent = 200;
-
-            GT_ParallelHelper helper = new GT_ParallelHelper().setRecipe(tRecipe).setItemInputs(aItemInputs)
-                    .setFluidInputs(aFluidInputs).setAvailableEUt(tEnergy).setMaxParallel(aMaxParallelRecipes)
-                    .enableConsumption().enableOutputCalculation().setEUtModifier(aEUPercent / 100.0f);
-            if (!voidExcess) {
-                helper.enableVoidProtection(this);
-            }
-
-            if (batchMode) {
-                helper.enableBatchMode(128);
-            }
-
-            helper.build();
-
-            if (helper.getCurrentParallel() == 0) {
-                return false;
-            }
-
-            this.mEfficiency = (10000 - (getIdealStatus() - getRepairStatus()) * 1000);
-            this.mEfficiencyIncrease = 10000;
-
-            GT_OverclockCalculator calculator = new GT_OverclockCalculator().setRecipeEUt(tRecipe.mEUt).setEUt(tEnergy)
-                    .setDuration(tRecipe.mDuration).setEUtDiscount(aEUPercent / 100.0f)
-                    .setSpeedBoost(100.0f / (100.0f + aSpeedBonusPercent))
-                    .setParallel((int) Math.floor(helper.getCurrentParallel() / helper.getDurationMultiplier()))
-                    .calculate();
-            lEUt = -calculator.getConsumption();
-            mMaxProgresstime = (int) Math.ceil(calculator.getDuration() * helper.getDurationMultiplier());
-
-            mOutputItems = helper.getItemOutputs();
-            mOutputFluids = helper.getFluidOutputs();
-            updateSlots();
-
-            // Play sounds (GT++ addition - GT multiblocks play no sounds)
-            startProcess();
-            return true;
+        GT_ParallelHelper helper = new GT_ParallelHelper().setRecipe(tRecipe).setItemInputs(aItemInputs)
+                .setAvailableEUt(tEnergy).setMaxParallel(aMaxParallelRecipes).enableConsumption()
+                .enableOutputCalculation().setEUtModifier(aEUPercent / 100.0f);
+        if (!voidExcess) {
+            helper.enableVoidProtection(this);
         }
 
-        return false;
+        if (batchMode) {
+            helper.enableBatchMode(128);
+        }
+
+        helper.build();
+
+        if (helper.getCurrentParallel() == 0) {
+            return false;
+        }
+
+        this.mEfficiency = (10000 - (getIdealStatus() - getRepairStatus()) * 1000);
+        this.mEfficiencyIncrease = 10000;
+
+        GT_OverclockCalculator calculator = new GT_OverclockCalculator().setRecipeEUt(tRecipe.mEUt).setEUt(tEnergy)
+                .setDuration(tRecipe.mDuration).setEUtDiscount(aEUPercent / 100.0f)
+                .setSpeedBoost(100.0f / (100.0f + aSpeedBonusPercent))
+                .setParallel((int) Math.floor(helper.getCurrentParallel() / helper.getDurationMultiplier()))
+                .calculate();
+        lEUt = -calculator.getConsumption();
+        mMaxProgresstime = (int) Math.ceil(calculator.getDuration() * helper.getDurationMultiplier());
+
+        mOutputItems = helper.getItemOutputs();
+
+        updateSlots();
+
+        // Play sounds (GT++ addition - GT multiblocks play no sounds)
+        startProcess();
+        return true;
     }
 
     @Override
@@ -307,7 +346,7 @@ public class GregtechMetaTileEntity_IndustrialChisel
 
     private static String sChiselSound = null;
 
-    private static final String getChiselSound() {
+    private static String getChiselSound() {
         if (sChiselSound == null) {
             sChiselSound = Carving.chisel.getVariationSound(Blocks.stone, 0);
         }

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/GregtechMetaTileEntity_IndustrialChisel.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/GregtechMetaTileEntity_IndustrialChisel.java
@@ -237,21 +237,15 @@ public class GregtechMetaTileEntity_IndustrialChisel
     }
 
     private GT_Recipe getRecipe() {
-        ArrayList<GT_MetaTileEntity_Hatch_InputBus> busses = this.mInputBusses;
-        GT_Recipe tRecipe;
-
-        for (GT_MetaTileEntity_Hatch_InputBus bus : busses) {
-            ItemStack[] busInventory = bus.mInventory;
-            ItemStack itemsInSlot;
-
+        for (GT_MetaTileEntity_Hatch_InputBus bus : this.mInputBusses) {
             if (bus instanceof GT_MetaTileEntity_ChiselBus) { // Chisel buses
-                if (busInventory[bus.getSizeInventory() - 1] == null) continue;
-                this.target = busInventory[bus.getSizeInventory() - 1];
+                if (bus.mInventory[bus.getSizeInventory() - 1] == null) continue;
+                this.target = bus.mInventory[bus.getSizeInventory() - 1];
 
                 for (int i = bus.getSizeInventory() - 2; i >= 0; i--) {
-                    itemsInSlot = busInventory[i];
+                    ItemStack itemsInSlot = bus.mInventory[i];
                     if (itemsInSlot != null) {
-                        tRecipe = generateChiselRecipe(itemsInSlot);
+                        GT_Recipe tRecipe = generateChiselRecipe(itemsInSlot);
                         if (tRecipe != null) {
                             return tRecipe;
                         }
@@ -260,9 +254,9 @@ public class GregtechMetaTileEntity_IndustrialChisel
             } else {
                 target = this.getGUIItemStack(); // Common buses
                 for (int i = bus.getSizeInventory() - 1; i >= 0; i--) {
-                    itemsInSlot = busInventory[i];
+                    ItemStack itemsInSlot = bus.mInventory[i];
                     if (itemsInSlot != null) {
-                        tRecipe = generateChiselRecipe(itemsInSlot);
+                        GT_Recipe tRecipe = generateChiselRecipe(itemsInSlot);
                         if (tRecipe != null) {
                             return tRecipe;
                         }

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/GregtechMetaTileEntity_IndustrialChisel.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/GregtechMetaTileEntity_IndustrialChisel.java
@@ -75,6 +75,7 @@ public class GregtechMetaTileEntity_IndustrialChisel
         tt.addMachineType(getMachineType()).addInfo("Factory Grade Auto Chisel")
                 .addInfo("Target block goes in Controller slot for common Input Buses")
                 .addInfo("You can also set a target block in each Chisel Input Bus and use them as an Input Bus")
+                .addInfo("If no target is provided for common buses, the result of the first chisel is used")
                 .addInfo("Speed: +200% | EU Usage: 75% | Parallel: Tier x 16")
                 .addPollutionAmount(getPollutionPerSecond(null)).addSeparator().beginStructureBlock(3, 3, 3, true)
                 .addController("Front center").addCasingInfo("Sturdy Printer Casing", 10).addInputBus("Any casing", 1)

--- a/src/main/java/gtPlusPlus/xmod/gregtech/registration/gregtech/GregtechCustomHatches.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/registration/gregtech/GregtechCustomHatches.java
@@ -285,14 +285,14 @@ public class GregtechCustomHatches {
     private static void run5() {
         int aID = 31777;
 
-        GregtechItemList.GT_MetaTileEntity_ChiselBus_I.set(
-                ((IMetaTileEntity) makeChiselBus(aID++, "hatch.chisel.tier.00", "Chisel Bus I", 0)).getStackForm(1L));
-        GregtechItemList.GT_MetaTileEntity_ChiselBus_II.set(
-                ((IMetaTileEntity) makeChiselBus(aID++, "hatch.chisel.tier.01", "Chisel Bus II", 1)).getStackForm(1L));
-        GregtechItemList.GT_MetaTileEntity_ChiselBus_III.set(
-                ((IMetaTileEntity) makeChiselBus(aID++, "hatch.chisel.tier.02", "Chisel Bus III", 2)).getStackForm(1L));
-        GregtechItemList.GT_MetaTileEntity_ChiselBus_IV.set(
-                ((IMetaTileEntity) makeChiselBus(aID++, "hatch.chisel.tier.03", "Chisel Bus IV", 3)).getStackForm(1L));
+        GregtechItemList.GT_MetaTileEntity_ChiselBus_I
+                .set((makeChiselBus(aID++, "hatch.chisel.tier.00", "Chisel Bus I", 0)).getStackForm(1L));
+        GregtechItemList.GT_MetaTileEntity_ChiselBus_II
+                .set((makeChiselBus(aID++, "hatch.chisel.tier.01", "Chisel Bus II", 1)).getStackForm(1L));
+        GregtechItemList.GT_MetaTileEntity_ChiselBus_III
+                .set((makeChiselBus(aID++, "hatch.chisel.tier.02", "Chisel Bus III", 2)).getStackForm(1L));
+        GregtechItemList.GT_MetaTileEntity_ChiselBus_IV
+                .set((makeChiselBus(aID++, "hatch.chisel.tier.03", "Chisel Bus IV", 3)).getStackForm(1L));
 
     }
 }

--- a/src/main/java/gtPlusPlus/xmod/gregtech/registration/gregtech/GregtechCustomHatches.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/registration/gregtech/GregtechCustomHatches.java
@@ -5,6 +5,7 @@ import gtPlusPlus.api.objects.Logger;
 import gtPlusPlus.core.util.minecraft.FluidUtils;
 import gtPlusPlus.core.util.minecraft.gregtech.PollutionUtils;
 import gtPlusPlus.xmod.gregtech.api.enums.GregtechItemList;
+import gtPlusPlus.xmod.gregtech.api.metatileentity.implementations.GT_MetaTileEntity_ChiselBus;
 import gtPlusPlus.xmod.gregtech.api.metatileentity.implementations.GT_MetaTileEntity_Hatch_AirIntake;
 import gtPlusPlus.xmod.gregtech.api.metatileentity.implementations.GT_MetaTileEntity_Hatch_AirIntake_Extreme;
 import gtPlusPlus.xmod.gregtech.api.metatileentity.implementations.GT_MetaTileEntity_Hatch_ControlCore;
@@ -27,6 +28,7 @@ public class GregtechCustomHatches {
         }
         run3();
         run4();
+        run5(); // Chisel buses
     }
 
     private static void run1() {
@@ -273,5 +275,24 @@ public class GregtechCustomHatches {
         GregtechItemList.Hatch_RTG_LV.set(aHatch1.getStackForm(1L));
         GregtechItemList.Hatch_RTG_MV.set(aHatch2.getStackForm(1L));
         GregtechItemList.Hatch_RTG_HV.set(aHatch3.getStackForm(1L));
+    }
+
+    private static GT_MetaTileEntity_ChiselBus makeChiselBus(int id, String unlocalizedName, String localizedName,
+            int tier) {
+        return new GT_MetaTileEntity_ChiselBus(id, unlocalizedName, localizedName, tier);
+    }
+
+    private static void run5() {
+        int aID = 31777;
+
+        GregtechItemList.GT_MetaTileEntity_ChiselBus_I.set(
+                ((IMetaTileEntity) makeChiselBus(aID++, "hatch.chisel.tier.00", "Chisel Bus I", 0)).getStackForm(1L));
+        GregtechItemList.GT_MetaTileEntity_ChiselBus_II.set(
+                ((IMetaTileEntity) makeChiselBus(aID++, "hatch.chisel.tier.01", "Chisel Bus II", 1)).getStackForm(1L));
+        GregtechItemList.GT_MetaTileEntity_ChiselBus_III.set(
+                ((IMetaTileEntity) makeChiselBus(aID++, "hatch.chisel.tier.02", "Chisel Bus III", 2)).getStackForm(1L));
+        GregtechItemList.GT_MetaTileEntity_ChiselBus_IV.set(
+                ((IMetaTileEntity) makeChiselBus(aID++, "hatch.chisel.tier.03", "Chisel Bus IV", 3)).getStackForm(1L));
+
     }
 }


### PR DESCRIPTION
Was -> The industrial 3D copier only worked with one recipe, 1 mult = 1 recipe. 
Now -> You can place a target block in each chisel bus and use them as a super input bus. As many chisel buses as there are recipes. Also old mechanic was saved, The industrial 3D copier can work with common buses.



https://github.com/GTNewHorizons/GTplusplus/assets/17906427/328547eb-162a-4ee1-acc8-a4b5483cc17e


