### PR TITLE
nitrobenzene followup

### DIFF
--- a/src/main/java/gtPlusPlus/core/item/chemistry/GenericChem.java
+++ b/src/main/java/gtPlusPlus/core/item/chemistry/GenericChem.java
@@ -924,11 +924,10 @@ public class GenericChem extends ItemPackage {
         CORE.RA.addChemicalPlantRecipe(
                 new ItemStack[] { getTierThreeChip(), },
                 new FluidStack[] { FluidUtils.getFluidStack(Benzene, 5000),
-                        FluidUtils.getFluidStack("sulfuricacid", 3000), FluidUtils.getFluidStack("nitricacid", 5000),
+                        FluidUtils.getFluidStack("sulfuricacid", 1000), FluidUtils.getFluidStack("nitricacid", 5000),
                         FluidUtils.getDistilledWater(10000) },
                 new ItemStack[] {},
-                new FluidStack[] { FluidUtils.getFluidStack("dilutedsulfuricacid", 3000),
-                        FluidUtils.getFluidStack(NitroBenzene, 5000), },
+                new FluidStack[] { FluidUtils.getFluidStack(NitroBenzene, 5000), },
                 20 * 30,
                 500,
                 4);


### PR DESCRIPTION
follow up to https://github.com/GTNewHorizons/GT5-Unofficial/pull/2076, discussed with boubou and adam.

Basically nitrobenzene is now available in LCR in EV (this time intentional) but there should be some bonus for people that are willing to make the titanium chemplant (much more expensive than a LCR) additional to being more energy efficient. This PR adds this bonus.

specifially the 3000L diluted sulfuric acid output is replaced by 2000L normal sulfuric acid (and then subtracted from the input).

The idea for this particular bonus is that the chemplant is 'advanced' and 'complex' enough so that it can avoid that the sulfuric acid gets diluted. However the total amount of sulfuric acid remains the same. For the player that means they dont need the additional distilling step (turning 3000 diluted back to 2000 normal) but the total sulfuric acid they need to input is the same as before (200L per 1000L of nitrobenzene).