### PR TITLE
Add New Recipes for Powergen Plasmas

### DIFF
--- a/src/main/java/gtPlusPlus/xmod/gregtech/loaders/recipe/RecipeLoader_Nuclear.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/loaders/recipe/RecipeLoader_Nuclear.java
@@ -1,23 +1,23 @@
 package gtPlusPlus.xmod.gregtech.loaders.recipe;
 
-import gtPlusPlus.core.material.ALLOY;
-import net.minecraft.item.ItemStack;
-import net.minecraftforge.fluids.FluidStack;
-
 import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sFusionRecipes;
 import static gregtech.api.util.GT_RecipeBuilder.SECONDS;
 import static gregtech.api.util.GT_RecipeConstants.FUSION_THRESHOLD;
 
-import gregtech.api.enums.TierEU;
+import net.minecraft.item.ItemStack;
+import net.minecraftforge.fluids.FluidStack;
+
 import gregtech.api.enums.GT_Values;
 import gregtech.api.enums.ItemList;
 import gregtech.api.enums.Materials;
 import gregtech.api.enums.OrePrefixes;
+import gregtech.api.enums.TierEU;
 import gregtech.api.util.GT_ModHandler;
 import gregtech.api.util.GT_OreDictUnificator;
 import gtPlusPlus.api.objects.Logger;
 import gtPlusPlus.core.item.chemistry.GenericChem;
 import gtPlusPlus.core.lib.CORE;
+import gtPlusPlus.core.material.ALLOY;
 import gtPlusPlus.core.material.ELEMENT;
 import gtPlusPlus.core.material.MISC_MATERIALS;
 import gtPlusPlus.core.material.nuclear.FLUORIDES;
