### PR TITLE
Fix item damage for some items

### DIFF
--- a/src/main/java/gtPlusPlus/core/item/base/itemblock/ItemBlockMeta.java
+++ b/src/main/java/gtPlusPlus/core/item/base/itemblock/ItemBlockMeta.java
@@ -91,11 +91,6 @@ public class ItemBlockMeta extends ItemBlockWithMetadata {
     }
 
     @Override
-    public int getDamage(ItemStack stack) {
-        return 0;
-    }
-
-    @Override
     public boolean showDurabilityBar(ItemStack stack) {
         return false;
     }

--- a/src/main/java/gtPlusPlus/core/item/base/itemblock/ItemBlockRoundRobinator.java
+++ b/src/main/java/gtPlusPlus/core/item/base/itemblock/ItemBlockRoundRobinator.java
@@ -84,11 +84,6 @@ public class ItemBlockRoundRobinator extends ItemBlockWithMetadata {
     }
 
     @Override
-    public int getDamage(ItemStack stack) {
-        return 0;
-    }
-
-    @Override
     public boolean showDurabilityBar(ItemStack stack) {
         return false;
     }

--- a/src/main/java/gtPlusPlus/core/item/general/ItemGenericToken.java
+++ b/src/main/java/gtPlusPlus/core/item/general/ItemGenericToken.java
@@ -146,11 +146,6 @@ public class ItemGenericToken extends CoreItem {
     }
 
     @Override
-    public int getDamage(ItemStack stack) {
-        return 0;
-    }
-
-    @Override
     public boolean showDurabilityBar(ItemStack stack) {
         return false;
     }


### PR DESCRIPTION
Blame https://github.com/GTNewHorizons/GTplusplus/pull/637
Turns out `getDisplayDamage` is different from `getDamage`.
`getDisplayDamage` is used for durability, I don't think it should be overrideen for those items