### PR TITLE
More LFTR Chain Fixes

### DIFF
--- a/src/main/java/gregtech/api/util/GasSpargingRecipe.java
+++ b/src/main/java/gregtech/api/util/GasSpargingRecipe.java
@@ -28,7 +28,7 @@ public class GasSpargingRecipe implements Comparable<GasSpargingRecipe> {
         aOutputs = ArrayUtils.insertElementAtIndex(aOutputs, 1, aSpargedFuel);
         mFluidOutputs = aOutputs;
         mMaxOutputQuantity = aMaxOutputQuantity;
-        mDuration = 500 * 10; // Actual recipe time is 10x less than this number, not sure why
+        mDuration = 500;
         mEUt = MaterialUtils.getVoltageForTier(5);
     }
 

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/GregtechMetaTileEntity_SpargeTower.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/GregtechMetaTileEntity_SpargeTower.java
@@ -224,6 +224,11 @@ public class GregtechMetaTileEntity_SpargeTower extends GregtechMeta_MultiBlockB
                             tRecipe.mFluidInputs[1]);
                     this.mOutputFluids = aFluidOutputs.toArray(new FluidStack[0]);
                     updateSlots();
+
+                    if (lEUt > 0) {
+                        lEUt = (-lEUt);
+                    }
+
                     return CheckRecipeResultRegistry.SUCCESSFUL;
                 }
             }

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/GregtechMetaTileEntity_SpargeTower.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/GregtechMetaTileEntity_SpargeTower.java
@@ -142,7 +142,6 @@ public class GregtechMetaTileEntity_SpargeTower extends GregtechMeta_MultiBlockB
         final GT_Multiblock_Tooltip_Builder tt = new GT_Multiblock_Tooltip_Builder();
         tt.addMachineType("Gas Sparge Tower").addInfo("Controller block for the Sparging Tower")
                 .addInfo("Runs gases through depleted molten salts to extract precious fluids")
-                .addInfo("Has a speed bonus of 10x - recipe times are 1/10 of what is shown on NEI")
                 .addInfo("Works the same way as the Distillation Tower, but with a fixed height of 8")
                 .addInfo("Fluids are only put out at the correct height")
                 .addInfo("The correct height equals the slot number in the NEI recipe").addSeparator()
@@ -204,7 +203,7 @@ public class GregtechMetaTileEntity_SpargeTower extends GregtechMeta_MultiBlockB
     @Override
     public @NotNull CheckRecipeResult checkProcessing() {
         ArrayList<FluidStack> tFluidList = getStoredFluids();
-        long tVoltage = getMaxInputVoltage();
+        long tVoltage = GT_Utility.roundUpVoltage(this.getMaxInputVoltage());
         byte tTier = (byte) Math.max(0, GT_Utility.getTier(tVoltage));
         FluidStack[] tFluids = tFluidList.toArray(new FluidStack[0]);
         if (tFluids.length > 0) {
@@ -219,7 +218,7 @@ public class GregtechMetaTileEntity_SpargeTower extends GregtechMeta_MultiBlockB
                     this.mEfficiencyIncrease = 10000;
 
                     calculateOverclockedNessMulti((long) tRecipe.mEUt, tRecipe.mDuration, 1, tVoltage);
-                    mMaxProgresstime = Math.max(1, mMaxProgresstime / 10);
+                    mMaxProgresstime = Math.max(1, mMaxProgresstime);
                     ArrayList<FluidStack> aFluidOutputs = getByproductsOfSparge(
                             tRecipe.mFluidInputs[0],
                             tRecipe.mFluidInputs[1]);

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/GregtechMetaTileEntity_SpargeTower.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/GregtechMetaTileEntity_SpargeTower.java
@@ -18,6 +18,7 @@ import java.util.List;
 
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NBTTagCompound;
 import net.minecraftforge.common.util.ForgeDirection;
 import net.minecraftforge.fluids.FluidStack;
 
@@ -489,5 +490,14 @@ public class GregtechMetaTileEntity_SpargeTower extends GregtechMeta_MultiBlockB
             aLayerIndex++;
         }
         return aLayerIndex > 0;
+    }
+
+    @Override
+    public void loadNBTData(NBTTagCompound aNBT) {
+        super.loadNBTData(aNBT);
+        // Ensure that lEUt is negative from loaded NBT data, since this multi consumes EU
+        if (lEUt > 0) {
+            lEUt = (-lEUt);
+        }
     }
 }

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/GregtechMTE_NuclearReactor.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/GregtechMTE_NuclearReactor.java
@@ -39,14 +39,11 @@ import gregtech.api.metatileentity.implementations.GT_MetaTileEntity_Hatch_Outpu
 import gregtech.api.objects.GT_ItemStack;
 import gregtech.api.recipe.check.CheckRecipeResult;
 import gregtech.api.recipe.check.CheckRecipeResultRegistry;
-import gregtech.api.recipe.check.FindRecipeResult;
 import gregtech.api.recipe.check.SimpleCheckRecipeResult;
