### PR TITLE
Fix steam multis now overclocking recipes which consume 2 eu/t

### DIFF
--- a/src/main/java/gtPlusPlus/xmod/gregtech/api/metatileentity/implementations/base/GregtechMeta_SteamMultiBase.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/api/metatileentity/implementations/base/GregtechMeta_SteamMultiBase.java
@@ -74,8 +74,7 @@ public abstract class GregtechMeta_SteamMultiBase<T extends GregtechMeta_SteamMu
     @Override
     protected void setProcessingLogicPower(ProcessingLogic logic) {
         logic.setAvailableVoltage(V[1]);
-        // We need to trick the GT_ParallelHelper we have enough amps for all recipe parallels, but also make sure we
-        // don't use them for overclocking so we will disable amperageOC
+        // We need to trick the GT_ParallelHelper we have enough amps for all recipe parallels.
         logic.setAvailableAmperage(getMaxParallelRecipes());
         logic.setAmperageOC(false);
     }

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/steam/GregtechMetaTileEntity_SteamCompressor.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/steam/GregtechMetaTileEntity_SteamCompressor.java
@@ -7,7 +7,11 @@ import static com.gtnewhorizon.structurelib.structure.StructureUtility.transpose
 import static gregtech.api.GregTech_API.sBlockCasings1;
 import static gregtech.api.util.GT_StructureUtility.buildHatchAdder;
 
+import javax.annotation.Nonnull;
+
 import net.minecraft.item.ItemStack;
+
+import org.jetbrains.annotations.NotNull;
 
 import com.gtnewhorizon.structurelib.alignment.constructable.ISurvivalConstructable;
 import com.gtnewhorizon.structurelib.structure.IStructureDefinition;
@@ -20,6 +24,7 @@ import gregtech.api.interfaces.tileentity.IGregTechTileEntity;
 import gregtech.api.logic.ProcessingLogic;
 import gregtech.api.objects.GT_RenderedTexture;
 import gregtech.api.util.GT_Multiblock_Tooltip_Builder;
+import gregtech.api.util.GT_OverclockCalculator;
 import gregtech.api.util.GT_Recipe;
 import gtPlusPlus.core.lib.CORE;
 import gtPlusPlus.xmod.gregtech.api.metatileentity.implementations.base.GregtechMeta_SteamMultiBase;
@@ -122,7 +127,14 @@ public class GregtechMetaTileEntity_SteamCompressor
 
     @Override
     protected ProcessingLogic createProcessingLogic() {
-        return super.createProcessingLogic().setMaxParallel(getMaxParallelRecipes());
+        return new ProcessingLogic() {
+
+            @Override
+            @Nonnull
+            protected GT_OverclockCalculator createOverclockCalculator(@NotNull GT_Recipe recipe) {
+                return GT_OverclockCalculator.ofNoOverclock(recipe);
+            }
+        }.setMaxParallel(getMaxParallelRecipes());
     }
 
 }

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/steam/GregtechMetaTileEntity_SteamMacerator.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/steam/GregtechMetaTileEntity_SteamMacerator.java
@@ -13,6 +13,8 @@ import javax.annotation.Nonnull;
 
 import net.minecraft.item.ItemStack;
 
+import org.jetbrains.annotations.NotNull;
+
 import com.gtnewhorizon.structurelib.alignment.constructable.ISurvivalConstructable;
 import com.gtnewhorizon.structurelib.structure.IStructureDefinition;
 import com.gtnewhorizon.structurelib.structure.ISurvivalBuildEnvironment;
@@ -26,6 +28,7 @@ import gregtech.api.logic.ProcessingLogic;
 import gregtech.api.objects.GT_RenderedTexture;
 import gregtech.api.objects.XSTR;
 import gregtech.api.util.GT_Multiblock_Tooltip_Builder;
+import gregtech.api.util.GT_OverclockCalculator;
 import gregtech.api.util.GT_ParallelHelper;
 import gregtech.api.util.GT_Recipe;
 import gtPlusPlus.core.lib.CORE;
@@ -147,6 +150,13 @@ public class GregtechMetaTileEntity_SteamMacerator
                     return items.toArray(new ItemStack[0]);
                 });
             }
+
+            @Override
+            @Nonnull
+            protected GT_OverclockCalculator createOverclockCalculator(@NotNull GT_Recipe recipe) {
+                return GT_OverclockCalculator.ofNoOverclock(recipe);
+            }
+
         }.setMaxParallel(getMaxParallelRecipes());
     }
 }


### PR DESCRIPTION
Follow up to https://github.com/GTNewHorizons/GTplusplus/pull/712
Apparently one can't do what I had done
https://discord.com/channels/181078474394566657/181078474394566657/1136816875637063811 discord report