### PR TITLE
Migrated mk4 and mk5 fusion to generic processing logic

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,6 +1,6 @@
 dependencies {
 
-    api('com.github.GTNewHorizons:GT5-Unofficial:5.09.43.131:dev')
+    api('com.github.GTNewHorizons:GT5-Unofficial:5.09.43.135:dev')
     api("com.github.GTNewHorizons:bartworks:0.7.30:dev")
 
     implementation('curse.maven:cofh-core-69162:2388751')

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/advanced/GregtechMetaTileEntity_Adv_Fusion_MK4.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/advanced/GregtechMetaTileEntity_Adv_Fusion_MK4.java
@@ -53,8 +53,8 @@ public class GregtechMetaTileEntity_Adv_Fusion_MK4 extends GT_MetaTileEntity_Fus
                 .addInfo("Controller block for the Fusion Reactor Mk IV")
                 .addInfo("131072EU/t and 320M EU capacity per Energy Hatch")
                 .addInfo("If the recipe has a startup cost greater than the")
-                .addInfo("number of energy hatches * cap, you can't do it").addSeparator()
-                .beginStructureBlock(15, 3, 15, false).addController("See diagram when placed")
+                .addInfo("number of energy hatches * cap, you can't do it").addInfo("Performs 4/4 overclocks")
+                .addSeparator().beginStructureBlock(15, 3, 15, false).addController("See diagram when placed")
                 .addCasingInfoMin("Fusion Machine Casings MK III", 79, false)
                 .addStructureInfo("Cover the coils with casing")
                 .addOtherStructurePart("Advanced Fusion Coils", "Center part of the ring")
@@ -111,7 +111,8 @@ public class GregtechMetaTileEntity_Adv_Fusion_MK4 extends GT_MetaTileEntity_Fus
 
     @Override
     public int overclock(int mStartEnergy) {
-        return (mStartEnergy < 160000000) ? 3 : ((mStartEnergy < 320000000) ? 2 : (mStartEnergy < 640000000) ? 1 : 0);
+        return (mStartEnergy <= 160000000) ? 3
+                : ((mStartEnergy <= 320000000) ? 2 : (mStartEnergy <= 640000000) ? 1 : 0);
     }
 
     @Override

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/advanced/GregtechMetaTileEntity_Adv_Fusion_MK4.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/advanced/GregtechMetaTileEntity_Adv_Fusion_MK4.java
@@ -11,6 +11,7 @@ import gregtech.api.enums.Textures;
 import gregtech.api.interfaces.IIconContainer;
 import gregtech.api.interfaces.ITexture;
 import gregtech.api.interfaces.tileentity.IGregTechTileEntity;
+import gregtech.api.logic.ProcessingLogic;
 import gregtech.api.metatileentity.MetaTileEntity;
 import gregtech.api.metatileentity.implementations.GT_MetaTileEntity_Hatch;
 import gregtech.api.metatileentity.implementations.GT_MetaTileEntity_Hatch_Energy;
@@ -104,8 +105,13 @@ public class GregtechMetaTileEntity_Adv_Fusion_MK4 extends GT_MetaTileEntity_Fus
     }
 
     @Override
+    protected ProcessingLogic createProcessingLogic() {
+        return super.createProcessingLogic().setOverclock(2, 2);
+    }
+
+    @Override
     public int overclock(int mStartEnergy) {
-        return (mStartEnergy < 160000000) ? 16 : ((mStartEnergy < 320000000) ? 8 : (mStartEnergy < 640000000) ? 4 : 1);
+        return (mStartEnergy < 160000000) ? 3 : ((mStartEnergy < 320000000) ? 2 : (mStartEnergy < 640000000) ? 1 : 0);
     }
 
     @Override

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/advanced/GregtechMetaTileEntity_Adv_Fusion_MK5.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/advanced/GregtechMetaTileEntity_Adv_Fusion_MK5.java
@@ -11,6 +11,7 @@ import gregtech.api.enums.Textures;
 import gregtech.api.interfaces.IIconContainer;
 import gregtech.api.interfaces.ITexture;
 import gregtech.api.interfaces.tileentity.IGregTechTileEntity;
