### PR TITLE
Make the New Plasma Powergen Chains Viable

### DIFF
--- a/src/main/java/gtPlusPlus/xmod/gregtech/loaders/RecipeGen_Plasma.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/loaders/RecipeGen_Plasma.java
@@ -46,7 +46,7 @@ public class RecipeGen_Plasma extends RecipeGen_Base {
                     case "Runite":
                         GT_Values.RA.addFuel(GT_Utility.copyAmount(1L, aPlasmaCell), aContainerItem, 350_000, 4);
                     case "CelestialTungsten":
-                        GT_Values.RA.addFuel(GT_Utility.copyAmount(1L, aPlasmaCell), aContainerItem, 600_000, 4);
+                        GT_Values.RA.addFuel(GT_Utility.copyAmount(1L, aPlasmaCell), aContainerItem, 720_000, 4);
                     default:
                         GT_Values.RA.addFuel(
                                 GT_Utility.copyAmount(1L, aPlasmaCell),

--- a/src/main/java/gtPlusPlus/xmod/gregtech/loaders/recipe/RecipeLoader_Nuclear.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/loaders/recipe/RecipeLoader_Nuclear.java
@@ -497,22 +497,22 @@ public class RecipeLoader_Nuclear {
 
         // Mk2
         GT_Values.RA.stdBuilder().noItemInputs().noItemOutputs()
-                .fluidInputs(Materials.Niobium.getPlasma(100), Materials.Zinc.getPlasma(100))
-                .fluidOutputs(new FluidStack(ELEMENT.getInstance().KRYPTON.getPlasma(), 100)).duration(3 * SECONDS)
+                .fluidInputs(Materials.Niobium.getPlasma(144), Materials.Zinc.getPlasma(144))
+                .fluidOutputs(new FluidStack(ELEMENT.getInstance().KRYPTON.getPlasma(), 100)).duration(32 * TICKS)
                 .eut(TierEU.RECIPE_ZPM).metadata(FUSION_THRESHOLD, 300000000).addTo(sFusionRecipes);
 
         GT_Values.RA.stdBuilder().noItemInputs().noItemOutputs()
                 .fluidInputs(
-                        new FluidStack(ELEMENT.getInstance().KRYPTON.getPlasma(), 100),
-                        new FluidStack(ELEMENT.STANDALONE.FORCE.getPlasma(), 100))
-                .fluidOutputs(new FluidStack(ELEMENT.STANDALONE.ASTRAL_TITANIUM.getPlasma(), 100)).duration(3 * SECONDS)
+                        new FluidStack(ELEMENT.getInstance().KRYPTON.getPlasma(), 144),
+                        new FluidStack(ELEMENT.STANDALONE.FORCE.getPlasma(), 1000))
+                .fluidOutputs(new FluidStack(ELEMENT.STANDALONE.ASTRAL_TITANIUM.getPlasma(), 1000)).duration(32 * TICKS)
                 .eut(TierEU.RECIPE_ZPM).metadata(FUSION_THRESHOLD, 300000000).addTo(sFusionRecipes);
 
         GT_Values.RA.stdBuilder().noItemInputs().noItemOutputs()
                 .fluidInputs(
-                        new FluidStack(ELEMENT.STANDALONE.ASTRAL_TITANIUM.getPlasma(), 100),
-                        new FluidStack(ALLOY.TITANSTEEL.getFluid(), 1000))
-                .fluidOutputs(new FluidStack(ELEMENT.STANDALONE.RUNITE.getPlasma(), 100)).duration(3 * SECONDS)
+                        new FluidStack(ELEMENT.STANDALONE.ASTRAL_TITANIUM.getPlasma(), 144),
+                        new FluidStack(ALLOY.TITANSTEEL.getFluid(), 8))
+                .fluidOutputs(new FluidStack(ELEMENT.STANDALONE.RUNITE.getPlasma(), 1000)).duration(32 * TICKS)
                 .eut(TierEU.RECIPE_ZPM).metadata(FUSION_THRESHOLD, 300000000).addTo(sFusionRecipes);
 
         // Mk3

--- a/src/main/java/gtPlusPlus/xmod/gregtech/loaders/recipe/RecipeLoader_Nuclear.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/loaders/recipe/RecipeLoader_Nuclear.java
@@ -2,6 +2,7 @@ package gtPlusPlus.xmod.gregtech.loaders.recipe;
 
 import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sFusionRecipes;
 import static gregtech.api.util.GT_RecipeBuilder.SECONDS;
+import static gregtech.api.util.GT_RecipeBuilder.TICKS;
 import static gregtech.api.util.GT_RecipeConstants.FUSION_THRESHOLD;
 
 import net.minecraft.item.ItemStack;
@@ -483,15 +484,15 @@ public class RecipeLoader_Nuclear {
     private static void fusionChainRecipes() {
         // Mk1
         GT_Values.RA.stdBuilder().noItemInputs().noItemOutputs()
-                .fluidInputs(Materials.Boron.getPlasma(100), Materials.Calcium.getPlasma(100))
-                .fluidOutputs(new FluidStack(ELEMENT.getInstance().NEON.getPlasma(), 100)).duration(3 * SECONDS)
+                .fluidInputs(Materials.Boron.getPlasma(144), Materials.Calcium.getPlasma(16))
+                .fluidOutputs(new FluidStack(ELEMENT.getInstance().NEON.getPlasma(), 1000)).duration(3 * SECONDS + 4 * TICKS)
                 .eut(TierEU.RECIPE_LuV).metadata(FUSION_THRESHOLD, 100000000).addTo(sFusionRecipes);
 
         GT_Values.RA.stdBuilder().noItemInputs().noItemOutputs()
                 .fluidInputs(
-                        new FluidStack(ELEMENT.getInstance().NEON.getPlasma(), 100),
-                        Materials.Bedrockium.getMolten(1000))
-                .fluidOutputs(new FluidStack(ELEMENT.STANDALONE.FORCE.getPlasma(), 100)).duration(3 * SECONDS)
+                        new FluidStack(ELEMENT.getInstance().NEON.getPlasma(), 144),
+                        Materials.Bedrockium.getMolten(144))
+                .fluidOutputs(new FluidStack(ELEMENT.STANDALONE.FORCE.getPlasma(), 1000)).duration(3 * SECONDS + 4 * TICKS)
                 .eut(TierEU.RECIPE_LuV).metadata(FUSION_THRESHOLD, 100000000).addTo(sFusionRecipes);
 
         // Mk2

--- a/src/main/java/gtPlusPlus/xmod/gregtech/loaders/recipe/RecipeLoader_Nuclear.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/loaders/recipe/RecipeLoader_Nuclear.java
@@ -498,7 +498,7 @@ public class RecipeLoader_Nuclear {
         // Mk2
         GT_Values.RA.stdBuilder().noItemInputs().noItemOutputs()
                 .fluidInputs(Materials.Niobium.getPlasma(144), Materials.Zinc.getPlasma(144))
-                .fluidOutputs(new FluidStack(ELEMENT.getInstance().KRYPTON.getPlasma(), 100)).duration(32 * TICKS)
+                .fluidOutputs(new FluidStack(ELEMENT.getInstance().KRYPTON.getPlasma(), 144)).duration(32 * TICKS)
                 .eut(TierEU.RECIPE_ZPM).metadata(FUSION_THRESHOLD, 300000000).addTo(sFusionRecipes);
 
         GT_Values.RA.stdBuilder().noItemInputs().noItemOutputs()

--- a/src/main/java/gtPlusPlus/xmod/gregtech/loaders/recipe/RecipeLoader_Nuclear.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/loaders/recipe/RecipeLoader_Nuclear.java
@@ -485,15 +485,17 @@ public class RecipeLoader_Nuclear {
         // Mk1
         GT_Values.RA.stdBuilder().noItemInputs().noItemOutputs()
                 .fluidInputs(Materials.Boron.getPlasma(144), Materials.Calcium.getPlasma(16))
-                .fluidOutputs(new FluidStack(ELEMENT.getInstance().NEON.getPlasma(), 1000)).duration(3 * SECONDS + 4 * TICKS)
-                .eut(TierEU.RECIPE_LuV).metadata(FUSION_THRESHOLD, 100000000).addTo(sFusionRecipes);
+                .fluidOutputs(new FluidStack(ELEMENT.getInstance().NEON.getPlasma(), 1000))
+                .duration(3 * SECONDS + 4 * TICKS).eut(TierEU.RECIPE_LuV).metadata(FUSION_THRESHOLD, 100000000)
+                .addTo(sFusionRecipes);
 
         GT_Values.RA.stdBuilder().noItemInputs().noItemOutputs()
                 .fluidInputs(
                         new FluidStack(ELEMENT.getInstance().NEON.getPlasma(), 144),
                         Materials.Bedrockium.getMolten(144))
-                .fluidOutputs(new FluidStack(ELEMENT.STANDALONE.FORCE.getPlasma(), 1000)).duration(3 * SECONDS + 4 * TICKS)
-                .eut(TierEU.RECIPE_LuV).metadata(FUSION_THRESHOLD, 100000000).addTo(sFusionRecipes);
+                .fluidOutputs(new FluidStack(ELEMENT.STANDALONE.FORCE.getPlasma(), 1000))
+                .duration(3 * SECONDS + 4 * TICKS).eut(TierEU.RECIPE_LuV).metadata(FUSION_THRESHOLD, 100000000)
+                .addTo(sFusionRecipes);
 
         // Mk2
         GT_Values.RA.stdBuilder().noItemInputs().noItemOutputs()
@@ -526,16 +528,14 @@ public class RecipeLoader_Nuclear {
                         new FluidStack(ELEMENT.getInstance().XENON.getPlasma(), 144),
                         new FluidStack(ELEMENT.STANDALONE.RUNITE.getPlasma(), 1000))
                 .fluidOutputs(new FluidStack(ELEMENT.STANDALONE.ADVANCED_NITINOL.getPlasma(), 1000))
-                .duration(16 * TICKS).eut(TierEU.RECIPE_UV).metadata(FUSION_THRESHOLD, 500000000)
-                .addTo(sFusionRecipes);
+                .duration(16 * TICKS).eut(TierEU.RECIPE_UV).metadata(FUSION_THRESHOLD, 500000000).addTo(sFusionRecipes);
 
         GT_Values.RA.stdBuilder().noItemInputs().noItemOutputs()
                 .fluidInputs(
                         new FluidStack(ELEMENT.STANDALONE.ADVANCED_NITINOL.getPlasma(), 144),
                         Materials.Tartarite.getMolten(8))
                 .fluidOutputs(new FluidStack(ELEMENT.STANDALONE.CELESTIAL_TUNGSTEN.getPlasma(), 1000))
-                .duration(16 * TICKS).eut(TierEU.RECIPE_UV).metadata(FUSION_THRESHOLD, 500000000)
-                .addTo(sFusionRecipes);
+                .duration(16 * TICKS).eut(TierEU.RECIPE_UV).metadata(FUSION_THRESHOLD, 500000000).addTo(sFusionRecipes);
     }
 
     private static void macerator() {

--- a/src/main/java/gtPlusPlus/xmod/gregtech/loaders/recipe/RecipeLoader_Nuclear.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/loaders/recipe/RecipeLoader_Nuclear.java
@@ -517,24 +517,24 @@ public class RecipeLoader_Nuclear {
 
         // Mk3
         GT_Values.RA.stdBuilder().noItemInputs().noItemOutputs()
-                .fluidInputs(ELEMENT.getInstance().CURIUM.getFluidStack(100), Materials.Americium.getPlasma(100))
-                .fluidOutputs(new FluidStack(ELEMENT.getInstance().XENON.getPlasma(), 100)).duration(3 * SECONDS)
+                .fluidInputs(ELEMENT.getInstance().CURIUM.getFluidStack(144), Materials.Americium.getPlasma(144))
+                .fluidOutputs(new FluidStack(ELEMENT.getInstance().XENON.getPlasma(), 144)).duration(16 * TICKS)
                 .eut(TierEU.RECIPE_UV).metadata(FUSION_THRESHOLD, 500000000).addTo(sFusionRecipes);
 
         GT_Values.RA.stdBuilder().noItemInputs().noItemOutputs()
                 .fluidInputs(
-                        new FluidStack(ELEMENT.getInstance().XENON.getPlasma(), 100),
-                        new FluidStack(ELEMENT.STANDALONE.RUNITE.getPlasma(), 100))
-                .fluidOutputs(new FluidStack(ELEMENT.STANDALONE.ADVANCED_NITINOL.getPlasma(), 100))
-                .duration(3 * SECONDS).eut(TierEU.RECIPE_UV).metadata(FUSION_THRESHOLD, 500000000)
+                        new FluidStack(ELEMENT.getInstance().XENON.getPlasma(), 144),
+                        new FluidStack(ELEMENT.STANDALONE.RUNITE.getPlasma(), 1000))
+                .fluidOutputs(new FluidStack(ELEMENT.STANDALONE.ADVANCED_NITINOL.getPlasma(), 1000))
+                .duration(16 * TICKS).eut(TierEU.RECIPE_UV).metadata(FUSION_THRESHOLD, 500000000)
                 .addTo(sFusionRecipes);
 
         GT_Values.RA.stdBuilder().noItemInputs().noItemOutputs()
                 .fluidInputs(
-                        new FluidStack(ELEMENT.STANDALONE.ADVANCED_NITINOL.getPlasma(), 100),
-                        Materials.Tartarite.getMolten(1000))
-                .fluidOutputs(new FluidStack(ELEMENT.STANDALONE.CELESTIAL_TUNGSTEN.getPlasma(), 100))
-                .duration(3 * SECONDS).eut(TierEU.RECIPE_UV).metadata(FUSION_THRESHOLD, 500000000)
+                        new FluidStack(ELEMENT.STANDALONE.ADVANCED_NITINOL.getPlasma(), 144),
+                        Materials.Tartarite.getMolten(8))
+                .fluidOutputs(new FluidStack(ELEMENT.STANDALONE.CELESTIAL_TUNGSTEN.getPlasma(), 1000))
+                .duration(16 * TICKS).eut(TierEU.RECIPE_UV).metadata(FUSION_THRESHOLD, 500000000)
                 .addTo(sFusionRecipes);
     }
 


### PR DESCRIPTION
See #651 for the PR that introduced these plasma chains. Big thanks to @S4mpsa for making the spreadsheet and helping me decide how these chains should be balanced to be useful, yet not too strong.

[PlasmaUnfuckening.xlsx](https://github.com/GTNewHorizons/GTplusplus/files/11738014/PlasmaUnfuckening.xlsx)

This is the spreadsheet Sampsa made, with a general overview of the numbers involved in this PR.

## What's the objective?

These plasma chains are meant to replace the Helium/Tin Plasma spam that has since been heavily nerfed when used together with XL Plasma Turbines, which was the usual setup. The final powergen numbers are somewhat similar to what Helium Plasma could do with compacts before, but the setup is a lot more extensive and more materials are needed to automate the chain. Hopefully, this amount of power will be enough to sustain a base until Dyson, but it won't be anywhere as simple as how fusion has been until the nerfs.

## What are the fusion chains like?

There are three chains, one for mk1 reactors, another for mk2 and the last for mk3. Each chain needs the final plasma of the previous one to be made. The focal point for compact reactors and XL turbines is the mk3 chain, which is the one that can match the previous powergen's numbers, but with a lot more complexity. The other two chains aren't as relevant for this stage, but they are both more powerful per fusion reactor than the 1-recipe setups of Helium and Tin Plasma, with an added cost like everything else.

## What would a compact reactor setup look like?

The final recipe that makes the strongest plasma, Celestial Tungsten Plasma, is the slowest recipe, so it's the only one that _needs_ to be a compact. However, other recipes might also be moved to compacts because they might only be 6x as fast, which would force a number of normal reactors. The entire mk3 chain, which includes the other two, starts from Helium Plasma and requires 14 new fusion steps to be completed, but the power per reactor is considerably higher if there are no bottlenecks before the final recipe. The complete setup would require a good number of reactors either way, but the added complexity and the choice of which chain to build between the three should add more entertainment and choice possibilities to the player, rather than simply choosing between Helium or Tin Plasma spam. 

## Other notes:

Celestial Tungsten Plasma's fuel value was buffed to 720M in order to improve the EU per reactor by more than 4x the mk2 equivalent, to account for the 4x difference in EU per amp across tiers. Additionally, this new fuel value avoids penalties even in the spacetime turbines.