### PR TITLE
Nerf low-grade plasmas in the XL Plasma turbine

### DIFF
--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/turbines/GT_MTE_LargeTurbine_Plasma.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/turbines/GT_MTE_LargeTurbine_Plasma.java
@@ -8,7 +8,6 @@ import net.minecraftforge.fluids.Fluid;
 import net.minecraftforge.fluids.FluidRegistry;
 import net.minecraftforge.fluids.FluidStack;
 
-import gregtech.api.enums.Materials;
 import gregtech.api.interfaces.ITexture;
 import gregtech.api.interfaces.metatileentity.IMetaTileEntity;
 import gregtech.api.interfaces.tileentity.IGregTechTileEntity;
@@ -24,10 +23,6 @@ import gtPlusPlus.xmod.gregtech.api.metatileentity.implementations.GT_MetaTileEn
 public class GT_MTE_LargeTurbine_Plasma extends GregtechMetaTileEntity_LargerTurbineBase {
 
     private static final HashSet<Fluid> BLACKLIST = new HashSet<>();
-
-    static {
-        BLACKLIST.add(Materials.Helium.getPlasma(0).getFluid());
-    }
 
     public GT_MTE_LargeTurbine_Plasma(int aID, String aName, String aNameRegional) {
         super(aID, aName, aNameRegional);
@@ -119,7 +114,7 @@ public class GT_MTE_LargeTurbine_Plasma extends GregtechMetaTileEntity_LargerTur
 
                     float aTotalBaseEff = 0;
                     float aTotalOptimalFlow = 0;
-                    
+
                     ItemStack aStack = getFullTurbineAssemblies().get(0).getTurbine();
                     aTotalBaseEff += GT_Utility.safeInt(
                             (long) ((5F + ((GT_MetaGenerated_Tool) aStack.getItem()).getToolCombatDamage(aStack))
@@ -131,11 +126,12 @@ public class GT_MTE_LargeTurbine_Plasma extends GregtechMetaTileEntity_LargerTur
                                             * GT_MetaGenerated_Tool.getPrimaryMaterial(aStack).mToolSpeed
                                             * 50));
 
-                        //Calculate total EU/t (as shown on turbine tooltip (Fast mode doesn't affect))
-                    double aEUPerTurbine = aTotalOptimalFlow
-                                    * 40 * 0.0105
-                                    * GT_MetaGenerated_Tool.getPrimaryMaterial(aStack).mPlasmaMultiplier
-                                    * (50.0f + (10.0f * ((GT_MetaGenerated_Tool) aStack.getItem()).getToolCombatDamage(aStack)));
+                    // Calculate total EU/t (as shown on turbine tooltip (Fast mode doesn't affect))
+                    double aEUPerTurbine = aTotalOptimalFlow * 40
+                            * 0.0105
+                            * GT_MetaGenerated_Tool.getPrimaryMaterial(aStack).mPlasmaMultiplier
+                            * (50.0f + (10.0f
+                                    * ((GT_MetaGenerated_Tool) aStack.getItem()).getToolCombatDamage(aStack)));
                     aTotalOptimalFlow *= getSpeedMultiplier();
 
                     if (aTotalOptimalFlow < 0) {
@@ -161,10 +157,11 @@ public class GT_MTE_LargeTurbine_Plasma extends GregtechMetaTileEntity_LargerTur
             // How much the turbine should be producing with this flow
             int newPower = fluidIntoPower(tFluids, optFlow, baseEff, flowMultipliers);
 
-            //Reduce produced power depending on the ratio between fuel value and turbine EU/t with the following formula:
+            // Reduce produced power depending on the ratio between fuel value and turbine EU/t with the following
+            // formula:
             // EU/t = EU/t * MIN(1, ( ( (FuelValue / 100) ^ 2 ) / EUPerTurbine))
             int fuelValue = getFuelValue(new FluidStack(tFluids.get(0), 0));
-            float magicValue = (fuelValue * 0.01f) * ( fuelValue * 0.01f);
+            float magicValue = (fuelValue * 0.01f) * (fuelValue * 0.01f);
             float efficiencyLoss = Math.min(1.0f, magicValue / euPerTurbine);
             newPower *= efficiencyLoss;
 

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/turbines/GT_MTE_LargeTurbine_Plasma.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/turbines/GT_MTE_LargeTurbine_Plasma.java
@@ -119,7 +119,7 @@ public class GT_MTE_LargeTurbine_Plasma extends GregtechMetaTileEntity_LargerTur
 
                     float aTotalBaseEff = 0;
                     float aTotalOptimalFlow = 0;
-                    
+
                     ItemStack aStack = getFullTurbineAssemblies().get(0).getTurbine();
                     aTotalBaseEff += GT_Utility.safeInt(
                             (long) ((5F + ((GT_MetaGenerated_Tool) aStack.getItem()).getToolCombatDamage(aStack))
@@ -131,11 +131,12 @@ public class GT_MTE_LargeTurbine_Plasma extends GregtechMetaTileEntity_LargerTur
                                             * GT_MetaGenerated_Tool.getPrimaryMaterial(aStack).mToolSpeed
                                             * 50));
 
-                        //Calculate total EU/t (as shown on turbine tooltip (Fast mode doesn't affect))
-                    double aEUPerTurbine = aTotalOptimalFlow
-                                    * 40 * 0.0105
-                                    * GT_MetaGenerated_Tool.getPrimaryMaterial(aStack).mPlasmaMultiplier
-                                    * (50.0f + (10.0f * ((GT_MetaGenerated_Tool) aStack.getItem()).getToolCombatDamage(aStack)));
+                    // Calculate total EU/t (as shown on turbine tooltip (Fast mode doesn't affect))
+                    double aEUPerTurbine = aTotalOptimalFlow * 40
+                            * 0.0105
+                            * GT_MetaGenerated_Tool.getPrimaryMaterial(aStack).mPlasmaMultiplier
+                            * (50.0f + (10.0f
+                                    * ((GT_MetaGenerated_Tool) aStack.getItem()).getToolCombatDamage(aStack)));
                     aTotalOptimalFlow *= getSpeedMultiplier();
 
                     if (aTotalOptimalFlow < 0) {
@@ -161,10 +162,11 @@ public class GT_MTE_LargeTurbine_Plasma extends GregtechMetaTileEntity_LargerTur
             // How much the turbine should be producing with this flow
             int newPower = fluidIntoPower(tFluids, optFlow, baseEff, flowMultipliers);
 
-            //Reduce produced power depending on the ratio between fuel value and turbine EU/t with the following formula:
+            // Reduce produced power depending on the ratio between fuel value and turbine EU/t with the following
+            // formula:
             // EU/t = EU/t * MIN(1, ( ( (FuelValue / 100) ^ 2 ) / EUPerTurbine))
             int fuelValue = getFuelValue(new FluidStack(tFluids.get(0), 0));
-            float magicValue = (fuelValue * 0.01f) * ( fuelValue * 0.01f);
+            float magicValue = (fuelValue * 0.01f) * (fuelValue * 0.01f);
             float efficiencyLoss = Math.min(1.0f, magicValue / euPerTurbine);
             newPower *= efficiencyLoss;
 

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/turbines/GregtechMetaTileEntity_LargerTurbineBase.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/turbines/GregtechMetaTileEntity_LargerTurbineBase.java
@@ -102,6 +102,8 @@ public abstract class GregtechMetaTileEntity_LargerTurbineBase extends
                 .addInfo("Fast Mode increases speed to 48x instead of 16x, with some penalties")
                 .addInfo("Maintenance problems and turbine damage happen 12x as often in Fast Mode")
                 .addInfo("XL Steam Turbines can use Loose Mode with either Slow or Fast Mode")
+                .addInfo("Plasma fuel efficiency is lower for high tier turbines when using low-grade plasmas")
+                .addInfo("Efficiency = ((FuelValue / 100000)^2) / (EU per Turbine)")
                 .addPollutionAmount(getPollutionPerSecond(null)).addInfo("Pollution is 3x higher in Fast Mode")
                 .addSeparator().beginStructureBlock(7, 9, 7, false).addController("Top Middle")
                 .addCasingInfoMin(getCasingName(), 360, false).addCasingInfoMin("Rotor Shaft", 30, false)

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/turbines/GregtechMetaTileEntity_LargerTurbineBase.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/turbines/GregtechMetaTileEntity_LargerTurbineBase.java
@@ -57,6 +57,7 @@ public abstract class GregtechMetaTileEntity_LargerTurbineBase extends
 
     protected int baseEff = 0;
     protected long optFlow = 0;
+    protected long euPerTurbine = 0;
     protected double realOptFlow = 0;
     protected int storedFluid = 0;
     protected int counter = 0;


### PR DESCRIPTION
Low-tier plasmas (primarily Helium) produce less EU/t for the same amount of fuel if the turbine EU/t is above a limit based on the fuel value of plasmas, following the formula  $\text{EU/t}=\text{EU/t}*\text{Min}(1.0, (\frac{ \text{fuelValue}  }{100})^2 / \text{EUPerTurbine})$

Some example values for various turbines:
![image](https://github.com/GTNewHorizons/GTplusplus/assets/69092953/06f10a06-f8ce-46cc-a5ae-632e343ff50f)