-import gregtech.api.recipe.check.SingleRecipeCheck;
 import gregtech.api.render.TextureFactory;
 import gregtech.api.util.GTPP_Recipe.GTPP_Recipe_Map;
 import gregtech.api.util.GT_Multiblock_Tooltip_Builder;
 import gregtech.api.util.GT_OverclockCalculator;
-import gregtech.api.util.GT_ParallelHelper;
 import gregtech.api.util.GT_Recipe;
 import gregtech.api.util.GT_Recipe.GT_Recipe_Map;
 import gtPlusPlus.core.block.ModBlocks;

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/GregtechMTE_NuclearReactor.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/GregtechMTE_NuclearReactor.java
@@ -12,9 +12,6 @@ import static gregtech.api.enums.GT_HatchElement.OutputHatch;
 import static gregtech.api.util.GT_StructureUtility.buildHatchAdder;
 import static gregtech.api.util.GT_StructureUtility.filterByMTETier;
 
-import gregtech.api.recipe.check.FindRecipeResult;
-import gregtech.api.recipe.check.SingleRecipeCheck;
-import gregtech.api.util.GT_ParallelHelper;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraftforge.common.util.ForgeDirection;
@@ -42,11 +39,14 @@ import gregtech.api.metatileentity.implementations.GT_MetaTileEntity_Hatch_Outpu
 import gregtech.api.objects.GT_ItemStack;
 import gregtech.api.recipe.check.CheckRecipeResult;
 import gregtech.api.recipe.check.CheckRecipeResultRegistry;
+import gregtech.api.recipe.check.FindRecipeResult;
 import gregtech.api.recipe.check.SimpleCheckRecipeResult;
+import gregtech.api.recipe.check.SingleRecipeCheck;
 import gregtech.api.render.TextureFactory;
 import gregtech.api.util.GTPP_Recipe.GTPP_Recipe_Map;
 import gregtech.api.util.GT_Multiblock_Tooltip_Builder;
 import gregtech.api.util.GT_OverclockCalculator;
+import gregtech.api.util.GT_ParallelHelper;
 import gregtech.api.util.GT_Recipe;
 import gregtech.api.util.GT_Recipe.GT_Recipe_Map;
 import gtPlusPlus.core.block.ModBlocks;
@@ -381,7 +381,8 @@ public class GregtechMTE_NuclearReactor extends GregtechMeta_MultiBlockBase<Greg
                 }
 
                 FindRecipeResult findRecipeResult;
