### PR TITLE
Make PSS stop pulling input power when it's full.

### DIFF
--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/storage/GregtechMetaTileEntity_PowerSubStationController.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/storage/GregtechMetaTileEntity_PowerSubStationController.java
@@ -590,7 +590,7 @@ public class GregtechMetaTileEntity_PowerSubStationController
         long stored = aHatch.getEUVar();
         long voltage = aHatch.maxEUInput() * aHatch.maxAmperesIn();
 
-        if (voltage > stored) {
+        if (voltage > stored || (voltage + this.getEUVar() > this.mBatteryCapacity)) {
             return 0;
         }
 


### PR DESCRIPTION
Currently PSS voids 1% of stored power whenever it fills up, which causes it to always draw power as quickly as it can. This is caused by a missing check in `drawEnergyFromHatch`, which charges the PSS over its capacity, which then triggers the overcharge check in `onRunningTick`. This change prevents the PSS from pulling power if it would cause it to overcharge.