### PR TITLE
Clean up BOP_block_Registrator and convert it to RA2

### DIFF
--- a/src/main/java/gtPlusPlus/xmod/bop/blocks/BOP_Block_Registrator.java
+++ b/src/main/java/gtPlusPlus/xmod/bop/blocks/BOP_Block_Registrator.java
@@ -120,12 +120,6 @@ public class BOP_Block_Registrator {
                     final ItemStack tPlanks = GT_Utility.copy(tStack);
                     tPlanks.stackSize = tPlanks.stackSize * 3 / 2;
                     GT_Values.RA.stdBuilder().itemInputs(new ItemStack(aStack.getItem(), 1, i))
-                            .fluidInputs(Materials.Lubricant.getFluid(1L))
-                            .itemOutputs(
-                                    GT_Utility.copy(tPlanks),
-                                    GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Wood, 1L))
-                            .duration(10 * SECONDS).eut(8).addTo(sCutterRecipes);
-                    GT_Values.RA.stdBuilder().itemInputs(new ItemStack(aStack.getItem(), 1, i))
                             .itemOutputs(
                                     GT_Utility.copyAmount(
                                             GT_Mod.gregtechproxy.mNerfedWoodPlank ? ((long) tStack.stackSize)
@@ -152,12 +146,6 @@ public class BOP_Block_Registrator {
             if (tStack2 != null) {
                 final ItemStack tPlanks2 = GT_Utility.copy(tStack2);
                 tPlanks2.stackSize = tPlanks2.stackSize * 3 / 2;
-                GT_Values.RA.stdBuilder().itemInputs(GT_Utility.copyAmount(1L, aStack))
-                        .fluidInputs(Materials.Lubricant.getFluid(1L))
-                        .itemOutputs(
-                                GT_Utility.copy(tPlanks2),
-                                GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Wood, 1L))
-                        .duration(10 * SECONDS).eut(8).addTo(sCutterRecipes);
                 GT_Values.RA.stdBuilder().itemInputs(GT_Utility.copyAmount(1L, aStack))
                         .itemOutputs(
                                 GT_Utility.copyAmount(

--- a/src/main/java/gtPlusPlus/xmod/bop/blocks/BOP_Block_Registrator.java
+++ b/src/main/java/gtPlusPlus/xmod/bop/blocks/BOP_Block_Registrator.java
@@ -1,5 +1,9 @@
 package gtPlusPlus.xmod.bop.blocks;
 
+import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sCutterRecipes;
+import static gregtech.api.util.GT_RecipeBuilder.SECONDS;
+import static gregtech.loaders.oreprocessing.ProcessingLog.addPyrolyeOvenRecipes;
+
 import net.minecraft.block.Block;
 import net.minecraft.init.Blocks;
 import net.minecraft.init.Items;
@@ -10,17 +14,13 @@ import gregtech.GT_Mod;
 import gregtech.api.GregTech_API;
 import gregtech.api.enums.ConfigCategories;
 import gregtech.api.enums.GT_Values;
-import gregtech.api.enums.ItemList;
 import gregtech.api.enums.Materials;
 import gregtech.api.enums.OrePrefixes;
 import gregtech.api.util.GT_ModHandler;
 import gregtech.api.util.GT_OreDictUnificator;
 import gregtech.api.util.GT_Utility;
-import gtPlusPlus.api.helpers.MaterialHelper;
-import gtPlusPlus.core.lib.CORE;
 import gtPlusPlus.core.recipe.common.CI;
 import gtPlusPlus.core.util.minecraft.ItemUtils;
-import gtPlusPlus.core.util.minecraft.MaterialUtils;
 import gtPlusPlus.core.util.minecraft.RecipeUtils;
 import gtPlusPlus.xmod.bop.blocks.pine.LeavesPineTree;
 import gtPlusPlus.xmod.bop.blocks.pine.LogPineTree;
@@ -39,41 +39,37 @@ public class BOP_Block_Registrator {
     public static Block sapling_Pine;
 
     // Runs Each tree Type separately
-    public static final void run() {
+    public static void run() {
         registerTree_Rainforest();
         registerTree_Pine();
     }
 
-    private static final boolean registerTree_Rainforest() {
+    private static void registerTree_Rainforest() {
         log_Rainforest = new LogRainforestTree();
         leaves_Rainforest = new LeavesRainforestTree();
         sapling_Rainforest = new SaplingRainforestTree();
         ItemUtils.addItemToOreDictionary(ItemUtils.getSimpleStack(log_Rainforest), "logWood", true);
         ItemUtils.addItemToOreDictionary(ItemUtils.getSimpleStack(leaves_Rainforest), "treeLeaves", true);
         ItemUtils.addItemToOreDictionary(ItemUtils.getSimpleStack(sapling_Rainforest), "treeSapling", true);
-        return true;
     }
 
-    private static final boolean registerTree_Pine() {
+    private static void registerTree_Pine() {
         log_Pine = new LogPineTree();
         leaves_Pine = new LeavesPineTree();
         sapling_Pine = new SaplingPineTree();
         ItemUtils.addItemToOreDictionary(ItemUtils.getSimpleStack(log_Pine), "logWood", true);
         ItemUtils.addItemToOreDictionary(ItemUtils.getSimpleStack(leaves_Pine), "treeLeaves", true);
         ItemUtils.addItemToOreDictionary(ItemUtils.getSimpleStack(sapling_Pine), "treeSapling", true);
-        return true;
     }
 
-    public static final void recipes() {
+    public static void recipes() {
         // Rainforest Oak
         addLogRecipes(ItemUtils.getSimpleStack(log_Rainforest));
-        addSaplingRecipes(ItemUtils.getSimpleStack(sapling_Rainforest));
         // Pine
         addLogRecipes(ItemUtils.getSimpleStack(log_Pine));
-        addSaplingRecipes(ItemUtils.getSimpleStack(sapling_Pine));
     }
 
-    public static final void addLogRecipes(final ItemStack aStack) {
+    public static void addLogRecipes(final ItemStack aStack) {
         RecipeUtils.addShapelessGregtechRecipe(
                 new ItemStack[] { aStack },
                 ItemUtils.getSimpleStack(
@@ -90,34 +86,21 @@ public class BOP_Block_Registrator {
                 null,
                 null,
                 ItemUtils.getSimpleStack(Item.getItemFromBlock(Blocks.planks), 4));
-        GT_ModHandler.addPulverisationRecipe(
-                GT_Utility.copyAmount(1L, aStack),
-                GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Wood, 6L),
-                GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Wood, 1L),
-                80,
-                false);
         GT_ModHandler.addCraftingRecipe(
                 GT_OreDictUnificator.get(OrePrefixes.stickLong, Materials.Wood, 2L),
                 GT_ModHandler.RecipeBits.DO_NOT_CHECK_FOR_COLLISIONS | GT_ModHandler.RecipeBits.BUFFERED,
                 new Object[] { "sLf", 'L', GT_Utility.copyAmount(1L, aStack) });
-        GT_Values.RA.addLatheRecipe(
-                GT_Utility.copyAmount(1L, aStack),
-                GT_OreDictUnificator.get(OrePrefixes.stickLong, Materials.Wood, 4L),
-                GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Wood, 2L),
-                160,
-                8);
 
         final short aMeta = (short) aStack.getItemDamage();
-        if (aMeta == 32767) {
-            if (GT_Utility.areStacksEqual(
-                    GT_ModHandler.getSmeltingOutput(GT_Utility.copyAmount(1L, aStack), false, null),
-                    new ItemStack(Items.coal, 1, 1))) {
-                addPyrolyeOvenRecipes(aStack);
-                if (GregTech_API.sRecipeFile
-                        .get(ConfigCategories.Recipes.disabledrecipes, "wood2charcoalsmelting", true)) {
-                    GT_ModHandler.removeFurnaceSmelting(GT_Utility.copyAmount(1L, aStack));
-                }
+        if (GT_Utility.areStacksEqual(
+                GT_ModHandler.getSmeltingOutput(GT_Utility.copyAmount(1L, aStack), false, null),
+                new ItemStack(Items.coal, 1, 1))) {
+            addPyrolyeOvenRecipes(aStack);
+            if (GregTech_API.sRecipeFile.get(ConfigCategories.Recipes.disabledrecipes, "wood2charcoalsmelting", true)) {
+                GT_ModHandler.removeFurnaceSmelting(GT_Utility.copyAmount(1L, aStack));
             }
+        }
+        if (aMeta == 32767) {
             for (int i = 0; i < 32767; ++i) {
                 if (GT_Utility.areStacksEqual(
                         GT_ModHandler.getSmeltingOutput(new ItemStack(aStack.getItem(), 1, i), false, null),
@@ -136,31 +119,25 @@ public class BOP_Block_Registrator {
                 } else {
                     final ItemStack tPlanks = GT_Utility.copy(tStack);
                     tPlanks.stackSize = tPlanks.stackSize * 3 / 2;
-                    GT_Values.RA.addCutterRecipe(
-                            new ItemStack(aStack.getItem(), 1, i),
-                            Materials.Lubricant.getFluid(1L),
-                            GT_Utility.copy(tPlanks),
-                            GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Wood, 1L),
-                            200,
-                            8);
-                    GT_Values.RA.addCutterRecipe(
-                            new ItemStack(aStack.getItem(), 1, i),
-                            GT_Utility.copyAmount(
-                                    GT_Mod.gregtechproxy.mNerfedWoodPlank ? ((long) tStack.stackSize)
-                                            : ((long) (tStack.stackSize * 5 / 4)),
-                                    tStack),
-                            GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Wood, 2L),
-                            200,
-                            8);
-                    GT_ModHandler.addSawmillRecipe(
-                            new ItemStack(aStack.getItem(), 1, i),
-                            tPlanks,
-                            GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Wood, 1L));
+                    GT_Values.RA.stdBuilder().itemInputs(new ItemStack(aStack.getItem(), 1, i))
+                            .fluidInputs(Materials.Lubricant.getFluid(1L))
+                            .itemOutputs(
+                                    GT_Utility.copy(tPlanks),
+                                    GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Wood, 1L))
+                            .duration(10 * SECONDS).eut(8).addTo(sCutterRecipes);
+                    GT_Values.RA.stdBuilder().itemInputs(new ItemStack(aStack.getItem(), 1, i))
+                            .itemOutputs(
+                                    GT_Utility.copyAmount(
+                                            GT_Mod.gregtechproxy.mNerfedWoodPlank ? ((long) tStack.stackSize)
+                                                    : (((long) tStack.stackSize) * 5L / 4),
+                                            tStack),
+                                    GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Wood, 2L))
+                            .duration(10 * SECONDS).eut(8).addTo(sCutterRecipes);
                     GT_ModHandler.removeRecipe(new ItemStack(aStack.getItem(), 1, i));
                     GT_ModHandler.addCraftingRecipe(
                             GT_Utility.copyAmount(
                                     GT_Mod.gregtechproxy.mNerfedWoodPlank ? ((long) tStack.stackSize)
-                                            : ((long) (tStack.stackSize * 5 / 4)),
+                                            : (((long) tStack.stackSize) * 5L / 4),
                                     tStack),
                             new Object[] { "s", "L", 'L', new ItemStack(aStack.getItem(), 1, i) });
                     GT_ModHandler.addShapelessCraftingRecipe(
@@ -171,44 +148,29 @@ public class BOP_Block_Registrator {
                 }
             }
         } else {
-            if (GT_Utility.areStacksEqual(
-                    GT_ModHandler.getSmeltingOutput(GT_Utility.copyAmount(1L, aStack), false, null),
-                    new ItemStack(Items.coal, 1, 1))) {
-                addPyrolyeOvenRecipes(aStack);
-                if (GregTech_API.sRecipeFile
-                        .get(ConfigCategories.Recipes.disabledrecipes, "wood2charcoalsmelting", true)) {
-                    GT_ModHandler.removeFurnaceSmelting(GT_Utility.copyAmount(1L, aStack));
-                }
-            }
             final ItemStack tStack2 = GT_ModHandler.getRecipeOutput(GT_Utility.copyAmount(1L, aStack));
             if (tStack2 != null) {
                 final ItemStack tPlanks2 = GT_Utility.copy(tStack2);
                 tPlanks2.stackSize = tPlanks2.stackSize * 3 / 2;
-                GT_Values.RA.addCutterRecipe(
-                        GT_Utility.copyAmount(1L, aStack),
-                        Materials.Lubricant.getFluid(1L),
-                        GT_Utility.copy(tPlanks2),
-                        GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Wood, 1L),
-                        200,
-                        8);
-                GT_Values.RA.addCutterRecipe(
-                        GT_Utility.copyAmount(1L, aStack),
-                        GT_Utility.copyAmount(
-                                GT_Mod.gregtechproxy.mNerfedWoodPlank ? ((long) tStack2.stackSize)
-                                        : ((long) (tStack2.stackSize * 5 / 4)),
-                                tStack2),
-                        GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Wood, 2L),
-                        200,
-                        8);
-                GT_ModHandler.addSawmillRecipe(
-                        GT_Utility.copyAmount(1L, aStack),
-                        tPlanks2,
-                        GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Wood, 1L));
+                GT_Values.RA.stdBuilder().itemInputs(GT_Utility.copyAmount(1L, aStack))
+                        .fluidInputs(Materials.Lubricant.getFluid(1L))
+                        .itemOutputs(
+                                GT_Utility.copy(tPlanks2),
+                                GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Wood, 1L))
+                        .duration(10 * SECONDS).eut(8).addTo(sCutterRecipes);
+                GT_Values.RA.stdBuilder().itemInputs(GT_Utility.copyAmount(1L, aStack))
+                        .itemOutputs(
+                                GT_Utility.copyAmount(
+                                        GT_Mod.gregtechproxy.mNerfedWoodPlank ? ((long) tStack2.stackSize)
+                                                : (((long) tStack2.stackSize) * 5L / 4),
+                                        tStack2),
+                                GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Wood, 2L))
+                        .duration(10 * SECONDS).eut(8).addTo(sCutterRecipes);
                 GT_ModHandler.removeRecipe(GT_Utility.copyAmount(1L, aStack));
                 GT_ModHandler.addCraftingRecipe(
                         GT_Utility.copyAmount(
                                 GT_Mod.gregtechproxy.mNerfedWoodPlank ? ((long) tStack2.stackSize)
-                                        : ((long) (tStack2.stackSize * 5 / 4)),
+                                        : (((long) tStack2.stackSize) * 5L / 4),
                                 tStack2),
                         new Object[] { "s", "L", 'L', GT_Utility.copyAmount(1L, aStack) });
                 GT_ModHandler.addShapelessCraftingRecipe(
@@ -225,132 +187,6 @@ public class BOP_Block_Registrator {
             if (GregTech_API.sRecipeFile.get(ConfigCategories.Recipes.disabledrecipes, "wood2charcoalsmelting", true)) {
                 GT_ModHandler.removeFurnaceSmelting(GT_Utility.copyAmount(1L, aStack));
             }
-        }
-    }
-
-    public static void addSaplingRecipes(final ItemStack aStack) {
-        GT_ModHandler.addPulverisationRecipe(
-                GT_Utility.copyAmount(1L, aStack),
-                GT_OreDictUnificator.get(OrePrefixes.dustSmall, Materials.Wood, 2L),
-                null,
-                0,
-                false);
-        GT_ModHandler
-                .addCompressionRecipe(GT_Utility.copyAmount(8L, aStack), ItemList.IC2_Plantball.get(1L, new Object[0]));
-        GT_Values.RA.addLatheRecipe(
-                GT_Utility.copyAmount(1L, aStack),
-                GT_OreDictUnificator.get(OrePrefixes.stick, Materials.Wood, 1L),
-                GT_OreDictUnificator.get(OrePrefixes.dustTiny, Materials.Wood, 1L),
-                16,
-                8);
-    }
-
-    public static void addPyrolyeOvenRecipes(final ItemStack logStack) {
-
-        Materials aOilHeavy = MaterialUtils.getMaterial("OilHeavy");
-        Materials aCharcoalByproducts = MaterialUtils.getMaterial("CharcoalByproducts");
-        Materials aWoodGas = MaterialUtils.getMaterial("WoodGas");
-        Materials aWoodVinegar = MaterialUtils.getMaterial("WoodVinegar");
-        Materials aWoodTar = MaterialUtils.getMaterial("WoodTar");
-
-        CORE.RA.addPyrolyseRecipe(
-                GT_Utility.copyAmount(16L, logStack),
-                GT_Values.NF,
-                1,
-                MaterialHelper.getGems(Materials.Charcoal, 20),
-                Materials.Creosote.getFluid(4000L),
-                640,
-                64);
-        CORE.RA.addPyrolyseRecipe(
-                GT_Utility.copyAmount(16L, logStack),
-                Materials.Nitrogen.getGas(1000L),
-                2,
-                MaterialHelper.getGems(Materials.Charcoal, 20),
-                Materials.Creosote.getFluid(4000L),
-                320,
-                96);
-
-        if (aOilHeavy != null) {
-            CORE.RA.addPyrolyseRecipe(
-                    GT_Utility.copyAmount(16L, logStack),
-                    GT_Values.NF,
-                    3,
-                    MaterialHelper.getDust(Materials.Ash, 4),
-                    aOilHeavy.getFluid(200L),
-                    320,
-                    192);
-        }
-        if (aCharcoalByproducts != null) {
-            CORE.RA.addPyrolyseRecipe(
-                    GT_Utility.copyAmount(16L, logStack),
-                    GT_Values.NF,
-                    3,
-                    MaterialHelper.getGems(Materials.Charcoal, 20),
-                    aCharcoalByproducts.getGas(4000L),
-                    640,
-                    64);
-            CORE.RA.addPyrolyseRecipe(
-                    GT_Utility.copyAmount(16L, logStack),
-                    Materials.Nitrogen.getGas(1000L),
-                    4,
-                    MaterialHelper.getGems(Materials.Charcoal, 20),
-                    aCharcoalByproducts.getGas(4000L),
-                    320,
-                    96);
-        }
-        if (aWoodGas != null) {
-            CORE.RA.addPyrolyseRecipe(
-                    GT_Utility.copyAmount(16L, logStack),
-                    GT_Values.NF,
-                    5,
-                    MaterialHelper.getGems(Materials.Charcoal, 20),
-                    aWoodGas.getGas(1500L),
-                    640,
-                    64);
-            CORE.RA.addPyrolyseRecipe(
-                    GT_Utility.copyAmount(16L, logStack),
-                    Materials.Nitrogen.getGas(1000L),
-                    6,
-                    MaterialHelper.getGems(Materials.Charcoal, 20),
-                    aWoodGas.getGas(1500L),
-                    320,
-                    96);
-        }
-        if (aWoodVinegar != null) {
-            CORE.RA.addPyrolyseRecipe(
-                    GT_Utility.copyAmount(16L, logStack),
-                    GT_Values.NF,
-                    7,
-                    MaterialHelper.getGems(Materials.Charcoal, 20),
-                    aWoodVinegar.getFluid(3000L),
-                    640,
-                    64);
-            CORE.RA.addPyrolyseRecipe(
-                    GT_Utility.copyAmount(16L, logStack),
-                    Materials.Nitrogen.getGas(1000L),
-                    8,
-                    MaterialHelper.getGems(Materials.Charcoal, 20),
-                    aWoodVinegar.getFluid(3000L),
-                    320,
-                    96);
-        }
-        if (aWoodTar != null) {
-            CORE.RA.addPyrolyseRecipe(
-                    GT_Utility.copyAmount(16L, logStack),
-                    GT_Values.NF,
-                    9,
-                    MaterialHelper.getGems(Materials.Charcoal, 20),
-                    aWoodTar.getFluid(1500L),
-                    640,
-                    64);
-            CORE.RA.addPyrolyseRecipe(
-                    GT_Utility.copyAmount(16L, logStack),
-                    Materials.Nitrogen.getGas(1000L),
-                    10,
-                    MaterialHelper.getGems(Materials.Charcoal, 20),
-                    aWoodTar.getFluid(1500L),
-                    320,
-                    96);
         }
     }
 }


### PR DESCRIPTION
Just a small cleanup with RA2 conversion.

- converted recipes to RA2
- removed duplicate sapling recipes (all are added by GT too)
- removed duplicate Pulverisation and Lathe recipes (all are added by GT too)
- removed unused themal expansion sawmill compat
- use proper GT method for Pyrolyse Oven recipes (instead of an outdated copied over variant with wrong circuits)
- some minor code cleanup