### PR TITLE
fix catalyst recipes

### DIFF
--- a/src/main/java/gtPlusPlus/core/item/chemistry/GenericChem.java
+++ b/src/main/java/gtPlusPlus/core/item/chemistry/GenericChem.java
@@ -625,8 +625,8 @@ public class GenericChem extends ItemPackage {
                         CI.getEmptyCatalyst(10),
                         GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Platinum, 4L),
                         ELEMENT.getInstance().RHODIUM.getDust(4))
-                .itemOutputs(ItemUtils.getSimpleStack(mFormaldehydeCatalyst, 4)).duration(30 * SECONDS)
-                .eut(TierEU.RECIPE_HV / 2).addTo(sAssemblerRecipes);
+                .itemOutputs(ItemUtils.getSimpleStack(mPinkCatalyst, 10)).duration(30 * SECONDS).eut(TierEU.RECIPE_EV)
+                .addTo(sAssemblerRecipes);
     }
 
     private void recipeCatalystFormaldehyde() {
@@ -636,8 +636,8 @@ public class GenericChem extends ItemPackage {
                         getTierThreeChip(),
                         CI.getEmptyCatalyst(4),
                         ItemUtils.getSimpleStack(RocketFuels.Formaldehyde_Catalyst_Dust, 8))
-                .itemOutputs(ItemUtils.getSimpleStack(mBrownCatalyst, 10)).duration(15 * SECONDS).eut(TierEU.RECIPE_LV)
-                .addTo(sAssemblerRecipes);
+                .itemOutputs(ItemUtils.getSimpleStack(mFormaldehydeCatalyst, 4)).duration(30 * SECONDS)
+                .eut(TierEU.RECIPE_HV / 2).addTo(sAssemblerRecipes);
     }
 
     private void recipeCatalystSolidAcid() {


### PR DESCRIPTION
Some code of formaldehyde catalysts and pink catalyst was mixed up in the RA2 conversion. now all fixed to the old numbers. Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/14724

![image](https://github.com/GTNewHorizons/GTplusplus/assets/40274384/a5fd023c-aab8-4dd7-83e4-5f7d5ce80761)
![image](https://github.com/GTNewHorizons/GTplusplus/assets/40274384/7a3b3edf-5c63-49a5-a2f2-1628d4d41499)

