### PR TITLE
Add Voltage-CoilHeat adjustment for Volcanus

### DIFF
--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/advanced/GregtechMetaTileEntity_Adv_EBF.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/advanced/GregtechMetaTileEntity_Adv_EBF.java
@@ -61,7 +61,8 @@ public class GregtechMetaTileEntity_Adv_EBF extends GregtechMeta_MultiBlockBase<
     private int mCasing;
     private final ArrayList<GT_MetaTileEntity_Hatch_CustomFluidBase> mPyrotheumHatches = new ArrayList<>();
 
-    private HeatingCoilLevel mHeatingCapacity = HeatingCoilLevel.None;
+    private HeatingCoilLevel mHeatingLevel = HeatingCoilLevel.None;
+    private int mHeatingCapacity=0;
 
     public GregtechMetaTileEntity_Adv_EBF(int aID, String aName, String aNameRegional) {
         super(aID, aName, aNameRegional);
@@ -102,7 +103,7 @@ public class GregtechMetaTileEntity_Adv_EBF extends GregtechMeta_MultiBlockBase<
     public String[] getExtraInfoData() {
         return new String[] { StatCollector.translateToLocal("GT5U.EBF.heat") + ": "
                 + EnumChatFormatting.GREEN
-                + GT_Utility.formatNumbers(mHeatingCapacity.getHeat())
+                + GT_Utility.formatNumbers(mHeatingLevel.getHeat())
                 + EnumChatFormatting.RESET
                 + " K" };
     }
@@ -156,7 +157,10 @@ public class GregtechMetaTileEntity_Adv_EBF extends GregtechMeta_MultiBlockBase<
         mCasing = 0;
         mPyrotheumHatches.clear();
         setCoilLevel(HeatingCoilLevel.None);
-        return checkPiece(mName, 1, 3, 0) && mCasing >= 8 && getCoilLevel() != HeatingCoilLevel.None && checkHatch();
+
+        boolean isSuccess = checkPiece(mName, 1, 3, 0) && mCasing >= 8 && getCoilLevel() != HeatingCoilLevel.None && checkHatch();
+        if(isSuccess) this.mHeatingCapacity = (int) getCoilLevel().getHeat() + 100 * (GT_Utility.getTier(getMaxInputVoltage()) - 2);
+        return isSuccess;
     }
 
     @Override
@@ -233,7 +237,7 @@ public class GregtechMetaTileEntity_Adv_EBF extends GregtechMeta_MultiBlockBase<
             @NotNull
             @Override
             protected CheckRecipeResult validateRecipe(@NotNull GT_Recipe recipe) {
-                return recipe.mSpecialValue <= getCoilLevel().getHeat() ? CheckRecipeResultRegistry.SUCCESSFUL
+                return recipe.mSpecialValue <= mHeatingCapacity ? CheckRecipeResultRegistry.SUCCESSFUL
                         : CheckRecipeResultRegistry.insufficientHeat(recipe.mSpecialValue);
             }
 
@@ -311,11 +315,11 @@ public class GregtechMetaTileEntity_Adv_EBF extends GregtechMeta_MultiBlockBase<
     }
 
     public HeatingCoilLevel getCoilLevel() {
-        return mHeatingCapacity;
+        return mHeatingLevel;
     }
 
     public void setCoilLevel(HeatingCoilLevel aCoilLevel) {
-        mHeatingCapacity = aCoilLevel;
+        mHeatingLevel = aCoilLevel;
     }
 
     @Override

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/advanced/GregtechMetaTileEntity_Adv_EBF.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/advanced/GregtechMetaTileEntity_Adv_EBF.java
@@ -59,10 +59,10 @@ public class GregtechMetaTileEntity_Adv_EBF extends GregtechMeta_MultiBlockBase<
     public static String mHatchName = "Pyrotheum Hatch";
     private static IStructureDefinition<GregtechMetaTileEntity_Adv_EBF> STRUCTURE_DEFINITION = null;
     private int mCasing;
