### PR TITLE
Fix XL Turbine tooltip

### DIFF
--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/turbines/GregtechMetaTileEntity_LargerTurbineBase.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/turbines/GregtechMetaTileEntity_LargerTurbineBase.java
@@ -103,11 +103,15 @@ public abstract class GregtechMetaTileEntity_LargerTurbineBase extends
                 .addInfo("Right-click with screwdriver to enable Fast Mode, to run it even faster")
                 .addInfo("Optimal flow will increase or decrease accordingly on mode switch")
                 .addInfo("Fast Mode increases speed to 48x instead of 16x, with some penalties")
-                .addInfo("Maintenance problems and turbine damage happen 12x as often in Fast Mode")
-                .addInfo("XL Steam Turbines can use Loose Mode with either Slow or Fast Mode")
-                .addInfo("Plasma fuel efficiency is lower for high tier turbines when using low-grade plasmas")
-                .addInfo("Efficiency = ((FuelValue / 100000)^2) / (EU per Turbine)")
-                .addPollutionAmount(getPollutionPerSecond(null)).addInfo("Pollution is 3x higher in Fast Mode")
+                .addInfo("Maintenance problems and turbine damage happen 12x as often in Fast Mode");
+                if(getTurbineType().contains("Steam")) {
+                    tt.addInfo("XL Steam Turbines can use Loose Mode with either Slow or Fast Mode");
+                }
+                if(getTurbineType().equals("Plasma")) {
+                    tt.addInfo("Plasma fuel efficiency is lower for high tier turbines when using low-grade plasmas")
+                     .addInfo("Efficiency = ((FuelValue / 200000)^2) / (EU per Turbine)");
+                }
+                tt.addPollutionAmount(getPollutionPerSecond(null)).addInfo("Pollution is 3x higher in Fast Mode")
                 .addSeparator().beginStructureBlock(7, 9, 7, false).addController("Top Middle")
                 .addCasingInfoMin(getCasingName(), 360, false).addCasingInfoMin("Rotor Shaft", 30, false)
                 .addOtherStructurePart("Rotor Assembly", "Any 1 dot hint", 1).addInputBus("Any 4 dot hint (min 1)", 4)

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/turbines/GregtechMetaTileEntity_LargerTurbineBase.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/turbines/GregtechMetaTileEntity_LargerTurbineBase.java
@@ -104,15 +104,15 @@ public abstract class GregtechMetaTileEntity_LargerTurbineBase extends
                 .addInfo("Optimal flow will increase or decrease accordingly on mode switch")
                 .addInfo("Fast Mode increases speed to 48x instead of 16x, with some penalties")
                 .addInfo("Maintenance problems and turbine damage happen 12x as often in Fast Mode");
-                if(getTurbineType().contains("Steam")) {
-                    tt.addInfo("XL Steam Turbines can use Loose Mode with either Slow or Fast Mode");
-                }
-                if(getTurbineType().equals("Plasma")) {
-                    tt.addInfo("Plasma fuel efficiency is lower for high tier turbines when using low-grade plasmas")
-                     .addInfo("Efficiency = ((FuelValue / 200000)^2) / (EU per Turbine)");
-                }
-                tt.addPollutionAmount(getPollutionPerSecond(null)).addInfo("Pollution is 3x higher in Fast Mode")
-                .addSeparator().beginStructureBlock(7, 9, 7, false).addController("Top Middle")
+        if (getTurbineType().contains("Steam")) {
+            tt.addInfo("XL Steam Turbines can use Loose Mode with either Slow or Fast Mode");
+        }
+        if (getTurbineType().equals("Plasma")) {
+            tt.addInfo("Plasma fuel efficiency is lower for high tier turbines when using low-grade plasmas")
+                    .addInfo("Efficiency = ((FuelValue / 200000)^2) / (EU per Turbine)");
+        }
+        tt.addPollutionAmount(getPollutionPerSecond(null)).addInfo("Pollution is 3x higher in Fast Mode").addSeparator()
+                .beginStructureBlock(7, 9, 7, false).addController("Top Middle")
                 .addCasingInfoMin(getCasingName(), 360, false).addCasingInfoMin("Rotor Shaft", 30, false)
                 .addOtherStructurePart("Rotor Assembly", "Any 1 dot hint", 1).addInputBus("Any 4 dot hint (min 1)", 4)
                 .addInputHatch("Any 4 dot hint(min 1)", 4);


### PR DESCRIPTION
Splits the tooltip for xl turbines so only the relevant info shows, also corrects the plasma formula tooltip.

Closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/14209 
& https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/13616