### PR TITLE
Adding The Fine Wire + Recipe in wiremill for Chromatic Glass

### DIFF
--- a/src/main/java/gtPlusPlus/core/item/ModItems.java
+++ b/src/main/java/gtPlusPlus/core/item/ModItems.java
@@ -1440,7 +1440,8 @@ public final class ModItems {
         MaterialUtils.generateComponentAndAssignToAMaterial(ComponentTypes.FINEWIRE, ALLOY.HG1223);
         MaterialUtils.generateComponentAndAssignToAMaterial(ComponentTypes.FINEWIRE, ALLOY.QUANTUM);
         MaterialUtils.generateComponentAndAssignToAMaterial(ComponentTypes.FINEWIRE, ELEMENT.STANDALONE.HYPOGEN);
-        MaterialUtils.generateComponentAndAssignToAMaterial(ComponentTypes.FINEWIRE, ELEMENT.STANDALONE.CHRONOMATIC_GLASS);
+        MaterialUtils
+                .generateComponentAndAssignToAMaterial(ComponentTypes.FINEWIRE, ELEMENT.STANDALONE.CHRONOMATIC_GLASS);
 
         // Foil
         MaterialUtils.generateComponentAndAssignToAMaterial(ComponentTypes.FOIL, ALLOY.BLACK_TITANIUM);

--- a/src/main/java/gtPlusPlus/core/item/ModItems.java
+++ b/src/main/java/gtPlusPlus/core/item/ModItems.java
@@ -1440,6 +1440,7 @@ public final class ModItems {
         MaterialUtils.generateComponentAndAssignToAMaterial(ComponentTypes.FINEWIRE, ALLOY.HG1223);
         MaterialUtils.generateComponentAndAssignToAMaterial(ComponentTypes.FINEWIRE, ALLOY.QUANTUM);
         MaterialUtils.generateComponentAndAssignToAMaterial(ComponentTypes.FINEWIRE, ELEMENT.STANDALONE.HYPOGEN);
+        MaterialUtils.generateComponentAndAssignToAMaterial(ComponentTypes.FINEWIRE, ELEMENT.STANDALONE.CHRONOMATIC_GLASS);
 
         // Foil
         MaterialUtils.generateComponentAndAssignToAMaterial(ComponentTypes.FOIL, ALLOY.BLACK_TITANIUM);

--- a/src/main/java/gtPlusPlus/core/recipe/RECIPES_General.java
+++ b/src/main/java/gtPlusPlus/core/recipe/RECIPES_General.java
@@ -436,6 +436,7 @@ public class RECIPES_General {
         generateWireRecipes(ALLOY.LEAGRISIUM);
         generateWireRecipes(ALLOY.TRINIUM_TITANIUM);
         generateWireRecipes(ELEMENT.STANDALONE.HYPOGEN);
+        generateWireRecipes(ELEMENT.STANDALONE.CHRONOMATIC_GLASS);
 
         GT_Materials[] g = new GT_Materials[] { GT_Materials.Staballoy, GT_Materials.Tantalloy60,
                 GT_Materials.Tantalloy61, GT_Materials.Void, GT_Materials.Potin, GT_Materials.MaragingSteel300,


### PR DESCRIPTION
Adding a Fine Wire Variant for Chromatic Glass for a better recipe of optical fiber.