@@ -482,86 +482,58 @@ public class RecipeLoader_Nuclear {
 
     private static void fusionChainRecipes() {
         // Mk1
-        GT_Values.RA.stdBuilder()
-                .noItemInputs()
-                .noItemOutputs()
+        GT_Values.RA.stdBuilder().noItemInputs().noItemOutputs()
                 .fluidInputs(Materials.Boron.getPlasma(100), Materials.Calcium.getPlasma(100))
-                .fluidOutputs(new FluidStack(ELEMENT.getInstance().NEON.getPlasma(), 100))
-                .duration(3 * SECONDS)
-                .eut(TierEU.RECIPE_LuV)
-                .metadata(FUSION_THRESHOLD, 100000000)
-                .addTo(sFusionRecipes);
+                .fluidOutputs(new FluidStack(ELEMENT.getInstance().NEON.getPlasma(), 100)).duration(3 * SECONDS)
+                .eut(TierEU.RECIPE_LuV).metadata(FUSION_THRESHOLD, 100000000).addTo(sFusionRecipes);
 
-        GT_Values.RA.stdBuilder()
-                .noItemInputs()
-                .noItemOutputs()
-                .fluidInputs(new FluidStack(ELEMENT.getInstance().NEON.getPlasma(), 100), Materials.Bedrockium.getMolten(1000))
-                .fluidOutputs(new FluidStack(ELEMENT.STANDALONE.FORCE.getPlasma(), 100))
-                .duration(3 * SECONDS)
-                .eut(TierEU.RECIPE_LuV)
-                .metadata(FUSION_THRESHOLD, 100000000)
-                .addTo(sFusionRecipes);
+        GT_Values.RA.stdBuilder().noItemInputs().noItemOutputs()
+                .fluidInputs(
+                        new FluidStack(ELEMENT.getInstance().NEON.getPlasma(), 100),
+                        Materials.Bedrockium.getMolten(1000))
+                .fluidOutputs(new FluidStack(ELEMENT.STANDALONE.FORCE.getPlasma(), 100)).duration(3 * SECONDS)
+                .eut(TierEU.RECIPE_LuV).metadata(FUSION_THRESHOLD, 100000000).addTo(sFusionRecipes);
 
         // Mk2
-        GT_Values.RA.stdBuilder()
-                .noItemInputs()
-                .noItemOutputs()
+        GT_Values.RA.stdBuilder().noItemInputs().noItemOutputs()
                 .fluidInputs(Materials.Niobium.getPlasma(100), Materials.Zinc.getPlasma(100))
-                .fluidOutputs(new FluidStack(ELEMENT.getInstance().KRYPTON.getPlasma(), 100))
-                .duration(3 * SECONDS)
-                .eut(TierEU.RECIPE_ZPM)
-                .metadata(FUSION_THRESHOLD, 300000000)
-                .addTo(sFusionRecipes);
+                .fluidOutputs(new FluidStack(ELEMENT.getInstance().KRYPTON.getPlasma(), 100)).duration(3 * SECONDS)
+                .eut(TierEU.RECIPE_ZPM).metadata(FUSION_THRESHOLD, 300000000).addTo(sFusionRecipes);
 
-        GT_Values.RA.stdBuilder()
-                .noItemInputs()
-                .noItemOutputs()
-                .fluidInputs(new FluidStack(ELEMENT.getInstance().KRYPTON.getPlasma(), 100), new FluidStack(ELEMENT.STANDALONE.FORCE.getPlasma(), 100))
-                .fluidOutputs(new FluidStack(ELEMENT.STANDALONE.ASTRAL_TITANIUM.getPlasma(), 100))
-                .duration(3 * SECONDS)
-                .eut(TierEU.RECIPE_ZPM)
-                .metadata(FUSION_THRESHOLD, 300000000)
-                .addTo(sFusionRecipes);
+        GT_Values.RA.stdBuilder().noItemInputs().noItemOutputs()
+                .fluidInputs(
+                        new FluidStack(ELEMENT.getInstance().KRYPTON.getPlasma(), 100),
+                        new FluidStack(ELEMENT.STANDALONE.FORCE.getPlasma(), 100))
+                .fluidOutputs(new FluidStack(ELEMENT.STANDALONE.ASTRAL_TITANIUM.getPlasma(), 100)).duration(3 * SECONDS)
+                .eut(TierEU.RECIPE_ZPM).metadata(FUSION_THRESHOLD, 300000000).addTo(sFusionRecipes);
 
-        GT_Values.RA.stdBuilder()
-                .noItemInputs()
-                .noItemOutputs()
-                .fluidInputs(new FluidStack(ELEMENT.STANDALONE.ASTRAL_TITANIUM.getPlasma(), 100), new FluidStack(ALLOY.TITANSTEEL.getFluid(), 1000))
-                .fluidOutputs(new FluidStack(ELEMENT.STANDALONE.RUNITE.getPlasma(), 100))
-                .duration(3 * SECONDS)
-                .eut(TierEU.RECIPE_ZPM)
-                .metadata(FUSION_THRESHOLD, 300000000)
-                .addTo(sFusionRecipes);
+        GT_Values.RA.stdBuilder().noItemInputs().noItemOutputs()
+                .fluidInputs(
+                        new FluidStack(ELEMENT.STANDALONE.ASTRAL_TITANIUM.getPlasma(), 100),
+                        new FluidStack(ALLOY.TITANSTEEL.getFluid(), 1000))
+                .fluidOutputs(new FluidStack(ELEMENT.STANDALONE.RUNITE.getPlasma(), 100)).duration(3 * SECONDS)
+                .eut(TierEU.RECIPE_ZPM).metadata(FUSION_THRESHOLD, 300000000).addTo(sFusionRecipes);
 
         // Mk3
-        GT_Values.RA.stdBuilder()
-                .noItemInputs()
-                .noItemOutputs()
+        GT_Values.RA.stdBuilder().noItemInputs().noItemOutputs()
                 .fluidInputs(ELEMENT.getInstance().CURIUM.getFluidStack(100), Materials.Americium.getPlasma(100))
-                .fluidOutputs(new FluidStack(ELEMENT.getInstance().XENON.getPlasma(), 100))
-                .duration(3 * SECONDS)
-                .eut(TierEU.RECIPE_UV)
-                .metadata(FUSION_THRESHOLD, 500000000)
-                .addTo(sFusionRecipes);
+                .fluidOutputs(new FluidStack(ELEMENT.getInstance().XENON.getPlasma(), 100)).duration(3 * SECONDS)
+                .eut(TierEU.RECIPE_UV).metadata(FUSION_THRESHOLD, 500000000).addTo(sFusionRecipes);
 
-        GT_Values.RA.stdBuilder()
-                .noItemInputs()
-                .noItemOutputs()
-                .fluidInputs(new FluidStack(ELEMENT.getInstance().XENON.getPlasma(), 100), new FluidStack(ELEMENT.STANDALONE.RUNITE.getPlasma(), 100))
+        GT_Values.RA.stdBuilder().noItemInputs().noItemOutputs()
+                .fluidInputs(
+                        new FluidStack(ELEMENT.getInstance().XENON.getPlasma(), 100),
+                        new FluidStack(ELEMENT.STANDALONE.RUNITE.getPlasma(), 100))
                 .fluidOutputs(new FluidStack(ELEMENT.STANDALONE.ADVANCED_NITINOL.getPlasma(), 100))
-                .duration(3 * SECONDS)
-                .eut(TierEU.RECIPE_UV)
-                .metadata(FUSION_THRESHOLD, 500000000)
+                .duration(3 * SECONDS).eut(TierEU.RECIPE_UV).metadata(FUSION_THRESHOLD, 500000000)
                 .addTo(sFusionRecipes);
 
-        GT_Values.RA.stdBuilder()
-                .noItemInputs()
-                .noItemOutputs()
-                .fluidInputs(new FluidStack(ELEMENT.STANDALONE.ADVANCED_NITINOL.getPlasma(), 100), Materials.Tartarite.getMolten(1000))
+        GT_Values.RA.stdBuilder().noItemInputs().noItemOutputs()
+                .fluidInputs(
+                        new FluidStack(ELEMENT.STANDALONE.ADVANCED_NITINOL.getPlasma(), 100),
+                        Materials.Tartarite.getMolten(1000))
                 .fluidOutputs(new FluidStack(ELEMENT.STANDALONE.CELESTIAL_TUNGSTEN.getPlasma(), 100))
-                .duration(3 * SECONDS)
-                .eut(TierEU.RECIPE_UV)
-                .metadata(FUSION_THRESHOLD, 500000000)
+                .duration(3 * SECONDS).eut(TierEU.RECIPE_UV).metadata(FUSION_THRESHOLD, 500000000)
                 .addTo(sFusionRecipes);
     }
 

--- a/src/main/java/gtPlusPlus/xmod/gregtech/loaders/recipe/RecipeLoader_Nuclear.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/loaders/recipe/RecipeLoader_Nuclear.java
@@ -1,5 +1,6 @@
 package gtPlusPlus.xmod.gregtech.loaders.recipe;
 
+import gtPlusPlus.core.material.ALLOY;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.fluids.FluidStack;
 
@@ -38,6 +39,7 @@ public class RecipeLoader_Nuclear {
         electroMagneticSeperator();
         fluidExtractorRecipes();
         fluidHeater();
+        fusionChainRecipes();
         macerator();
         mixerRecipes();
         sifter();
@@ -471,6 +473,67 @@ public class RecipeLoader_Nuclear {
                 FLUORIDES.ZIRCONIUM_TETRAFLUORIDE.getFluidStack(144),
                 200,
                 512 + 256);
+    }
+
+    private static void fusionChainRecipes() {
+        // Mk1
+        GT_Values.RA.addFusionReactorRecipe(
+                new FluidStack[] { Materials.Boron.getPlasma(100), Materials.Calcium.getPlasma(100) },
+                new FluidStack[] { new FluidStack(ELEMENT.getInstance().NEON.getPlasma(), 100) },
+                3 * 20,
+                (int) TierEU.RECIPE_LuV,
+                100_000_000);
+
+        GT_Values.RA.addFusionReactorRecipe(
+                new FluidStack[] { new FluidStack(ELEMENT.getInstance().NEON.getPlasma(), 100), Materials.Bedrockium.getMolten(1000) },
+                new FluidStack[] { new FluidStack(ELEMENT.STANDALONE.FORCE.getPlasma(), 100) },
+                3 * 20,
+                (int) TierEU.RECIPE_LuV,
+                100_000_000);
+
+        // Mk2
+        GT_Values.RA.addFusionReactorRecipe(
+                new FluidStack[] { Materials.Niobium.getPlasma(100), Materials.Zinc.getPlasma(100) },
+                new FluidStack[] { new FluidStack(ELEMENT.getInstance().KRYPTON.getPlasma(), 100) },
+                3 * 20,
+                (int) TierEU.RECIPE_ZPM,
+                300_000_000);
+
+        GT_Values.RA.addFusionReactorRecipe(
+                new FluidStack[] { new FluidStack(ELEMENT.getInstance().NEON.getPlasma(), 100), new FluidStack(ELEMENT.STANDALONE.FORCE.getPlasma(), 100) },
+                new FluidStack[] { new FluidStack(ELEMENT.STANDALONE.ASTRAL_TITANIUM.getPlasma(), 100) },
+                3 * 20,
+                (int) TierEU.RECIPE_ZPM,
+                300_000_000);
+
+        GT_Values.RA.addFusionReactorRecipe(
+                new FluidStack[] { new FluidStack(ELEMENT.STANDALONE.ASTRAL_TITANIUM.getPlasma(), 100), new FluidStack(ALLOY.TITANSTEEL.getFluid(), 1000) },
+                new FluidStack[] { new FluidStack(ELEMENT.STANDALONE.RUNITE.getPlasma(), 100) },
+                3 * 20,
+                (int) TierEU.RECIPE_ZPM,
+                300_000_000);
+
+        // Mk3
+        GT_Values.RA.addFusionReactorRecipe(
+                new FluidStack[] { ELEMENT.getInstance().CURIUM.getFluidStack(100), Materials.Americium.getPlasma(100) },
+                new FluidStack[] { new FluidStack(ELEMENT.getInstance().XENON.getPlasma(), 100) },
+                3 * 20,
+                (int) TierEU.RECIPE_UV,
+                500_000_000);
+
+        GT_Values.RA.addFusionReactorRecipe(
+                new FluidStack[] { new FluidStack(ELEMENT.getInstance().XENON.getPlasma(), 100), new FluidStack(ELEMENT.STANDALONE.RUNITE.getPlasma(), 100) },
+                new FluidStack[] { new FluidStack(ELEMENT.STANDALONE.ADVANCED_NITINOL.getPlasma(), 100) },
+                3 * 20,
+                (int) TierEU.RECIPE_UV,
+                500_000_000);
+
+        GT_Values.RA.addFusionReactorRecipe(
+                new FluidStack[] { new FluidStack(ELEMENT.STANDALONE.ADVANCED_NITINOL.getPlasma(), 100), Materials.Tartarite.getMolten(1000) },
+                new FluidStack[] { new FluidStack(ELEMENT.STANDALONE.CELESTIAL_TUNGSTEN.getPlasma(), 100) },
+                3 * 20,
+                (int) TierEU.RECIPE_UV,
+                500_000_000);
     }
 
     private static void macerator() {

--- a/src/main/java/gtPlusPlus/xmod/gregtech/loaders/recipe/RecipeLoader_Nuclear.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/loaders/recipe/RecipeLoader_Nuclear.java
@@ -4,6 +4,11 @@ import gtPlusPlus.core.material.ALLOY;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.fluids.FluidStack;
 
+import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sFusionRecipes;
+import static gregtech.api.util.GT_RecipeBuilder.SECONDS;
+import static gregtech.api.util.GT_RecipeConstants.FUSION_THRESHOLD;
+
+import gregtech.api.enums.TierEU;
 import gregtech.api.enums.GT_Values;
 import gregtech.api.enums.ItemList;
 import gregtech.api.enums.Materials;
@@ -477,63 +482,87 @@ public class RecipeLoader_Nuclear {
 
     private static void fusionChainRecipes() {
         // Mk1
-        GT_Values.RA.addFusionReactorRecipe(
-                new FluidStack[] { Materials.Boron.getPlasma(100), Materials.Calcium.getPlasma(100) },
-                new FluidStack[] { new FluidStack(ELEMENT.getInstance().NEON.getPlasma(), 100) },
-                3 * 20,
-                (int) TierEU.RECIPE_LuV,
-                100_000_000);
+        GT_Values.RA.stdBuilder()
+                .noItemInputs()
+                .noItemOutputs()
+                .fluidInputs(Materials.Boron.getPlasma(100), Materials.Calcium.getPlasma(100))
+                .fluidOutputs(new FluidStack(ELEMENT.getInstance().NEON.getPlasma(), 100))
+                .duration(3 * SECONDS)
+                .eut(TierEU.RECIPE_LuV)
+                .metadata(FUSION_THRESHOLD, 100000000)
+                .addTo(sFusionRecipes);
 
-        GT_Values.RA.addFusionReactorRecipe(
-                new FluidStack[] { new FluidStack(ELEMENT.getInstance().NEON.getPlasma(), 100), Materials.Bedrockium.getMolten(1000) },
-                new FluidStack[] { new FluidStack(ELEMENT.STANDALONE.FORCE.getPlasma(), 100) },
-                3 * 20,
-                (int) TierEU.RECIPE_LuV,
-                100_000_000);
+        GT_Values.RA.stdBuilder()
+                .noItemInputs()
+                .noItemOutputs()
+                .fluidInputs(new FluidStack(ELEMENT.getInstance().NEON.getPlasma(), 100), Materials.Bedrockium.getMolten(1000))
+                .fluidOutputs(new FluidStack(ELEMENT.STANDALONE.FORCE.getPlasma(), 100))
+                .duration(3 * SECONDS)
+                .eut(TierEU.RECIPE_LuV)
+                .metadata(FUSION_THRESHOLD, 100000000)
+                .addTo(sFusionRecipes);
 
         // Mk2
-        GT_Values.RA.addFusionReactorRecipe(
-                new FluidStack[] { Materials.Niobium.getPlasma(100), Materials.Zinc.getPlasma(100) },
-                new FluidStack[] { new FluidStack(ELEMENT.getInstance().KRYPTON.getPlasma(), 100) },
-                3 * 20,
-                (int) TierEU.RECIPE_ZPM,
-                300_000_000);
+        GT_Values.RA.stdBuilder()
+                .noItemInputs()
+                .noItemOutputs()
+                .fluidInputs(Materials.Niobium.getPlasma(100), Materials.Zinc.getPlasma(100))
+                .fluidOutputs(new FluidStack(ELEMENT.getInstance().KRYPTON.getPlasma(), 100))
+                .duration(3 * SECONDS)
+                .eut(TierEU.RECIPE_ZPM)
+                .metadata(FUSION_THRESHOLD, 300000000)
+                .addTo(sFusionRecipes);
 
-        GT_Values.RA.addFusionReactorRecipe(
-                new FluidStack[] { new FluidStack(ELEMENT.getInstance().NEON.getPlasma(), 100), new FluidStack(ELEMENT.STANDALONE.FORCE.getPlasma(), 100) },
-                new FluidStack[] { new FluidStack(ELEMENT.STANDALONE.ASTRAL_TITANIUM.getPlasma(), 100) },
-                3 * 20,
-                (int) TierEU.RECIPE_ZPM,
-                300_000_000);
+        GT_Values.RA.stdBuilder()
+                .noItemInputs()
+                .noItemOutputs()
+                .fluidInputs(new FluidStack(ELEMENT.getInstance().KRYPTON.getPlasma(), 100), new FluidStack(ELEMENT.STANDALONE.FORCE.getPlasma(), 100))
+                .fluidOutputs(new FluidStack(ELEMENT.STANDALONE.ASTRAL_TITANIUM.getPlasma(), 100))
+                .duration(3 * SECONDS)
+                .eut(TierEU.RECIPE_ZPM)
+                .metadata(FUSION_THRESHOLD, 300000000)
+                .addTo(sFusionRecipes);
 
-        GT_Values.RA.addFusionReactorRecipe(
-                new FluidStack[] { new FluidStack(ELEMENT.STANDALONE.ASTRAL_TITANIUM.getPlasma(), 100), new FluidStack(ALLOY.TITANSTEEL.getFluid(), 1000) },
-                new FluidStack[] { new FluidStack(ELEMENT.STANDALONE.RUNITE.getPlasma(), 100) },
-                3 * 20,
-                (int) TierEU.RECIPE_ZPM,
-                300_000_000);
+        GT_Values.RA.stdBuilder()
+                .noItemInputs()
+                .noItemOutputs()
+                .fluidInputs(new FluidStack(ELEMENT.STANDALONE.ASTRAL_TITANIUM.getPlasma(), 100), new FluidStack(ALLOY.TITANSTEEL.getFluid(), 1000))
+                .fluidOutputs(new FluidStack(ELEMENT.STANDALONE.RUNITE.getPlasma(), 100))
+                .duration(3 * SECONDS)
+                .eut(TierEU.RECIPE_ZPM)
+                .metadata(FUSION_THRESHOLD, 300000000)
+                .addTo(sFusionRecipes);
 
         // Mk3
-        GT_Values.RA.addFusionReactorRecipe(
-                new FluidStack[] { ELEMENT.getInstance().CURIUM.getFluidStack(100), Materials.Americium.getPlasma(100) },
-                new FluidStack[] { new FluidStack(ELEMENT.getInstance().XENON.getPlasma(), 100) },
-                3 * 20,
-                (int) TierEU.RECIPE_UV,
-                500_000_000);
+        GT_Values.RA.stdBuilder()
+                .noItemInputs()
+                .noItemOutputs()
+                .fluidInputs(ELEMENT.getInstance().CURIUM.getFluidStack(100), Materials.Americium.getPlasma(100))
+                .fluidOutputs(new FluidStack(ELEMENT.getInstance().XENON.getPlasma(), 100))
+                .duration(3 * SECONDS)
+                .eut(TierEU.RECIPE_UV)
+                .metadata(FUSION_THRESHOLD, 500000000)
+                .addTo(sFusionRecipes);
 
-        GT_Values.RA.addFusionReactorRecipe(
-                new FluidStack[] { new FluidStack(ELEMENT.getInstance().XENON.getPlasma(), 100), new FluidStack(ELEMENT.STANDALONE.RUNITE.getPlasma(), 100) },
-                new FluidStack[] { new FluidStack(ELEMENT.STANDALONE.ADVANCED_NITINOL.getPlasma(), 100) },
-                3 * 20,
-                (int) TierEU.RECIPE_UV,
-                500_000_000);
+        GT_Values.RA.stdBuilder()
+                .noItemInputs()
+                .noItemOutputs()
+                .fluidInputs(new FluidStack(ELEMENT.getInstance().XENON.getPlasma(), 100), new FluidStack(ELEMENT.STANDALONE.RUNITE.getPlasma(), 100))
+                .fluidOutputs(new FluidStack(ELEMENT.STANDALONE.ADVANCED_NITINOL.getPlasma(), 100))
+                .duration(3 * SECONDS)
+                .eut(TierEU.RECIPE_UV)
+                .metadata(FUSION_THRESHOLD, 500000000)
+                .addTo(sFusionRecipes);
 
-        GT_Values.RA.addFusionReactorRecipe(
-                new FluidStack[] { new FluidStack(ELEMENT.STANDALONE.ADVANCED_NITINOL.getPlasma(), 100), Materials.Tartarite.getMolten(1000) },
-                new FluidStack[] { new FluidStack(ELEMENT.STANDALONE.CELESTIAL_TUNGSTEN.getPlasma(), 100) },
-                3 * 20,
-                (int) TierEU.RECIPE_UV,
-                500_000_000);
+        GT_Values.RA.stdBuilder()
+                .noItemInputs()
+                .noItemOutputs()
+                .fluidInputs(new FluidStack(ELEMENT.STANDALONE.ADVANCED_NITINOL.getPlasma(), 100), Materials.Tartarite.getMolten(1000))
+                .fluidOutputs(new FluidStack(ELEMENT.STANDALONE.CELESTIAL_TUNGSTEN.getPlasma(), 100))
+                .duration(3 * SECONDS)
+                .eut(TierEU.RECIPE_UV)
+                .metadata(FUSION_THRESHOLD, 500000000)
+                .addTo(sFusionRecipes);
     }
 
     private static void macerator() {


### PR DESCRIPTION
This PR comes as a follow-up to the one that changed XL Plasma Turbines to apply penalties to plasmas based on their fuel value. The idea is that Helium and Tin plasmas won't be used from ZPM to many tiers later, upscaled indefinitely with compacts and XLs.

As an alternative, I suggest these fusion recipes for plasmas that already exist in the pack, generated by GT++ (which is why this PR is in GT++), but which have no recipes. This makes it so Plasma Mixer setups are unchanged. The fusion recipes follow a chain, instead of being just two common materials fused into a plasma to be used for power directly:

Mk1: Boron Plasma + Calcium Plasma -> Neon Plasma
Neon Plasma +  Molten Bedrockium -> Force Plasma

Mk2: Niobium Plasma + Zinc Plasma -> Krypton Plasma
Krypton Plasma + Force Plasma -> Astral Titanium Plasma
Astral Titanium Plasma +  Molten Titansteel -> Runite Plasma

Mk3: Molten Curium + Americium Plasma -> Xenon Plasma
Xenon Plasma + Runite Plasma -> Advanced Nitinol Plasma
Advanced Nitinol Plasma + Molten Tartarite -> Celestial Tungsten Plasma

I wrote a txt file with more information, and pasted it inside the spoiler below.

<details>
  <summary>Full doc</summary>
    Fusion chain logic: two fusion reactor outputs fuse into a new plasma, and then a material of the appropriate GT tier is fused into that plasma to create the power-dense plasma. At mk2 and mk3, the previous plasma needs to be added to the chain to make the new one.
  
  The first fusion makes a noble gas plasma. For mk2 and mk3, the next step makes a "magical metal" plasma by fusing the noble gas with the previous tier's complete plasma. The last step is to add a GT tier-appropriate material, which makes the power-dense plasma - Force, Runite or Dragonblood.
  
  All the new plasmas already exist in the pack, created by GT++. They just need to receive recipes.
  
  Mk1: Boron Plasma + Calcium Plasma -> X Plasma
  X Plasma +  Molten Bedrockium -> Improved X Plasma
  
  Mk2: Niobium Plasma + Zinc Plasma -> Y Plasma
  Y Plasma + Improved X Plasma -> XY Plasma
  XY Plasma +  Molten Titansteel -> Improved XY Plasma
  
  Mk3: Molten Curium + Americium Plasma -> Z Plasma
  Z Plasma + Improved XY Plasma -> XYZ Plasma
  XYZ Plasma + Molten Tairitsu -> Improved XYZ Plasma
  
  -----------------------------------------------------
  
  Mk1: Boron Plasma + Calcium Plasma -> Neon Plasma
  Neon Plasma +  Molten Bedrockium -> Force Plasma
  
  Mk2: Niobium Plasma + Zinc Plasma -> Krypton Plasma
  Krypton Plasma + Force Plasma -> Astral Titanium Plasma
  Astral Titanium Plasma +  Molten Titansteel ->  Runite Plasma
  
  Mk3: Molten Curium + Americium Plasma -> Xenon Plasma
  Xenon Plasma + Runite Plasma -> Advanced Nitinol Plasma
  Advanced Nitinol Plasma + Molten Tartarite -> Celestial Tungsten Plasma
  
</details>

Recipe numbers are not final, since I do not want to balance this by myself. The only rule applied here is that the recipes are set to mk1, mk2 or mk3 reactors. The fuel values are also the default ones, and will be changed when the XL formula is fully reasoned through.