### PR TITLE
Fix EBF with Advanced Muffer Hatch being able to run without filter

### DIFF
--- a/src/main/java/gtPlusPlus/xmod/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_Hatch_Muffler_Adv.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_Hatch_Muffler_Adv.java
@@ -110,7 +110,8 @@ public class GT_MetaTileEntity_Hatch_Muffler_Adv extends GT_MetaTileEntity_Hatch
 
     @Override
     public boolean polluteEnvironment(MetaTileEntity unused) {
-        if (airCheck() && damageAirFilter()) {
+        if (airCheck()) {
+            damageAirFilter();
             int aEmission = this.calculatePollutionReduction(10000);
             PollutionUtils.addPollution(this.getBaseMetaTileEntity(), aEmission);
             // Logger.INFO("Outputting "+aEmission+"gbl");


### PR DESCRIPTION
Without a filter Advanced Muffler Hatch was unable to vent pollution because
damageAirFilter returns false if no filter is found.

So moved the call inside since the EBF is supposed to be able to run without a filter,
this way it will damage an inserted filter, but just continue if no filter inserted.

The pollution reduction is calculated elsewhere so this change shouldn't impact that.