+import gregtech.api.logic.ProcessingLogic;
 import gregtech.api.metatileentity.MetaTileEntity;
 import gregtech.api.metatileentity.implementations.GT_MetaTileEntity_Hatch;
 import gregtech.api.metatileentity.implementations.GT_MetaTileEntity_Hatch_Energy;
@@ -104,10 +105,15 @@ public class GregtechMetaTileEntity_Adv_Fusion_MK5 extends GT_MetaTileEntity_Fus
     }
 
     @Override
+    protected ProcessingLogic createProcessingLogic() {
+        return super.createProcessingLogic().setOverclock(2, 2);
+    }
+
+    @Override
     public int overclock(int mStartEnergy) {
-        return (mStartEnergy < 160_000_000) ? 32
-                : ((mStartEnergy < 320_000_000) ? 16
-                        : ((mStartEnergy < 640_000_000) ? 8 : ((mStartEnergy < 1_280_000_000) ? 4 : 1)));
+        return (mStartEnergy < 160_000_000) ? 4
+                : ((mStartEnergy < 320_000_000) ? 3
+                        : ((mStartEnergy < 640_000_000) ? 2 : ((mStartEnergy < 1_280_000_000) ? 1 : 0)));
     }
 
     @Override

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/advanced/GregtechMetaTileEntity_Adv_Fusion_MK5.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/advanced/GregtechMetaTileEntity_Adv_Fusion_MK5.java
@@ -53,8 +53,8 @@ public class GregtechMetaTileEntity_Adv_Fusion_MK5 extends GT_MetaTileEntity_Fus
                 .addInfo("Controller block for the Fusion Reactor Mk V")
                 .addInfo("524,288EU/t and 1.28B EU capacity per Energy Hatch")
                 .addInfo("If the recipe has a startup cost greater than the")
-                .addInfo("number of energy hatches * cap, you can't do it").addSeparator()
-                .beginStructureBlock(15, 3, 15, false).addController("See diagram when placed")
+                .addInfo("number of energy hatches * cap, you can't do it").addInfo("Performs 4/4 overclocks")
+                .addSeparator().beginStructureBlock(15, 3, 15, false).addController("See diagram when placed")
                 .addCasingInfoMin("Fusion Machine Casings MK IV", 79, false)
                 .addStructureInfo("Cover the coils with casing")
                 .addOtherStructurePart("Advanced Fusion Coils II", "Center part of the ring")
@@ -111,9 +111,9 @@ public class GregtechMetaTileEntity_Adv_Fusion_MK5 extends GT_MetaTileEntity_Fus
 
     @Override
     public int overclock(int mStartEnergy) {
-        return (mStartEnergy < 160_000_000) ? 4
-                : ((mStartEnergy < 320_000_000) ? 3
-                        : ((mStartEnergy < 640_000_000) ? 2 : ((mStartEnergy < 1_280_000_000) ? 1 : 0)));
+        return (mStartEnergy <= 160_000_000) ? 4
+                : ((mStartEnergy <= 320_000_000) ? 3
+                        : ((mStartEnergy <= 640_000_000) ? 2 : ((mStartEnergy <= 1_280_000_000) ? 1 : 0)));
     }
 
     @Override


### PR DESCRIPTION
Needs https://github.com/GTNewHorizons/GT5-Unofficial/pull/2145
Migrated fusion mk4 and mk5 to generic processing logic.
This fixes an ancient overclock bug/oversight so in theory it's a balance change, which is why admin approval is required. before if you'd do a mk3 recipe in a mk4 fusion reactor it would OC 2/2 -> 2/2 -> 4/4, so inconsistent behavior.
In practices this shouldn't change balance because applying consistent 4/4 OC is the behavior of compact fusions, which are used more commonly.