### PR TITLE
Lower reservoir hatch tier to EV, add tooltip showing tier for reservoir + air intake hatches

### DIFF
--- a/src/main/java/gtPlusPlus/xmod/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_Hatch_FluidGenerator.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_Hatch_FluidGenerator.java
@@ -3,11 +3,13 @@ package gtPlusPlus.xmod.gregtech.api.metatileentity.implementations;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.util.EnumChatFormatting;
 import net.minecraft.world.World;
 import net.minecraftforge.common.util.ForgeDirection;
 import net.minecraftforge.fluids.Fluid;
 import net.minecraftforge.fluids.FluidStack;
 
+import gregtech.api.enums.GT_Values;
 import gregtech.api.enums.Textures;
 import gregtech.api.interfaces.IIconContainer;
 import gregtech.api.interfaces.ITexture;
@@ -46,10 +48,14 @@ public abstract class GT_MetaTileEntity_Hatch_FluidGenerator extends GT_MetaTile
     @Override
     public synchronized String[] getDescription() {
         mDescriptionArray[1] = "Capacity: " + GT_Utility.formatNumbers(getCapacity()) + "L";
+        final String[] hatchTierString = new String[] {
+                "Hatch Tier: " + GT_Values.TIER_COLORS[mTier] + GT_Values.VN[mTier] + EnumChatFormatting.RESET };
+
         String[] aCustomTips = getCustomTooltip();
-        final String[] desc = new String[mDescriptionArray.length + aCustomTips.length + 1];
+        final String[] desc = new String[mDescriptionArray.length + aCustomTips.length + 2];
         System.arraycopy(mDescriptionArray, 0, desc, 0, mDescriptionArray.length);
-        System.arraycopy(aCustomTips, 0, desc, mDescriptionArray.length, aCustomTips.length);
+        System.arraycopy(hatchTierString, 0, desc, mDescriptionArray.length, 1);
+        System.arraycopy(aCustomTips, 0, desc, mDescriptionArray.length + 1, aCustomTips.length);
         desc[mDescriptionArray.length + aCustomTips.length] = CORE.GT_Tooltip.get();
         return desc;
     }

--- a/src/main/java/gtPlusPlus/xmod/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_Hatch_FluidGenerator.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_Hatch_FluidGenerator.java
@@ -3,13 +3,11 @@ package gtPlusPlus.xmod.gregtech.api.metatileentity.implementations;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
-import net.minecraft.util.EnumChatFormatting;
 import net.minecraft.world.World;
 import net.minecraftforge.common.util.ForgeDirection;
 import net.minecraftforge.fluids.Fluid;
 import net.minecraftforge.fluids.FluidStack;
 
-import gregtech.api.enums.GT_Values;
 import gregtech.api.enums.Textures;
 import gregtech.api.interfaces.IIconContainer;
 import gregtech.api.interfaces.ITexture;
@@ -48,8 +46,7 @@ public abstract class GT_MetaTileEntity_Hatch_FluidGenerator extends GT_MetaTile
     @Override
     public synchronized String[] getDescription() {
         mDescriptionArray[1] = "Capacity: " + GT_Utility.formatNumbers(getCapacity()) + "L";
-        final String[] hatchTierString = new String[] {
-                "Hatch Tier: " + GT_Values.TIER_COLORS[mTier] + GT_Values.VN[mTier] + EnumChatFormatting.RESET };
+        final String[] hatchTierString = new String[] { "Hatch Tier: " + GT_Utility.getColoredTierNameFromTier(mTier) };
 
         String[] aCustomTips = getCustomTooltip();
         final String[] desc = new String[mDescriptionArray.length + aCustomTips.length + 2];

--- a/src/main/java/gtPlusPlus/xmod/gregtech/registration/gregtech/GregtechCustomHatches.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/registration/gregtech/GregtechCustomHatches.java
@@ -91,7 +91,7 @@ public class GregtechCustomHatches {
 
         // Multiblock Reservoir Hatch
         GregtechItemList.Hatch_Reservoir.set(
-                new GT_MetaTileEntity_Hatch_Reservoir(31071, "hatch.water.intake.tier.00", "Reservoir Hatch", 6)
+                new GT_MetaTileEntity_Hatch_Reservoir(31071, "hatch.water.intake.tier.00", "Reservoir Hatch", 4)
                         .getStackForm(1L));
 
         // Steam Hatch


### PR DESCRIPTION
The reservoir hatch currently has an internal tier of LuV. This means that it can't be used in a chemplant that has lower than LuV hulls. Since the reservoir hatch is made in EV, I lowered its tier to EV. 

![java_Smwoj8ri5u](https://github.com/GTNewHorizons/GTplusplus/assets/33518699/c5e8fe61-11fe-4510-89c4-c0c9954da593)

I also added to the tooltip in a base class to show the tier of the hatch. Affects: Reservoir Hatch, Air Intake Hatch, Extreme Air Intake Hatch.

![image](https://github.com/GTNewHorizons/GTplusplus/assets/33518699/ff43e4d3-84ef-4ea7-9296-9e5d666d6750)

![image](https://github.com/GTNewHorizons/GTplusplus/assets/33518699/77ebf58d-c056-4079-b380-724c5df6ee6e)
