### PR TITLE
Remove the duplicate pu239

### DIFF
--- a/src/main/java/gtPlusPlus/core/item/ModItems.java
+++ b/src/main/java/gtPlusPlus/core/item/ModItems.java
@@ -579,9 +579,6 @@ public final class ModItems {
             // in radioisotope thermoelectric generators (RTGs)
             // and radioisotope heater units - one gram of plutonium-238 generates approximately 0.5 W of thermal power.
             MaterialGenerator.generateNuclearMaterial(ELEMENT.getInstance().PLUTONIUM238, false);
-            if (ItemUtils.getItemStackOfAmountFromOreDictNoBroken("dustPlutonium239", 1) == null) {
-                MaterialGenerator.generateNuclearMaterial(ELEMENT.getInstance().PLUTONIUM239, false);
-            }
 
             // RTG Fuel Materials
             MaterialGenerator.generateNuclearMaterial(ELEMENT.getInstance().STRONTIUM90, false);

--- a/src/main/java/gtPlusPlus/core/material/ELEMENT.java
+++ b/src/main/java/gtPlusPlus/core/material/ELEMENT.java
@@ -374,7 +374,10 @@ public final class ELEMENT {
             false,
             "Np",
             2); // Not a GT Inherited Material
-    public final Material PLUTONIUM244 = MaterialUtils.generateMaterialFromGtENUM(Materials.Plutonium);
+
+    public final Material PLUTONIUM244 = MaterialUtils.generateMaterialFromGtENUM(Materials.Plutonium); // This one
+                                                                                                        // looks
+                                                                                                        // incorrect.
     public final Material PLUTONIUM241 = MaterialUtils.generateMaterialFromGtENUM(Materials.Plutonium241);
     public final Material AMERICIUM = MaterialUtils.generateMaterialFromGtENUM(Materials.Americium); // Americium
     public final Material CURIUM = new Material(
@@ -512,20 +515,7 @@ public final class ELEMENT {
             StringUtils.superscript("232Th"),
             1,
             true); // Not a GT Inherited Material
-    public final Material PLUTONIUM239 = new Material(
-            "Plutonium-239",
-            MaterialState.SOLID,
-            TextureSets.NUCLEAR.get(),
-            Materials.Plutonium.mDurability,
-            Materials.Plutonium.mRGBa,
-            Materials.Plutonium.mMeltingPoint,
-            Materials.Plutonium.mBlastFurnaceTemp,
-            94,
-            145,
-            false,
-            StringUtils.superscript("239Pu"),
-            4,
-            true); // Not a GT Inherited Material
+
     // RTG Fuels
     public final Material PLUTONIUM238 = new Material(
             "Plutonium-238",

--- a/src/main/java/gtPlusPlus/core/recipe/RECIPES_GREGTECH.java
+++ b/src/main/java/gtPlusPlus/core/recipe/RECIPES_GREGTECH.java
@@ -210,37 +210,6 @@ public class RECIPES_GREGTECH {
                 64,
                 2);
 
-        // Convert GT++ Plutonium239 into normal Plutonium
-        if (Materials.Plutonium.mDefaultLocalName.equals("Plutonium 239")) {
-            CORE.RA.addChemicalPlantRecipe(
-                    new ItemStack[] { CI.getNumberedAdvancedCircuit(16),
-                            ELEMENT.getInstance().PLUTONIUM239.getDust(1) },
-                    new FluidStack[] {},
-                    new ItemStack[] { ItemUtils.getItemStackOfAmountFromOreDict("dustPlutonium", 1) },
-                    new FluidStack[] {},
-                    5 * 20,
-                    1,
-                    2);
-            CORE.RA.addChemicalPlantRecipe(
-                    new ItemStack[] { CI.getNumberedAdvancedCircuit(16),
-                            ELEMENT.getInstance().PLUTONIUM239.getSmallDust(1) },
-                    new FluidStack[] {},
-                    new ItemStack[] { ItemUtils.getItemStackOfAmountFromOreDict("dustSmallPlutonium", 1) },
-                    new FluidStack[] {},
-                    5 * 20,
-                    1,
-                    2);
-            CORE.RA.addChemicalPlantRecipe(
-                    new ItemStack[] { CI.getNumberedAdvancedCircuit(16),
-                            ELEMENT.getInstance().PLUTONIUM239.getTinyDust(1) },
-                    new FluidStack[] {},
-                    new ItemStack[] { ItemUtils.getItemStackOfAmountFromOreDict("dustTinyPlutonium", 1) },
-                    new FluidStack[] {},
-                    5 * 20,
-                    1,
-                    2);
-        }
-
         int aLaureniumTier = ALLOY.LAURENIUM.vTier;
         // Adding Recipes for Casings
         CORE.RA.addChemicalPlantRecipe(
@@ -1652,7 +1621,7 @@ public class RECIPES_GREGTECH {
         // Strontium pu239
         CORE.RA.addCyclotronRecipe(
                 CI.getNumberedCircuit(1),
-                FluidUtils.getFluidStack("molten.plutonium239", 10),
+                FluidUtils.getFluidStack("molten.plutonium", 10),
                 new ItemStack[] { GregtechItemList.Pellet_RTG_SR90.get(1) },
                 null,
                 new int[] { 220 },

--- a/src/main/java/gtPlusPlus/xmod/gregtech/loaders/recipe/RecipeLoader_Nuclear.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/loaders/recipe/RecipeLoader_Nuclear.java
@@ -1,6 +1,8 @@
 package gtPlusPlus.xmod.gregtech.loaders.recipe;
 
+import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sCentrifugeRecipes;
 import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sFusionRecipes;
+import static gregtech.api.util.GT_RecipeBuilder.MINUTES;
 import static gregtech.api.util.GT_RecipeBuilder.SECONDS;
 import static gregtech.api.util.GT_RecipeBuilder.TICKS;
 import static gregtech.api.util.GT_RecipeConstants.FUSION_THRESHOLD;
@@ -15,6 +17,7 @@ import gregtech.api.enums.OrePrefixes;
 import gregtech.api.enums.TierEU;
 import gregtech.api.util.GT_ModHandler;
 import gregtech.api.util.GT_OreDictUnificator;
+import gregtech.api.util.GT_Utility;
 import gtPlusPlus.api.objects.Logger;
 import gtPlusPlus.core.item.chemistry.GenericChem;
 import gtPlusPlus.core.lib.CORE;
@@ -92,51 +95,47 @@ public class RecipeLoader_Nuclear {
         // Process Used Fuel Rods for Krypton
 
         // Uranium
-        GT_Values.RA.addCentrifugeRecipe(
-                CI.getNumberedCircuit(20),
-                ItemUtils.getItemStackFromFQRN("IC2:reactorUraniumSimpledepleted", 8),
-                GT_Values.NF,
-                ELEMENT.getInstance().KRYPTON.getFluidStack(60),
-                ItemList.IC2_Fuel_Rod_Empty.get(8),
-                ELEMENT.getInstance().URANIUM238.getDust(2),
-                ELEMENT.getInstance().URANIUM232.getSmallDust(1),
-                ELEMENT.getInstance().URANIUM233.getSmallDust(1),
-                ELEMENT.getInstance().URANIUM235.getSmallDust(1),
-                ELEMENT.getInstance().PLUTONIUM239.getTinyDust(1),
-                new int[] { 0, 0, 1000, 1000, 1000, 500 },
-                500 * 20,
-                4000);
+        GT_Values.RA.stdBuilder()
+                .itemInputs(
+                        ItemUtils.getItemStackFromFQRN("IC2:reactorUraniumSimpledepleted", 8),
+                        GT_Utility.getIntegratedCircuit(20))
+                .itemOutputs(
+                        ItemList.IC2_Fuel_Rod_Empty.get(8),
+                        GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Uranium, 2L),
+                        ELEMENT.getInstance().URANIUM232.getSmallDust(1),
+                        ELEMENT.getInstance().URANIUM233.getSmallDust(1),
+                        GT_OreDictUnificator.get(OrePrefixes.dustSmall, Materials.Uranium235, 1L),
+                        GT_OreDictUnificator.get(OrePrefixes.dustTiny, Materials.Plutonium, 1L))
+                .outputChances(10000, 10000, 1000, 1000, 1000, 500).noFluidInputs()
+                .fluidOutputs(FluidUtils.getFluidStack("krypton", 60)).duration(4 * MINUTES + 10 * SECONDS)
+                .eut(TierEU.RECIPE_IV).addTo(sCentrifugeRecipes);
         // Mox
-        GT_Values.RA.addCentrifugeRecipe(
-                CI.getNumberedCircuit(20),
-                ItemUtils.getItemStackFromFQRN("IC2:reactorMOXSimpledepleted", 8),
-                GT_Values.NF,
-                ELEMENT.getInstance().KRYPTON.getFluidStack(90),
-                ItemList.IC2_Fuel_Rod_Empty.get(8),
-                ELEMENT.getInstance().PLUTONIUM244.getDust(2),
-                ELEMENT.getInstance().PLUTONIUM241.getTinyDust(1),
-                ELEMENT.getInstance().PLUTONIUM239.getTinyDust(1),
-                ELEMENT.getInstance().PLUTONIUM238.getTinyDust(1),
-                ELEMENT.getInstance().PLUTONIUM239.getTinyDust(1),
-                new int[] { 0, 0, 500, 500, 500, 500 },
-                750 * 20,
-                4000);
-
+        GT_Values.RA.stdBuilder()
+                .itemInputs(
+                        ItemUtils.getItemStackFromFQRN("IC2:reactorMOXSimpledepleted", 8),
+                        GT_Utility.getIntegratedCircuit(20))
+                .itemOutputs(
+                        ItemList.IC2_Fuel_Rod_Empty.get(8),
+                        GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Plutonium, 2L),
+                        GT_OreDictUnificator.get(OrePrefixes.dustTiny, Materials.Plutonium241, 1L),
+                        GT_OreDictUnificator.get(OrePrefixes.dustTiny, Materials.Plutonium, 1L),
+                        ELEMENT.getInstance().PLUTONIUM238.getTinyDust(1),
+                        GT_OreDictUnificator.get(OrePrefixes.dustTiny, Materials.Plutonium, 1L))
+                .outputChances(10000, 10000, 500, 500, 500, 500).noFluidInputs()
+                .fluidOutputs(FluidUtils.getFluidStack("krypton", 90)).duration(6 * MINUTES + 15 * SECONDS)
+                .eut(TierEU.RECIPE_IV).addTo(sCentrifugeRecipes);
         // Thorium
-        GT_Values.RA.addCentrifugeRecipe(
-                CI.getNumberedCircuit(20),
-                ItemList.Depleted_Thorium_1.get(8),
-                GT_Values.NF,
-                ELEMENT.getInstance().KRYPTON.getFluidStack(30),
-                ItemList.IC2_Fuel_Rod_Empty.get(8),
-                ELEMENT.getInstance().THORIUM.getDust(2),
-                ELEMENT.getInstance().THORIUM232.getDust(1),
-                ELEMENT.getInstance().LUTETIUM.getSmallDust(1),
-                ELEMENT.getInstance().POLONIUM.getSmallDust(1),
-                ELEMENT.getInstance().THALLIUM.getTinyDust(1),
-                new int[] { 0, 0, 5000, 5000, 5000, 2500 },
-                250 * 20,
-                4000);
+        GT_Values.RA.stdBuilder().itemInputs(ItemList.Depleted_Thorium_1.get(8), GT_Utility.getIntegratedCircuit(20))
+                .itemOutputs(
+                        ItemList.IC2_Fuel_Rod_Empty.get(8),
+                        GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Thorium, 2L),
+                        ELEMENT.getInstance().THORIUM232.getDust(1),
+                        GT_OreDictUnificator.get(OrePrefixes.dustSmall, Materials.Lutetium, 1L),
+                        ELEMENT.getInstance().POLONIUM.getSmallDust(1),
+                        ELEMENT.getInstance().THALLIUM.getTinyDust(1))
+                .outputChances(10000, 10000, 5000, 5000, 5000, 2500).noFluidInputs()
+                .fluidOutputs(FluidUtils.getFluidStack("krypton", 30)).duration(2 * MINUTES + 5 * SECONDS)
+                .eut(TierEU.RECIPE_IV).addTo(sCentrifugeRecipes);
     }
 
     private static void chemicalBathRecipes() {

--- a/src/main/resources/assets/miscutils/lang/en_US.lang
+++ b/src/main/resources/assets/miscutils/lang/en_US.lang
@@ -1528,14 +1528,6 @@ item.itemDustTinyUN18Fertiliser.name=Tiny Pile of UN-18 Fertiliser Dust
 item.itemDustUN32Fertiliser.name=UN-32 Fertiliser Dust
 item.itemDustSmallUN32Fertiliser.name=Small Pile of UN-32 Fertiliser Dust
 item.itemDustTinyUN32Fertiliser.name=Tiny Pile of UN-32 Fertiliser Dust
-item.itemNuggetPlutonium239.name=Plutonium 239 Nugget
-item.itemCellPlutonium239.name=Plutonium 239 Cell
-item.itemIngotPlutonium239.name=Plutonium 239 Ingot
-item.itemPlatePlutonium239.name=Plutonium 239 Plate
-item.itemPlateDoublePlutonium239.name=Double Plutonium 239 Plate 
-item.itemDustPlutonium239.name=Plutonium 239 Dust
-item.itemDustSmallPlutonium239.name=Small Plutonium 239 Dust 
-item.itemDustTinyPlutonium239.name=Tiny Plutonium 239 Dust
 item.itemCustomMetaCover.miscutils.GtMachineCasings=%s Machine Plate Cover
 item.itemGregtechPump.tooltip.0=Cannot drain any other standard fluid container block
 item.itemGregtechPump.tooltip.1=Cannot be emptied via RMB, use inside a tank with GUI
@@ -2020,7 +2012,6 @@ tile.blockDarkWorldPortalFrame.name=Containment Frame
 
 
 //Added 1/4/18
-tile.Block of Plutonium-239.name=Block of Plutonium-239
 tile.blockMiningPipeFake.name=Strengthened Mining Pipe
 tile.blockMiningHeadFake.name=Bedrock Drill
 item.itemPlateMeatRaw.name=Fleshy Panel

--- a/src/main/resources/assets/miscutils/lang/ru_RU.lang
+++ b/src/main/resources/assets/miscutils/lang/ru_RU.lang
@@ -1484,14 +1484,6 @@ item.itemDustTinyUN18Fertiliser.name=Tiny Pile of UN-18 Fertiliser Dust
 item.itemDustUN32Fertiliser.name=UN-32 Fertiliser Dust
 item.itemDustSmallUN32Fertiliser.name=Small Pile of UN-32 Fertiliser Dust
 item.itemDustTinyUN32Fertiliser.name=Tiny Pile of UN-32 Fertiliser Dust
-item.itemNuggetPlutonium239.name=Plutonium 239 Nugget
-item.itemCellPlutonium239.name=Plutonium 239 Cell
-item.itemIngotPlutonium239.name=Plutonium 239 Ingot
-item.itemPlatePlutonium239.name=Plutonium 239 Plate
-item.itemPlateDoublePlutonium239.name=Double Plutonium 239 Plate 
-item.itemDustPlutonium239.name=Пыль Плутония 239
-item.itemDustSmallPlutonium239.name=Small Plutonium 239 Dust 
-item.itemDustTinyPlutonium239.name=Tiny Plutonium 239 Dust
 
 
 //Multitools
@@ -1952,7 +1944,6 @@ tile.blockDarkWorldPortalFrame.name=Containment Frame
 
 
 //Added 1/4/18
-tile.Block of Plutonium-239.name=Блок Плутона-239
 tile.blockMiningPipeFake.name=Strengthened Mining Pipe
 tile.blockMiningHeadFake.name=Bedrock Drill
 item.itemPlateMeatRaw.name=Fleshy Panel

--- a/src/main/resources/assets/miscutils/lang/zh_CN.lang
+++ b/src/main/resources/assets/miscutils/lang/zh_CN.lang
@@ -1484,14 +1484,6 @@ item.itemDustTinyUN18Fertiliser.name=小撮流体肥料un-18粉
 item.itemDustUN32Fertiliser.name=流体肥料UN-32粉
 item.itemDustSmallUN32Fertiliser.name=小堆流体肥料UN-32粉
 item.itemDustTinyUN32Fertiliser.name=小撮流体肥料UN-32粉
-item.itemNuggetPlutonium239.name=钚-239粒
-item.itemCellPlutonium239.name=钚-239单元
-item.itemIngotPlutonium239.name=钚-239锭
-item.itemPlatePlutonium239.name=钚-239板
-item.itemPlateDoublePlutonium239.name=双重钚-239板
-item.itemDustPlutonium239.name=钚-239粉
-item.itemDustSmallPlutonium239.name=小堆钚-239粉
-item.itemDustTinyPlutonium239.name=小撮钚-239粉
 
 
 //Multitools
@@ -1952,7 +1944,6 @@ tile.blockDarkWorldPortalFrame.name=遏制框架
 
 
 //Added 1/4/18
-tile.Block of Plutonium-239.name=钚-239块
 tile.blockMiningPipeFake.name=强化钢筋挖掘管道
 tile.blockMiningHeadFake.name=基岩钻头
 item.itemPlateMeatRaw.name=生肉板


### PR DESCRIPTION
We have one in GT, this one just causes issues.

Sadly this is not enough to fix the replicator issue https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/13748 as bartworks also messes with it. A followup PR there will fix the issue. (https://github.com/GTNewHorizons/bartworks/pull/342)

As a bonus, this also fixes the molten plutonium to sr pellet recipe which now uses an actually obtainable molten plutonium.