### PR TITLE
Change XL Plasma Penalty Formula and Fuel Values for New Plasmas

### DIFF
--- a/src/main/java/gtPlusPlus/core/material/MaterialGenerator.java
+++ b/src/main/java/gtPlusPlus/core/material/MaterialGenerator.java
@@ -422,6 +422,7 @@ public class MaterialGenerator {
             new RecipeGen_MaterialProcessing(matInfo);
             new RecipeGen_DustGeneration(matInfo);
             new RecipeGen_Recycling(matInfo);
+            new RecipeGen_Plasma(matInfo);
             return true;
         } catch (final Throwable t) {
             Logger.MATERIALS("" + matInfo.getLocalizedName() + " failed to generate.");

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/turbines/GT_MTE_LargeTurbine_Plasma.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/turbines/GT_MTE_LargeTurbine_Plasma.java
@@ -159,9 +159,9 @@ public class GT_MTE_LargeTurbine_Plasma extends GregtechMetaTileEntity_LargerTur
 
             // Reduce produced power depending on the ratio between fuel value and turbine EU/t with the following
             // formula:
-            // EU/t = EU/t * MIN(1, ( ( (FuelValue / 100) ^ 2 ) / EUPerTurbine))
+            // EU/t = EU/t * MIN(1, ( ( (FuelValue / 200) ^ 2 ) / EUPerTurbine))
             int fuelValue = getFuelValue(new FluidStack(tFluids.get(0), 0));
-            float magicValue = (fuelValue * 0.01f) * (fuelValue * 0.01f);
+            float magicValue = (fuelValue * 0.005f) * (fuelValue * 0.005f);
             float efficiencyLoss = Math.min(1.0f, magicValue / euPerTurbine);
             newPower *= efficiencyLoss;
 

--- a/src/main/java/gtPlusPlus/xmod/gregtech/loaders/RecipeGen_Plasma.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/loaders/RecipeGen_Plasma.java
@@ -40,25 +40,13 @@ public class RecipeGen_Plasma extends RecipeGen_Base {
                     ? GT_Utility.getContainerItem(aPlasmaCell, true)
                     : CI.emptyCells(1);
             if (ItemUtils.checkForInvalidItems(new ItemStack[] { aPlasmaCell, aContainerItem })) {
-                switch(material.getUnlocalizedName()) {
+                switch (material.getUnlocalizedName()) {
                     case "Force":
-                        GT_Values.RA.addFuel(
-                                GT_Utility.copyAmount(1L, aPlasmaCell),
-                                aContainerItem,
-                                150_000,
-                                4);
+                        GT_Values.RA.addFuel(GT_Utility.copyAmount(1L, aPlasmaCell), aContainerItem, 150_000, 4);
                     case "Runite":
-                        GT_Values.RA.addFuel(
-                                GT_Utility.copyAmount(1L, aPlasmaCell),
-                                aContainerItem,
-                                350_000,
-                                4);
+                        GT_Values.RA.addFuel(GT_Utility.copyAmount(1L, aPlasmaCell), aContainerItem, 350_000, 4);
                     case "CelestialTungsten":
-                        GT_Values.RA.addFuel(
-                                GT_Utility.copyAmount(1L, aPlasmaCell),
-                                aContainerItem,
-                                600_000,
-                                4);
+                        GT_Values.RA.addFuel(GT_Utility.copyAmount(1L, aPlasmaCell), aContainerItem, 600_000, 4);
                     default:
                         GT_Values.RA.addFuel(
                                 GT_Utility.copyAmount(1L, aPlasmaCell),

--- a/src/main/java/gtPlusPlus/xmod/gregtech/loaders/RecipeGen_Plasma.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/loaders/RecipeGen_Plasma.java
@@ -40,11 +40,33 @@ public class RecipeGen_Plasma extends RecipeGen_Base {
                     ? GT_Utility.getContainerItem(aPlasmaCell, true)
                     : CI.emptyCells(1);
             if (ItemUtils.checkForInvalidItems(new ItemStack[] { aPlasmaCell, aContainerItem })) {
-                GT_Values.RA.addFuel(
-                        GT_Utility.copyAmount(1L, aPlasmaCell),
-                        aContainerItem,
-                        (int) Math.max(1024L, 1024L * material.getMass()),
-                        4);
+                switch(material.getUnlocalizedName()) {
+                    case "Force":
+                        GT_Values.RA.addFuel(
+                                GT_Utility.copyAmount(1L, aPlasmaCell),
+                                aContainerItem,
+                                150_000,
+                                4);
+                    case "Runite":
+                        GT_Values.RA.addFuel(
+                                GT_Utility.copyAmount(1L, aPlasmaCell),
+                                aContainerItem,
+                                350_000,
+                                4);
+                    case "CelestialTungsten":
+                        GT_Values.RA.addFuel(
+                                GT_Utility.copyAmount(1L, aPlasmaCell),
+                                aContainerItem,
+                                600_000,
+                                4);
+                    default:
+                        GT_Values.RA.addFuel(
+                                GT_Utility.copyAmount(1L, aPlasmaCell),
+                                aContainerItem,
+                                (int) Math.max(1024L, 1024L * material.getMass()),
+                                4);
+
+                }
             }
             if (ItemUtils.checkForInvalidItems(new ItemStack[] { aCell, aPlasmaCell })) {
                 GT_Values.RA.addVacuumFreezerRecipe(aPlasmaCell, aCell, (int) Math.max(material.getMass() * 2L, 1L));


### PR DESCRIPTION
Refer to [GT5U #2060](https://github.com/GTNewHorizons/GT5-Unofficial/pull/2060) for the Tin Plasma change.

![image](https://github.com/GTNewHorizons/GTplusplus/assets/70096037/6b960dea-4a44-46d3-8263-1c484ba6665c)

These are the changes that this PR proposes. The objective is to change the formula to properly penalize Tin Plasma, alongside the GT5u PR I made alongside this one ([GT5U #2060](https://github.com/GTNewHorizons/GT5-Unofficial/pull/2060)) since it's only slightly lower than 50% efficiency with the current formula, which means that people just need to double their reactors and XLs to continue using the same powergen. At the same time, the new fusion chains I added now have a good fuel value that makes them escape the penalty on different turbine materials, depending on the fusion tier of the plasma.

Currently, the best plasma to use with infinity XLs is probably Americium, since it's still one-step, with a tiny penalty and not very expensive. This will be discussed later, alongside the actual numbers and EU/t for the fusion chains. I haven't set proper numbers for those because I still don't know if the intention is to match the extreme numbers of Helium/Tin Plasma with fusion spam that were possible before these penalties.