-                if (isRecipeLocked && recipeLockableMachine != null && recipeLockableMachine.getSingleRecipeCheck() != null) {
+                if (isRecipeLocked && recipeLockableMachine != null
+                        && recipeLockableMachine.getSingleRecipeCheck() != null) {
                     // Recipe checker is already built, we'll use it
                     SingleRecipeCheck singleRecipeCheck = recipeLockableMachine.getSingleRecipeCheck();
                     // Validate recipe here, otherwise machine will show "not enough output space"
@@ -389,9 +390,8 @@ public class GregtechMTE_NuclearReactor extends GregtechMeta_MultiBlockBase<Greg
                     if (singleRecipeCheck.checkRecipeInputs(false, 1, inputItems, inputFluids) == 0) {
                         return CheckRecipeResultRegistry.NO_RECIPE;
                     }
-                    findRecipeResult = FindRecipeResult.ofSuccess(
-                            recipeLockableMachine.getSingleRecipeCheck()
-                                    .getRecipe());
+                    findRecipeResult = FindRecipeResult
+                            .ofSuccess(recipeLockableMachine.getSingleRecipeCheck().getRecipe());
                 } else {
                     findRecipeResult = findRecipe(recipeMap);
                 }
@@ -420,8 +420,7 @@ public class GregtechMTE_NuclearReactor extends GregtechMeta_MultiBlockBase<Greg
                 helper.setCalculator(calculator);
                 helper.build();
 
-                if (!helper.getResult()
-                        .wasSuccessful()) {
+                if (!helper.getResult().wasSuccessful()) {
                     return helper.getResult();
                 }
 

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/GregtechMetaTileEntity_Refinery.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/GregtechMetaTileEntity_Refinery.java
@@ -163,7 +163,8 @@ public class GregtechMetaTileEntity_Refinery extends GregtechMeta_MultiBlockBase
         mCasing = 0;
         if (checkPiece(mName, 1, 7, 0) && mCasing >= 7) {
             if (this.mInputHatches.size() >= 2 && this.mInputHatches.size() <= 4
-                    && this.mOutputHatches.size() >= 1 && this.mOutputHatches.size() <= 2
+                    && this.mOutputHatches.size() >= 1
+                    && this.mOutputHatches.size() <= 2
                     && this.mMufflerHatches.size() == 1
                     && this.mMaintenanceHatches.size() == 1
                     && this.mEnergyHatches.size() == 1) {

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/GregtechMetaTileEntity_Refinery.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/GregtechMetaTileEntity_Refinery.java
@@ -67,10 +67,10 @@ public class GregtechMetaTileEntity_Refinery extends GregtechMeta_MultiBlockBase
                 .addCasingInfoMin("Incoloy-DS Fluid Containment Block", 5, false)
                 .addCasingInfoMin("Zeron-100 Reactor Shielding", 4, false)
                 .addCasingInfoMin("Hastelloy-N Sealant Blocks", 17, false).addInputHatch("Base platform", 1)
-                .addOutputHatch("Base platform", 1).addOutputBus("Base platform", 1).addMufflerHatch("Base platform", 1)
+                .addOutputHatch("Base platform", 1).addMufflerHatch("Base platform", 1)
                 .addMaintenanceHatch("Base platform", 1).addEnergyHatch("Base platform", 1)
                 .addStructureInfo("Muffler's Tier must be IV+")
-                .addStructureInfo("4x Input Hatches, 2x Output Hatches, 1x Output Bus")
+                .addStructureInfo("2-4x Input Hatches, 1-2x Output Hatches")
                 .addStructureInfo("1x Muffler, 1x Maintenance Hatch, 1x Energy Hatch")
                 .toolTipFinisher(CORE.GT_Tooltip_Builder.get());
         return tt;
@@ -162,8 +162,8 @@ public class GregtechMetaTileEntity_Refinery extends GregtechMeta_MultiBlockBase
     public boolean checkMachine(IGregTechTileEntity aBaseMetaTileEntity, ItemStack aStack) {
         mCasing = 0;
         if (checkPiece(mName, 1, 7, 0) && mCasing >= 7) {
-            if (this.mInputHatches.size() == 4 && this.mOutputHatches.size() == 2
-                    && this.mOutputBusses.size() == 1
+            if (this.mInputHatches.size() >= 2 && this.mInputHatches.size() <= 4
+                    && this.mOutputHatches.size() >= 1 && this.mOutputHatches.size() <= 2
                     && this.mMufflerHatches.size() == 1
                     && this.mMaintenanceHatches.size() == 1
                     && this.mEnergyHatches.size() == 1) {

--- a/src/main/java/gtPlusPlus/xmod/gregtech/loaders/recipe/RecipeLoader_NuclearFuelProcessing.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/loaders/recipe/RecipeLoader_NuclearFuelProcessing.java
@@ -232,8 +232,8 @@ public class RecipeLoader_NuclearFuelProcessing {
          */
 
         CORE.RA.addFissionFuel(
-                FLUORIDES.ZIRCONIUM_TETRAFLUORIDE.getFluidStack(1000),
-                NUCLIDE.LiFBeF2UF4.getFluidStack(9000),
+                FLUORIDES.ZIRCONIUM_TETRAFLUORIDE.getFluidStack(100),
+                NUCLIDE.LiFBeF2UF4.getFluidStack(900),
                 null,
                 null,
                 null,
@@ -241,9 +241,9 @@ public class RecipeLoader_NuclearFuelProcessing {
                 null,
                 null,
                 null,
-                NUCLIDE.LiFBeF2ZrF4UF4.getFluidStack(10000),
+                NUCLIDE.LiFBeF2ZrF4UF4.getFluidStack(1000),
                 null,
-                20 * 60 * 120, // Duration
+                20 * 60 * 12, // Duration
                 MaterialUtils.getVoltageForTier(5));
 
         // LiFBeF2ThF4UF4
@@ -258,8 +258,8 @@ public class RecipeLoader_NuclearFuelProcessing {
          */
 
         CORE.RA.addFissionFuel(
-                FLUORIDES.THORIUM_TETRAFLUORIDE.getFluidStack(1000),
-                NUCLIDE.LiFBeF2UF4.getFluidStack(9000),
+                FLUORIDES.THORIUM_TETRAFLUORIDE.getFluidStack(100),
+                NUCLIDE.LiFBeF2UF4.getFluidStack(900),
                 null,
                 null,
                 null,
@@ -267,9 +267,9 @@ public class RecipeLoader_NuclearFuelProcessing {
                 null,
                 null,
                 null,
-                NUCLIDE.LiFBeF2ThF4UF4.getFluidStack(10000),
+                NUCLIDE.LiFBeF2ThF4UF4.getFluidStack(1000),
                 null,
-                20 * 60 * 150, // Duration
+                20 * 60 * 15, // Duration
                 MaterialUtils.getVoltageForTier(5));
     }
 }


### PR DESCRIPTION
Coming in with more fixes for the LFTR chain before the next stable, including some problems that resurfaced from processing logic changes:

- LFTR no longer keeps running without fuel;
- Sparge Tower no longer runs 10x as fast as NEI's recipe times, NEI was adjusted to reflect the real processing times;
- Sparge Tower now consumes EU properly, instead of "generating" it;
- Fuel Refinery now has more reasonable hatch requirements, while keeping the old maximums for old structures;
- Tweaked the very long (7200s-9000s) Refinery recipes to only do 1/10 of the recipe, but at 1/10 of the recipe time, for more reasonable fuel refining.