+    private int mHeatingCapacity;
     private final ArrayList<GT_MetaTileEntity_Hatch_CustomFluidBase> mPyrotheumHatches = new ArrayList<>();
 
     private HeatingCoilLevel mHeatingLevel = HeatingCoilLevel.None;
-    private int mHeatingCapacity=0;
 
     public GregtechMetaTileEntity_Adv_EBF(int aID, String aName, String aNameRegional) {
         super(aID, aName, aNameRegional);
@@ -157,9 +157,11 @@ public class GregtechMetaTileEntity_Adv_EBF extends GregtechMeta_MultiBlockBase<
         mCasing = 0;
         mPyrotheumHatches.clear();
         setCoilLevel(HeatingCoilLevel.None);
-
-        boolean isSuccess = checkPiece(mName, 1, 3, 0) && mCasing >= 8 && getCoilLevel() != HeatingCoilLevel.None && checkHatch();
-        if(isSuccess) this.mHeatingCapacity = (int) getCoilLevel().getHeat() + 100 * (GT_Utility.getTier(getMaxInputVoltage()) - 2);
+        boolean isSuccess = checkPiece(mName, 1, 3, 0) && mCasing >= 8
+                && getCoilLevel() != HeatingCoilLevel.None
+                && checkHatch();
+        if (isSuccess) this.mHeatingCapacity = (int) getCoilLevel().getHeat()
+                + 100 * (GT_Utility.getTier(getMaxInputVoltage()) - 2);
         return isSuccess;
     }
 
@@ -214,6 +216,7 @@ public class GregtechMetaTileEntity_Adv_EBF extends GregtechMeta_MultiBlockBase<
     protected IIconContainer getInactiveOverlay() {
         return TexturesGtBlock.Overlay_Machine_Controller_Advanced;
     }
+
     @Override
     protected int getCasingTextureId() {
         return CASING_TEXTURE_ID;

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/advanced/GregtechMetaTileEntity_Adv_EBF.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/advanced/GregtechMetaTileEntity_Adv_EBF.java
@@ -103,7 +103,7 @@ public class GregtechMetaTileEntity_Adv_EBF extends GregtechMeta_MultiBlockBase<
     public String[] getExtraInfoData() {
         return new String[] { StatCollector.translateToLocal("GT5U.EBF.heat") + ": "
                 + EnumChatFormatting.GREEN
-                + GT_Utility.formatNumbers(mHeatingLevel.getHeat())
+                + GT_Utility.formatNumbers(mHeatingCapacity)
                 + EnumChatFormatting.RESET
                 + " K" };
     }
@@ -214,7 +214,6 @@ public class GregtechMetaTileEntity_Adv_EBF extends GregtechMeta_MultiBlockBase<
     protected IIconContainer getInactiveOverlay() {
         return TexturesGtBlock.Overlay_Machine_Controller_Advanced;
     }
-
     @Override
     protected int getCasingTextureId() {
         return CASING_TEXTURE_ID;


### PR DESCRIPTION
As is well known, EBF has the feature of adjusting heat based on voltage, but Volcanus does not. This feature is generally not very useful, except here: UHV Superconductor. You need UHV Superconductor to make UHV Energy Hatch, which are required for crafting T8 rockets, obtaining the Awakened Dragon, and making Awakened Draconium Coils. The problem is that UHV Superconductors require Awakened Draconium Ingots to smelt. Therefore, you have to use a EBF (or you have a Electrum Flux Coil Mega EBF) to bypass this peculiar situation. Adding heat adjustment to Volcanus can avoid the need for this EBF, which is only needed to smelt a few UHV superconductor ingots then got dismantled.
![image](https://github.com/GTNewHorizons/GTplusplus/assets/31100241/d80d2dc9-a8c2-4440-9b8f-8be43293f50a)
