### PR TITLE
Fix Algae Farm compost calculation

### DIFF
--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/algae/GregtechMTE_AlgaePondBase.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/algae/GregtechMTE_AlgaePondBase.java
@@ -334,7 +334,7 @@ public class GregtechMTE_AlgaePondBase extends GregtechMeta_MultiBlockBase<Gregt
         ItemStack aCompost = ItemUtils.getSimpleStack(AgriculturalChem.mCompost, 1);
         for (ItemStack i : aItemInputs) {
             if (GT_Utility.areStacksEqual(aCompost, i)) {
-                if (i.stackSize >= 8) {
+                if (i.stackSize >= RecipeLoader_AlgaeFarm.compostForTier(mLevel)) {
                     return true;
                 }
             }

--- a/src/main/java/gtPlusPlus/xmod/gregtech/loaders/recipe/RecipeLoader_AlgaeFarm.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/loaders/recipe/RecipeLoader_AlgaeFarm.java
@@ -50,6 +50,10 @@ public class RecipeLoader_AlgaeFarm {
         Logger.INFO("Using recipe with index of " + aIndex + ". " + aComp);
         return aTemp.get(aIndex);
     }
+    
+    public static int compostForTier(int aTier) {
+        return aTier > 1 ? (int) Math.min(64, Math.pow(2, aTier - 1)) : 1;
+    }
 
     private static GT_Recipe generateBaseRecipe(boolean aUsingCompost, int aTier) {
 
@@ -81,7 +85,7 @@ public class RecipeLoader_AlgaeFarm {
             // Compost consumption maxes out at 1 stack per cycle
             ItemStack aCompost = ItemUtils.getSimpleStack(
                     AgriculturalChem.mCompost,
-                    aTier > 1 ? (int) Math.min(64, Math.pow(2, aTier - 1)) : 1);
+                    compostForTier(aTier));
             aInputs = new ItemStack[] { aCompost };
             // Boost Tier by one if using compost so it gets a speed boost
             aTier++;

--- a/src/main/java/gtPlusPlus/xmod/gregtech/loaders/recipe/RecipeLoader_AlgaeFarm.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/loaders/recipe/RecipeLoader_AlgaeFarm.java
@@ -50,7 +50,7 @@ public class RecipeLoader_AlgaeFarm {
         Logger.INFO("Using recipe with index of " + aIndex + ". " + aComp);
         return aTemp.get(aIndex);
     }
-    
+
     public static int compostForTier(int aTier) {
         return aTier > 1 ? (int) Math.min(64, Math.pow(2, aTier - 1)) : 1;
     }
@@ -83,9 +83,7 @@ public class RecipeLoader_AlgaeFarm {
         if (aUsingCompost) {
             // Make it use 4 compost per tier if we have some available
             // Compost consumption maxes out at 1 stack per cycle
-            ItemStack aCompost = ItemUtils.getSimpleStack(
-                    AgriculturalChem.mCompost,
-                    compostForTier(aTier));
+            ItemStack aCompost = ItemUtils.getSimpleStack(AgriculturalChem.mCompost, compostForTier(aTier));
             aInputs = new ItemStack[] { aCompost };
             // Boost Tier by one if using compost so it gets a speed boost
             aTier++;


### PR DESCRIPTION
Currently EV+ algae farms stop working if they have 8 or more compost input, but less than the required amount e.g. 16 at EV, having 14 in the input bus causes the machine to stop with "machine crashed" in the controller interface.

ULV-MV farms also wont use 1/2/4 compost unless >=8 is in the input bus.

This fix replaces the hardcoded 8 in `isUsingCompost` with a reference to recipe's compost calculation.