### PR TITLE
Cleanup gt++ phthalic acid

### DIFF
--- a/src/main/java/gtPlusPlus/core/item/chemistry/CoalTar.java
+++ b/src/main/java/gtPlusPlus/core/item/chemistry/CoalTar.java
@@ -2,6 +2,7 @@ package gtPlusPlus.core.item.chemistry;
 
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.fluids.Fluid;
+import net.minecraftforge.fluids.FluidRegistry;
 import net.minecraftforge.fluids.FluidStack;
 
 import gregtech.api.enums.GT_Values;
@@ -28,7 +29,6 @@ public class CoalTar extends ItemPackage {
     public static Fluid Coal_Tar_Oil;
     public static Fluid Sulfuric_Coal_Tar_Oil;
     public static Fluid Naphthalene;
-    public static Fluid Phthalic_Acid;
 
     private static void recipeEthylBenzineFuelsIntoHeavyFuel() {
         CORE.RA.addChemicalRecipe(
@@ -238,7 +238,7 @@ public class CoalTar extends ItemPackage {
                 ItemUtils.getItemStackOfAmountFromOreDict("cellNaphthalene", 2),
                 ItemUtils.getItemStackOfAmountFromOreDict("dustLithium", 5),
                 null,
-                FluidUtils.getFluidStack("fluid.phthalicacid", 2500),
+                FluidRegistry.getFluidStack("phtalicacid", 2500),
                 ItemUtils.getItemStackOfAmountFromOreDict("cellEmpty", 2),
                 20 * 16);
     }
@@ -246,7 +246,7 @@ public class CoalTar extends ItemPackage {
     private static void recipePhthalicAcidToPhthalicAnhydride() {
         CORE.RA.addDehydratorRecipe(
                 new ItemStack[] { CI.getNumberedBioCircuit(15) },
-                FluidUtils.getFluidStack("fluid.phthalicacid", 1000),
+                FluidRegistry.getFluidStack("phtalicacid", 1000),
                 null,
                 new ItemStack[] { ItemUtils.getItemStackOfAmountFromOreDict("dustPhthalicAnhydride", 15) },
                 new int[] { 10000 },
@@ -273,8 +273,6 @@ public class CoalTar extends ItemPackage {
 
         recipeEthylBenzineFuelsIntoHeavyFuel();
 
-        recipePhthalicAcidConversion();
-
         // Burn the coal gas!
         GT_Values.RA.addFuel(ItemUtils.getItemStackOfAmountFromOreDict("cellCoalGas", 1), null, 96, 1);
         CORE.RA.addSemifluidFuel(ItemUtils.getItemStackOfAmountFromOreDict("cellSulfuricCoalTarOil", 1), 64);
@@ -284,19 +282,8 @@ public class CoalTar extends ItemPackage {
         return true;
     }
 
-    private void recipePhthalicAcidConversion() {
-        FluidStack aMyAcid = FluidUtils.getFluidStack(Phthalic_Acid, 500);
-        FluidStack aGtAcid = FluidUtils.getFluidStack("phtalicacid", 500);
-        if (aMyAcid != null && aGtAcid != null) {
-            CORE.RA.addDistilleryRecipe(CI.getNumberedBioCircuit(8), aMyAcid, aGtAcid, null, 50, 16, false);
-            CORE.RA.addDistilleryRecipe(CI.getNumberedBioCircuit(9), aGtAcid, aMyAcid, null, 50, 16, false);
-        }
-    }
-
     @Override
     public void items() {
-        // Phthalic_Acid = FluidUtils.generateFluidNonMolten("PhthalicAcid", "Phthalic Acid", 207, new short[]{210, 220,
-        // 210, 100}, null, null);
         // v - Dehydrate at 180C+
         // Create Phthalic Anhydride
         ItemUtils.generateSpecialUseDusts(
@@ -403,18 +390,5 @@ public class CoalTar extends ItemPackage {
                 new short[] { 210, 185, 135, 100 },
                 null,
                 null);
-        // v - Oxidize with mercury and nitric acid
-        // Create Phthalic Acid
-        Phthalic_Acid = FluidUtils.generateFluidNonMolten(
-                "PhthalicAcid",
-                "Phthalic Acid",
-                207,
-                new short[] { 210, 220, 210, 100 },
-                null,
-                null);
-        // v - Dehydrate at 180C+
-        // Create Phthalic Anhydride
-        // ItemUtils.generateSpecialUseDusts("PhthalicAnhydride", "Phthalic Anhydride", "C6H4(CO)2O",
-        // Utils.rgbtoHexValue(175, 175, 175));
     }
 }

--- a/src/main/java/gtPlusPlus/core/item/chemistry/CoalTar.java
+++ b/src/main/java/gtPlusPlus/core/item/chemistry/CoalTar.java
@@ -2,7 +2,6 @@ package gtPlusPlus.core.item.chemistry;
 
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.fluids.Fluid;
-import net.minecraftforge.fluids.FluidRegistry;
 import net.minecraftforge.fluids.FluidStack;
 
 import gregtech.api.enums.GT_Values;
@@ -238,7 +237,7 @@ public class CoalTar extends ItemPackage {
                 ItemUtils.getItemStackOfAmountFromOreDict("cellNaphthalene", 2),
                 ItemUtils.getItemStackOfAmountFromOreDict("dustLithium", 5),
                 null,
-                FluidRegistry.getFluidStack("phtalicacid", 2500),
+                Materials.PhthalicAcid.getFluid(2500),
                 ItemUtils.getItemStackOfAmountFromOreDict("cellEmpty", 2),
                 20 * 16);
     }
@@ -246,7 +245,7 @@ public class CoalTar extends ItemPackage {
     private static void recipePhthalicAcidToPhthalicAnhydride() {
         CORE.RA.addDehydratorRecipe(
                 new ItemStack[] { CI.getNumberedBioCircuit(15) },
-                FluidRegistry.getFluidStack("phtalicacid", 1000),
+                Materials.PhthalicAcid.getFluid(1000),
                 null,
                 new ItemStack[] { ItemUtils.getItemStackOfAmountFromOreDict("dustPhthalicAnhydride", 15) },
                 new int[] { 10000 },

--- a/src/main/resources/assets/miscutils/lang/de_DE.lang
+++ b/src/main/resources/assets/miscutils/lang/de_DE.lang
@@ -1633,7 +1633,6 @@ item.CoalTar.name=Kohl-Teer-Zelle
 item.CoalTarOil.name=Kohl-Teeröl-Zelle
 item.SulfuricCoalTarOil.name=Schweflige Kohl-Teeröl-Zelle
 item.Naphthalene.name=Naphthalin-Zelle
-item.PhthalicAcid.name=Phthalsäure-Zelle
 item.itemDustPhthalicAnhydride.name=Phthalsäureanhydrid-Staub
 item.itemDustSmallPhthalicAnhydride.name=Kleines Häufchen Phthalsäureanhydrid-Staub
 item.itemDustTinyPhthalicAnhydride.name=Winziges Häufchen Phthalsäureanhydrid-Staub

--- a/src/main/resources/assets/miscutils/lang/en_US.lang
+++ b/src/main/resources/assets/miscutils/lang/en_US.lang
@@ -1724,7 +1724,6 @@ item.CoalTar.name=Coal Tar Cell
 item.CoalTarOil.name=Coal Tar Oil Cell
 item.SulfuricCoalTarOil.name=Sulfuric Coal Tar Oil Cell
 item.Naphthalene.name=Naphthalene Cell
-item.PhthalicAcid.name=Phthalic Acid Cell
 item.itemDustPhthalicAnhydride.name=Phthalic Anhydride Dust
 item.itemDustSmallPhthalicAnhydride.name=Small Pile of Phthalic Anhydride Dust
 item.itemDustTinyPhthalicAnhydride.name=Tiny Pile of Phthalic Anhydride Dust

--- a/src/main/resources/assets/miscutils/lang/ru_RU.lang
+++ b/src/main/resources/assets/miscutils/lang/ru_RU.lang
@@ -1669,7 +1669,6 @@ item.CoalTar.name=Coal Tar Cell
 item.CoalTarOil.name=Coal Tar Oil Cell
 item.SulfuricCoalTarOil.name=Sulfuric Coal Tar Oil Cell
 item.Naphthalene.name=Naphthalene Cell
-item.PhthalicAcid.name=Phthalic Acid Cell
 item.itemDustPhthalicAnhydride.name=Phthalic Anhydride Dust
 item.itemDustSmallPhthalicAnhydride.name=Small Pile of Phthalic Anhydride Dust
 item.itemDustTinyPhthalicAnhydride.name=Tiny Pile of Phthalic Anhydride Dust

--- a/src/main/resources/assets/miscutils/lang/zh_CN.lang
+++ b/src/main/resources/assets/miscutils/lang/zh_CN.lang
@@ -1669,7 +1669,6 @@ item.CoalTar.name=煤焦油单元
 item.CoalTarOil.name=煤焦油单元
 item.SulfuricCoalTarOil.name=硫酸煤焦油单元
 item.Naphthalene.name=萘单元
-item.PhthalicAcid.name=邻苯二甲酸单元
 item.itemDustPhthalicAnhydride.name=邻苯二甲酸酐粉
 item.itemDustSmallPhthalicAnhydride.name=小堆邻苯二甲酸酐粉
 item.itemDustTinyPhthalicAnhydride.name=小撮邻苯二甲酸酐粉


### PR DESCRIPTION
It exists in GT. So just use the GT variant everywhere.

there is a followup quest PR here https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/pull/14432