### PR TITLE
Remove outdated botdustries compat recipes

### DIFF
--- a/src/main/java/gtPlusPlus/core/item/chemistry/RocketFuels.java
+++ b/src/main/java/gtPlusPlus/core/item/chemistry/RocketFuels.java
@@ -123,59 +123,6 @@ public class RocketFuels extends ItemPackage {
                 20 * 30,
                 MaterialUtils.getVoltageForTier(2),
                 1);
-
-        FluidStack aBartWorksHydrazine = FluidUtils.getWildcardFluidStack("hydrazine", 1000);
-        if (aBartWorksHydrazine != null) {
-            Logger.INFO("Found BW Hydrazine, adding compat recipe.");
-            CORE.RA.addDistilleryRecipe(
-                    GT_Utility.getIntegratedCircuit(24),
-                    FluidUtils.getFluidStack(Hydrazine, 1000),
-                    aBartWorksHydrazine,
-                    null,
-                    20,
-                    8,
-                    false);
-
-            CORE.RA.addDistilleryRecipe(
-                    GT_Utility.getIntegratedCircuit(24),
-                    aBartWorksHydrazine,
-                    FluidUtils.getFluidStack(Hydrazine, 1000),
-                    null,
-                    20,
-                    8,
-                    false);
-        }
-
-        FluidStack aBartWorksHydrogenPeroxide = FluidUtils.getWildcardFluidStack("Hydrogen Peroxide", 1000);
-        if (aBartWorksHydrogenPeroxide != null) {
-            Logger.INFO("Found BW Hydrogen Peroxide, adding compat recipe.");
-            CORE.RA.addChemicalPlantRecipe(
-                    new ItemStack[] { CI.getNumberedCircuit(22) },
-                    new FluidStack[] { aBartWorksHydrogenPeroxide, FluidUtils.getFluidStack("ammonia", 2000), },
-                    new ItemStack[] {},
-                    new FluidStack[] { FluidUtils.getFluidStack(Hydrazine, 1000), },
-                    20 * 30,
-                    MaterialUtils.getVoltageForTier(2),
-                    1);
-
-            CORE.RA.addDistilleryRecipe(
-                    GT_Utility.getIntegratedCircuit(24),
-                    FluidUtils.getFluidStack("fluid.hydrogenperoxide", 1000),
-                    aBartWorksHydrogenPeroxide,
-                    null,
-                    20,
-                    8,
-                    false);
-
-            CORE.RA.addDistilleryRecipe(
-                    GT_Utility.getIntegratedCircuit(24),
-                    aBartWorksHydrogenPeroxide,
-                    FluidUtils.getFluidStack("fluid.hydrogenperoxide", 1000),
-                    null,
-                    20,
-                    8,
-                    false);
-        }
     }
 
     public static void createMonomethylhydrazine() {
@@ -194,7 +141,7 @@ public class RocketFuels extends ItemPackage {
 
         FluidStack aBartWorksMonomethylhydrazine = FluidUtils.getWildcardFluidStack("Monomethylhydrazine", 1000);
         if (aBartWorksMonomethylhydrazine != null) {
-            Logger.INFO("Found BW Hydrazine, adding compat recipe.");
+            Logger.INFO("Found BW Monomethylhydrazine, adding compat recipe.");
             CORE.RA.addDistilleryRecipe(
                     GT_Utility.getIntegratedCircuit(24),
                     FluidUtils.getFluidStack(Monomethylhydrazine, 1000),
@@ -269,28 +216,6 @@ public class RocketFuels extends ItemPackage {
                 20 * 90,
                 120,
                 1);
-
-        FluidStack aBartWorksFormaldehyde = FluidUtils.getWildcardFluidStack("Formaldehyde", 1000);
-        if (aBartWorksFormaldehyde != null) {
-            Logger.INFO("Found BW Formaldehyde, adding compat recipe.");
-            CORE.RA.addDistilleryRecipe(
-                    GT_Utility.getIntegratedCircuit(24),
-                    FluidUtils.getFluidStack(Formaldehyde, 1000),
-                    aBartWorksFormaldehyde,
-                    null,
-                    20,
-                    8,
-                    false);
-
-            CORE.RA.addDistilleryRecipe(
-                    GT_Utility.getIntegratedCircuit(24),
-                    aBartWorksFormaldehyde,
-                    FluidUtils.getFluidStack(Formaldehyde, 1000),
-                    null,
-                    20,
-                    8,
-                    false);
-        }
     }
 
     private static void createFormaldehydeCatalyst() {


### PR DESCRIPTION
follow up to https://github.com/GTNewHorizons/GTNH-Lanthanides/pull/58.
These botdustries fluids no longer exists (marked here as bartworks as they were part of that material system, last in GTNH lanth), so these compat recipes can go. In fact they just detect gt++s own fluid and do a convert them to themselves.