### PR TITLE
Patches the hole in Dangote

### DIFF
--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/advanced/GregtechMetaTileEntity_Adv_DistillationTower.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/advanced/GregtechMetaTileEntity_Adv_DistillationTower.java
@@ -107,12 +107,10 @@ public class GregtechMetaTileEntity_Adv_DistillationTower extends
                                             .atLeast(layeredOutputHatch, Energy, Maintenance)
                                             .disallowOnly(ForgeDirection.UP, ForgeDirection.DOWN)
                                             .casingIndex(getCasingTextureId()).dot(2).build(),
-                                    onElementPass(
-                                            GregtechMetaTileEntity_Adv_DistillationTower::onTopLayerFound,
-                                            ofHatchAdder(
-                                                    GregtechMetaTileEntity_Adv_DistillationTower::addMufflerToMachineList,
-                                                    getCasingTextureId(),
-                                                    3)),
+                                    ofHatchAdder(
+                                            GregtechMetaTileEntity_Adv_DistillationTower::addMufflerToMachineList,
+                                            getCasingTextureId(),
+                                            3),
                                     ofBlock(GregTech_API.sBlockCasings4, 1)))
                     .addElement(
                             'c',


### PR DESCRIPTION
Haven't been able to reproduce since changing this. Tested Dangotes of all sizes and all formed as expected.
Fun bug though :(

Closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/13944