### PR TITLE
Advanced boiler steam capacity fix 

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,19 +1,19 @@
 dependencies {
 
     api('com.github.GTNewHorizons:GT5-Unofficial:5.09.43.123:dev')
-    api("com.github.GTNewHorizons:bartworks:0.7.17:dev")
+    api("com.github.GTNewHorizons:bartworks:0.7.27:dev")
 
     implementation('curse.maven:cofh-core-69162:2388751')
     // https://www.curseforge.com/minecraft/mc-mods/advancedsolarpanels
     implementation('curse.maven:advsolar-362768:2885953')
 
     compileOnly('com.github.GTNewHorizons:Baubles:1.0.1.16:dev') {transitive=false}
-    compileOnly('com.github.GTNewHorizons:EnderCore:0.2.14:dev') {transitive=false}
+    compileOnly('com.github.GTNewHorizons:EnderCore:0.2.16:dev') {transitive=false}
     compileOnly('com.github.GTNewHorizons:SC2:2.0.2:dev') {transitive=false}
-    compileOnly('com.github.GTNewHorizons:Binnie:2.1.2:dev') {transitive = false}
+    compileOnly('com.github.GTNewHorizons:Binnie:2.1.6:dev') {transitive = false}
     compileOnly('curse.maven:PlayerAPI-228969:2248928') {transitive=false}
     compileOnly('thaumcraft:Thaumcraft:1.7.10-4.2.3.5:dev') {transitive=false}
-    compileOnly('com.github.GTNewHorizons:Chisel:2.11.0-GTNH:dev') {transitive=false}
+    compileOnly('com.github.GTNewHorizons:Chisel:2.11.3-GTNH:dev') {transitive=false}
 
-    runtimeOnly('com.github.GTNewHorizons:ForestryMC:4.6.7:dev') {transitive=false}
+    runtimeOnly('com.github.GTNewHorizons:ForestryMC:4.6.10:dev') {transitive=false}
 }

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,6 +1,6 @@
 dependencies {
 
-    api('com.github.GTNewHorizons:GT5-Unofficial:5.09.43.80:dev')
+    api('com.github.GTNewHorizons:GT5-Unofficial:5.09.43.123:dev')
     api("com.github.GTNewHorizons:bartworks:0.7.17:dev")
 
     implementation('curse.maven:cofh-core-69162:2388751')

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/generators/GT_MetaTileEntity_Boiler_Base.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/generators/GT_MetaTileEntity_Boiler_Base.java
@@ -172,6 +172,7 @@ public class GT_MetaTileEntity_Boiler_Base extends GT_MetaTileEntity_Boiler {
     }
 
     // This type of machine can have different water and steam capacities.
+    @Override
     public int getSteamCapacity() {
         return 2 * getCapacity();
     }
@@ -209,17 +210,6 @@ public class GT_MetaTileEntity_Boiler_Base extends GT_MetaTileEntity_Boiler {
         int burnTime = getBurnTime(fuelStack);
         if (burnTime > 0 && this.mTemperature <= 101) {
             consumeFuel(tile, fuelStack, burnTime);
-        }
-    }
-
-    @Override
-    protected void produceSteam(int aAmount) {
-        super.produceSteam(aAmount);
-
-        if (mSteam.amount > getSteamCapacity()) {
-            sendSound(SOUND_EVENT_LET_OFF_EXCESS_STEAM);
-
-            mSteam.amount = getSteamCapacity();
         }
     }
 


### PR DESCRIPTION
Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/13872 

Been broken for 2 years, even if the GTPP method had worked it would spam the vent sound repeatedly as soon as steam filled up.
Tested and works exactly as anticipated. If there is a better method to do this please do let me know.

Should be merged with: https://github.com/GTNewHorizons/GT5-Unofficial/pull/2128