### PR TITLE
Tartarite Buff

### DIFF
--- a/src/main/java/gtPlusPlus/xmod/gregtech/loaders/recipe/RecipeLoader_Nuclear.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/loaders/recipe/RecipeLoader_Nuclear.java
@@ -517,7 +517,7 @@ public class RecipeLoader_Nuclear {
         GT_Values.RA.stdBuilder().noItemInputs().noItemOutputs()
                 .fluidInputs(
                         new FluidStack(ELEMENT.STANDALONE.ADVANCED_NITINOL.getPlasma(), 144),
-                        Materials.Tartarite.getMolten(8))
+                        Materials.Tartarite.getMolten(2))
                 .fluidOutputs(new FluidStack(ELEMENT.STANDALONE.CELESTIAL_TUNGSTEN.getPlasma(), 1000))
                 .duration(16 * TICKS).eut(TierEU.RECIPE_UV).metadata(FUSION_THRESHOLD, 500000000).addTo(sFusionRecipes);
     }


### PR DESCRIPTION
This is a buff to one step of the new plasma chain: it divides the required Tartarite by 4.

This has come up a few times as a hurdle holding back the line a bit. At the moment a base T3 reactor running the recipe constantly needs 10L/s tartarite.

There is three aspects to this:

1. The power cost. Smelting the Tartarite takes around 5% of the final power output of the line (less with volcanus, more with inefficient OCs). This part is relative high and a buff here seems to be desired by a lot of people but I think it would be acceptable in isolation, the total power cost of the line is around 16% of the output which is quite manageable. 
2. Obtaining the Tartarite. One can get it with VMs on T8 planets but the rate is relatively poor (e.g. around 0.21 tartarite ores/s  empircally with a xenon vm3 on barnada C) making this a quite annoying part. in particular with:
3. Scalablity: the line should scale nicely to lets say a mk3 compact fusion reactor continuously running the final recipe (for around 8 billion eu/t with XL plasma, currently needing 640L/s Tartarite). when doing so 1) requires either a dedicated high tier MEBF or volcanus spam while 2) becomes a major annoyance needing 3 oganesson or 10 xenon VM3s. With the buff here, a single oganesson VM thus should be able to do it.

this step was not really designed to be this involved, in fact it didnt even make the unfuckening spreadsheet. A 4x buff thus does not affect the orginal balance intention of the line despite being quite massive.

------------

relevant links:
- some discussion in this ticket: https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/14427
- some discussion on github: https://discord.com/channels/181078474394566657/401118216228831252/1152336327187116073
- some discussion of the power aspect around here in meta-dev: https://discord.com/channels/181078474394566657/939305179524792340/1145746894396588195

------------

Super Fun extra questionaire:
1. What goal is this change trying to achieve? What tier is it targeting?

already explained. late UV-UEV

2. What side effects does this have on other lines/systems? How does it change the game meta?

no other lines affected. I am not an oracle but a buff is a buff.

4. If relevant, do you have any metrics or a spreadsheet/visualization explaining your change? If it is a new multiblock, could you provide a picture of it and/or a practical setup? This may help us understand it better.

see the unfuckening spreadsheet for the line numbers. mentioned the tartarite numbers above.

5. Is this change made in expectation or in tandem with another unwritten or unmerged change coming later?

no. though EHE balancing is very much an open thing and an ongoing discussion.