### PR TITLE
Add Alternative Recipe in LFTR Chain to Avoid Cells

### DIFF
--- a/src/main/java/gtPlusPlus/xmod/gregtech/loaders/recipe/RecipeLoader_NuclearFuelProcessing.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/loaders/recipe/RecipeLoader_NuclearFuelProcessing.java
@@ -213,6 +213,22 @@ public class RecipeLoader_NuclearFuelProcessing {
                 MaterialUtils.getVoltageForTier(5),
                 5400);
 
+        CORE.RA.addChemicalPlantRecipe(
+                new ItemStack[] { },
+                new FluidStack[] {
+                        FLUORIDES.URANIUM_HEXAFLUORIDE.getFluidStack(1000),
+                        NUCLIDE.LiFBeF2.getFluidStack(1000),
+                        ELEMENT.getInstance().HYDROGEN.getFluidStack(2000)
+                },
+                new ItemStack[] { },
+                new FluidStack[] {
+                        NUCLIDE.LiFBeF2UF4.getFluidStack(3000),
+                        FluidUtils.getFluidStack("hydrofluoricacid", 2000)
+                },
+                300 * 10,
+                MaterialUtils.getVoltageForTier(5),
+                4);
+
         // LiFBeF2ZrF4U235 - We can't add both ZrF4 and U235 here, so best we leave this disabled.
         /*
          * CORE.RA.addReactorProcessingUnitRecipe( CI.getNumberedAdvancedCircuit(8), NUCLIDE.LiFBeF2UF4.getCell(9),

--- a/src/main/java/gtPlusPlus/xmod/gregtech/loaders/recipe/RecipeLoader_NuclearFuelProcessing.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/loaders/recipe/RecipeLoader_NuclearFuelProcessing.java
@@ -212,7 +212,7 @@ public class RecipeLoader_NuclearFuelProcessing {
                 300 * 10,
                 MaterialUtils.getVoltageForTier(5),
                 5400);
-
+        // Alternative recipe to the above, for chemplant, to not use cells
         CORE.RA.addChemicalPlantRecipe(
                 new ItemStack[] { },
                 new FluidStack[] {

--- a/src/main/java/gtPlusPlus/xmod/gregtech/loaders/recipe/RecipeLoader_NuclearFuelProcessing.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/loaders/recipe/RecipeLoader_NuclearFuelProcessing.java
@@ -214,17 +214,12 @@ public class RecipeLoader_NuclearFuelProcessing {
                 5400);
         // Alternative recipe to the above, for chemplant, to not use cells
         CORE.RA.addChemicalPlantRecipe(
-                new ItemStack[] { },
-                new FluidStack[] {
-                        FLUORIDES.URANIUM_HEXAFLUORIDE.getFluidStack(1000),
-                        NUCLIDE.LiFBeF2.getFluidStack(1000),
-                        ELEMENT.getInstance().HYDROGEN.getFluidStack(2000)
-                },
-                new ItemStack[] { },
-                new FluidStack[] {
-                        NUCLIDE.LiFBeF2UF4.getFluidStack(3000),
-                        FluidUtils.getFluidStack("hydrofluoricacid", 2000)
-                },
+                new ItemStack[] {},
+                new FluidStack[] { FLUORIDES.URANIUM_HEXAFLUORIDE.getFluidStack(1000),
+                        NUCLIDE.LiFBeF2.getFluidStack(1000), ELEMENT.getInstance().HYDROGEN.getFluidStack(2000) },
+                new ItemStack[] {},
+                new FluidStack[] { NUCLIDE.LiFBeF2UF4.getFluidStack(3000),
+                        FluidUtils.getFluidStack("hydrofluoricacid", 2000) },
                 300 * 10,
                 MaterialUtils.getVoltageForTier(5),
                 4);


### PR DESCRIPTION
<details>
  <summary>Screenshots</summary>
  
![2023-09-22_01 01 05](https://github.com/GTNewHorizons/GTplusplus/assets/70096037/e7d31534-84a8-492e-a0fa-39416912540f)

![2023-09-22_01 01 10](https://github.com/GTNewHorizons/GTplusplus/assets/70096037/ef88eee3-a91a-4cfc-bd36-f949397e15b0)
  
</details>

See above for the screenshots of the relevant recipes.

The LFTR chain has an EBF recipe that handles multiple fluid inputs and outputs. However, as the EBF cannot normally handle so many fluids, most of them are in cells, which should not be present in IV+ automation. For that reason, I added an equivalent Chemical Plant recipe that uses no cells.
