### PR TITLE
Fix gt++ pollution tooltips

### DIFF
--- a/src/main/java/gtPlusPlus/xmod/gregtech/api/metatileentity/implementations/base/GregtechMeta_MultiBlockBase.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/api/metatileentity/implementations/base/GregtechMeta_MultiBlockBase.java
@@ -111,6 +111,15 @@ public abstract class GregtechMeta_MultiBlockBase<T extends GT_MetaTileEntity_Ex
 
     public static final boolean DEBUG_DISABLE_CORES_TEMPORARILY = true;
 
+    private static Method calculatePollutionReduction = null;
+
+    static {
+        try {
+            calculatePollutionReduction = GT_MetaTileEntity_Hatch_Muffler.class
+                    .getDeclaredMethod("calculatePollutionReduction", int.class);
+        } catch (NoSuchMethodException | SecurityException ignored) {}
+    }
+
     public GT_Recipe mLastRecipe;
     private boolean mInternalCircuit = false;
     protected long mTotalRunTime = 0;
@@ -1601,8 +1610,6 @@ public abstract class GregtechMeta_MultiBlockBase<T extends GT_MetaTileEntity_Ex
     /**
      * Pollution Management
      */
-    private static Method calculatePollutionReduction = null;
-
     public int calculatePollutionReductionForHatch(GT_MetaTileEntity_Hatch_Muffler i, int g) {
         if (calculatePollutionReduction != null) {
             try {

--- a/src/main/java/gtPlusPlus/xmod/gregtech/api/metatileentity/implementations/base/GregtechMeta_MultiBlockBase.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/api/metatileentity/implementations/base/GregtechMeta_MultiBlockBase.java
@@ -111,15 +111,6 @@ public abstract class GregtechMeta_MultiBlockBase<T extends GT_MetaTileEntity_Ex
 
     public static final boolean DEBUG_DISABLE_CORES_TEMPORARILY = true;
 
-    private static Method calculatePollutionReduction = null;
-
-    static {
-        try {
-            calculatePollutionReduction = GT_MetaTileEntity_Hatch_Muffler.class
-                    .getDeclaredMethod("calculatePollutionReduction", int.class);
-        } catch (NoSuchMethodException | SecurityException ignored) {}
-    }
-
     public GT_Recipe mLastRecipe;
     private boolean mInternalCircuit = false;
     protected long mTotalRunTime = 0;
@@ -1610,15 +1601,8 @@ public abstract class GregtechMeta_MultiBlockBase<T extends GT_MetaTileEntity_Ex
     /**
      * Pollution Management
      */
-    public int calculatePollutionReductionForHatch(GT_MetaTileEntity_Hatch_Muffler i, int g) {
-        if (calculatePollutionReduction != null) {
-            try {
-                return (int) calculatePollutionReduction.invoke(i, g);
-            } catch (IllegalAccessException | IllegalArgumentException | InvocationTargetException e) {
-
-            }
-        }
-        return 0;
+    public int calculatePollutionReductionForHatch(GT_MetaTileEntity_Hatch_Muffler hatch, int poll) {
+        return hatch.calculatePollutionReduction(poll);
     }
 
     @Override


### PR DESCRIPTION
They incorrectly just showed reduction to 0% for any muffler: 
![image](https://github.com/GTNewHorizons/GTplusplus/assets/40274384/934ba71b-8907-427d-a332-5f2c2055e8cb)
now working correctly:
![image](https://github.com/GTNewHorizons/GTplusplus/assets/40274384/9c24ff53-d411-4407-b49e-9dd394bde44a)


was broken by https://github.com/GTNewHorizons/GTplusplus/pull/531 which is where I got the needed code from :P

I think the actual pollution was functional.

fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/13633