### PR TITLE
Add tooltip to Steam Output Bus about auto-export 

### DIFF
--- a/src/main/java/gtPlusPlus/xmod/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_Hatch_Steam_BusOutput.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_Hatch_Steam_BusOutput.java
@@ -30,8 +30,8 @@ public class GT_MetaTileEntity_Hatch_Steam_BusOutput extends GT_MetaTileEntity_H
                 aNameRegional,
                 aTier,
                 4,
-                new String[] { "Item Output for Steam Multiblocks", "Capacity: 4 stacks",
-                        "Does not work with non-steam multiblocks", CORE.GT_Tooltip.get() });
+                new String[] { "Item Output for Steam Multiblocks", "Does not automatically export items",
+                        "Capacity: 4 stacks", "Does not work with non-steam multiblocks", CORE.GT_Tooltip.get() });
     }
 
     public GT_MetaTileEntity_Hatch_Steam_BusOutput(String aName, int aTier, String aDescription,


### PR DESCRIPTION
Tooltip to alleviate confusion on auto-pushing mechanics for Output Buses in general