### PR TITLE
Adds a platline comb recipe to QFT

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,5 +1,5 @@
 dependencies {
-    api('com.github.GTNewHorizons:GT5-Unofficial:5.09.43.67-pre:dev')
+    api('com.github.GTNewHorizons:GT5-Unofficial:5.09.43.79-pre:dev')
     api("com.github.GTNewHorizons:bartworks:0.7.12:dev")
 
     implementation('curse.maven:cofh-core-69162:2388751')

--- a/src/main/java/gtPlusPlus/xmod/gregtech/loaders/recipe/RecipeLoader_ChemicalSkips.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/loaders/recipe/RecipeLoader_ChemicalSkips.java
@@ -210,7 +210,21 @@ public class RecipeLoader_ChemicalSkips {
                 20 * 20,
                 (int) TierEU.RECIPE_UIV,
                 4);
-
+        // Platline skip using Platline Combs (Palladium, Osmium, Iridium, Platinum)
+        CORE.RA.addQuantumTransformerRecipe(
+                new ItemStack[] { WerkstoffLoader.PTMetallicPowder.get(OrePrefixes.dust, 16), GT_Bees.combs.getStackForType(CombType.PLATINUM, 16),
+                        GT_Bees.combs.getStackForType(CombType.PALLADIUM, 16),
+                        GT_Bees.combs.getStackForType(CombType.OSMIUM, 16),
+                        GT_Bees.combs.getStackForType(CombType.IRIDIUM, 16),
+                        ItemUtils.getSimpleStack(GenericChem.mPlatinumGroupCatalyst, 0) },
+                null,
+                null,
+                new ItemStack[] { Materials.Platinum.getDust(64), Materials.Palladium.getDust(64),
+                        Materials.Iridium.getDust(64), Materials.Osmium.getDust(64) },
+                new int[] { 2500, 2500, 2500, 2500 },
+                20 * 10,
+                (int) TierEU.RECIPE_UV,
+                1);
         // Bio Cells and Mutated Solder
         CORE.RA.addQuantumTransformerRecipe(
                 new ItemStack[] { ItemList.Circuit_Chip_Stemcell.get(16), Materials.InfinityCatalyst.getDust(4),

--- a/src/main/java/gtPlusPlus/xmod/gregtech/loaders/recipe/RecipeLoader_ChemicalSkips.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/loaders/recipe/RecipeLoader_ChemicalSkips.java
@@ -212,7 +212,8 @@ public class RecipeLoader_ChemicalSkips {
                 4);
         // Platline skip using Platline Combs (Palladium, Osmium, Iridium, Platinum)
         CORE.RA.addQuantumTransformerRecipe(
-                new ItemStack[] { WerkstoffLoader.PTMetallicPowder.get(OrePrefixes.dust, 16), GT_Bees.combs.getStackForType(CombType.PLATINUM, 16),
+                new ItemStack[] { WerkstoffLoader.PTMetallicPowder.get(OrePrefixes.dust, 16),
+                        GT_Bees.combs.getStackForType(CombType.PLATINUM, 16),
                         GT_Bees.combs.getStackForType(CombType.PALLADIUM, 16),
                         GT_Bees.combs.getStackForType(CombType.OSMIUM, 16),
                         GT_Bees.combs.getStackForType(CombType.IRIDIUM, 16),


### PR DESCRIPTION
Addition to PMP recipe, a comb pmp recipe needing Osmium, Palladium, Iridium and Platinum combs to give 2x more output than the regular PMP QFT recipe.

This also needs a dep update. GT5-Unofficial:5.09.43.80, bartworks:0.7.16

![image](https://github.com/GTNewHorizons/GTplusplus/assets/48415331/15c5f66f-cdb8-418c-96a4-1a3ad5185588)
