### PR TITLE
Qft addition

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,5 +1,5 @@
 dependencies {
-    api('com.github.GTNewHorizons:GT5-Unofficial:5.09.43.67-pre:dev')
+    api('com.github.GTNewHorizons:GT5-Unofficial:5.09.43.79-pre:dev')
     api("com.github.GTNewHorizons:bartworks:0.7.12:dev")
 
     implementation('curse.maven:cofh-core-69162:2388751')

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,6 +1,6 @@
 dependencies {
     api('com.github.GTNewHorizons:GT5-Unofficial:5.09.43.79-pre:dev')
-    api("com.github.GTNewHorizons:bartworks:0.7.12:dev")
+    api("com.github.GTNewHorizons:bartworks:0.7.17:dev")
 
     implementation('curse.maven:cofh-core-69162:2388751')
     // https://www.curseforge.com/minecraft/mc-mods/advancedsolarpanels

--- a/src/main/java/gtPlusPlus/xmod/gregtech/loaders/recipe/RecipeLoader_ChemicalSkips.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/loaders/recipe/RecipeLoader_ChemicalSkips.java
@@ -210,7 +210,21 @@ public class RecipeLoader_ChemicalSkips {
                 20 * 20,
                 (int) TierEU.RECIPE_UIV,
                 4);
-
+        // Platline skip using Platline Combs (Palladium, Osmium, Iridium, Platinum)
+        CORE.RA.addQuantumTransformerRecipe(
+                new ItemStack[] { WerkstoffLoader.PTMetallicPowder.get(OrePrefixes.dust, 16), GT_Bees.combs.getStackForType(CombType.PLATINUM, 16),
+                        GT_Bees.combs.getStackForType(CombType.PALLADIUM, 16),
+                        GT_Bees.combs.getStackForType(CombType.OSMIUM, 16),
+                        GT_Bees.combs.getStackForType(CombType.IRIDIUM, 16),
+                        ItemUtils.getSimpleStack(GenericChem.mPlatinumGroupCatalyst, 0) },
+                null,
+                null,
+                new ItemStack[] { Materials.Platinum.getDust(64), Materials.Palladium.getDust(64),
+                        Materials.Iridium.getDust(64), Materials.Osmium.getDust(64) },
+                new int[] { 2500, 2500, 2500, 2500 },
+                20 * 10,
+                (int) TierEU.RECIPE_UV,
+                1);
         // Bio Cells and Mutated Solder
         CORE.RA.addQuantumTransformerRecipe(
                 new ItemStack[] { ItemList.Circuit_Chip_Stemcell.get(16), Materials.InfinityCatalyst.getDust(4),

--- a/src/main/java/gtPlusPlus/xmod/gregtech/loaders/recipe/RecipeLoader_ChemicalSkips.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/loaders/recipe/RecipeLoader_ChemicalSkips.java
@@ -212,18 +212,17 @@ public class RecipeLoader_ChemicalSkips {
                 4);
         // Platline skip using Platline Combs (Palladium, Osmium, Iridium, Platinum)
         CORE.RA.addQuantumTransformerRecipe(
-                new ItemStack[] { WerkstoffLoader.PTMetallicPowder.get(OrePrefixes.dust, 16),
-                        GT_Bees.combs.getStackForType(CombType.PLATINUM, 16),
-                        GT_Bees.combs.getStackForType(CombType.PALLADIUM, 16),
-                        GT_Bees.combs.getStackForType(CombType.OSMIUM, 16),
-                        GT_Bees.combs.getStackForType(CombType.IRIDIUM, 16),
+                new ItemStack[] { GT_Bees.combs.getStackForType(CombType.PLATINUM, 32),
+                        GT_Bees.combs.getStackForType(CombType.PALLADIUM, 32),
+                        GT_Bees.combs.getStackForType(CombType.OSMIUM, 32),
+                        GT_Bees.combs.getStackForType(CombType.IRIDIUM, 32),
                         ItemUtils.getSimpleStack(GenericChem.mPlatinumGroupCatalyst, 0) },
-                null,
-                null,
-                new ItemStack[] { Materials.Platinum.getDust(64), Materials.Palladium.getDust(64),
-                        Materials.Iridium.getDust(64), Materials.Osmium.getDust(64) },
+                new FluidStack[] {},
+                new FluidStack[] { Materials.Osmium.getMolten(144 * 128), Materials.Palladium.getMolten(144 * 128),
+                        Materials.Iridium.getMolten(144 * 128), Materials.Platinum.getMolten(144 * 128) },
+                new ItemStack[] { },
                 new int[] { 2500, 2500, 2500, 2500 },
-                20 * 10,
+                20 * 20,
                 (int) TierEU.RECIPE_UV,
                 1);
         // Bio Cells and Mutated Solder

--- a/src/main/java/gtPlusPlus/xmod/gregtech/loaders/recipe/RecipeLoader_ChemicalSkips.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/loaders/recipe/RecipeLoader_ChemicalSkips.java
@@ -212,7 +212,8 @@ public class RecipeLoader_ChemicalSkips {
                 4);
         // Platline skip using Platline Combs (Palladium, Osmium, Iridium, Platinum)
         CORE.RA.addQuantumTransformerRecipe(
-                new ItemStack[] { WerkstoffLoader.PTMetallicPowder.get(OrePrefixes.dust, 16), GT_Bees.combs.getStackForType(CombType.PLATINUM, 16),
+                new ItemStack[] { WerkstoffLoader.PTMetallicPowder.get(OrePrefixes.dust, 16),
+                        GT_Bees.combs.getStackForType(CombType.PLATINUM, 16),
                         GT_Bees.combs.getStackForType(CombType.PALLADIUM, 16),
                         GT_Bees.combs.getStackForType(CombType.OSMIUM, 16),
                         GT_Bees.combs.getStackForType(CombType.IRIDIUM, 16),


### PR DESCRIPTION
![image](https://github.com/GTNewHorizons/GTplusplus/assets/48415331/931a8f09-885e-4023-ae00-30a7c25c0934)

Now that QFT recipes are in the PlatinumSludge exception list, this is the proper recipe
+ updated bartwork dep to 0.7.17 
