### PR TITLE
Fix europa 'blizz' drops

### DIFF
--- a/src/main/java/gtPlusPlus/core/common/CommonProxy.java
+++ b/src/main/java/gtPlusPlus/core/common/CommonProxy.java
@@ -257,9 +257,8 @@ public class CommonProxy {
         }
 
         // GalaxySpace Support
-        if (ReflectionUtils.doesClassExist("galaxyspace.SolarSystem.moons.europa.entities.EntityEvolvedColdBlaze")) {
-            Class<?> aColdBlaze = ReflectionUtils
-                    .getClass("galaxyspace.SolarSystem.moons.europa.entities.EntityEvolvedColdBlaze");
+        if (ReflectionUtils.doesClassExist("galaxyspace.core.entity.mob.EntityEvolvedColdBlaze")) {
+            Class<?> aColdBlaze = ReflectionUtils.getClass("galaxyspace.core.entity.mob.EntityEvolvedColdBlaze");
             ItemStack aSmallBlizz, aTinyBlizz, aSmallCryo, aTinyCryo;
             aSmallBlizz = ItemUtils.getItemStackOfAmountFromOreDict("dustSmallBlizz", 1);
             aTinyBlizz = ItemUtils.getItemStackOfAmountFromOreDict("dustTinyBlizz", 1);


### PR DESCRIPTION
Fixes the mob drops for the 'blizz' mob on europa.

Was broken since the class name changed a few years back.

works now: 
![image](https://github.com/GTNewHorizons/GTplusplus/assets/40274384/8f14210d-ee46-4c26-b540-950e5f970910)
