### PR TITLE
Remove ruthenium roasting

### DIFF
--- a/src/main/java/gtPlusPlus/core/recipe/RECIPES_GREGTECH.java
+++ b/src/main/java/gtPlusPlus/core/recipe/RECIPES_GREGTECH.java
@@ -658,44 +658,6 @@ public class RECIPES_GREGTECH {
                 20 * 300,
                 4000);
 
-        // Ruthenium Roasting
-        CORE.RA.addBlastSmelterRecipe(
-                new ItemStack[] { ItemUtils.getGregtechCircuit(19),
-                        ItemUtils.getItemStackOfAmountFromOreDict("crushedPurifiedIridium", 8),
-                        ELEMENT.getInstance().CARBON.getDust(32), },
-                Materials.SulfuricAcid.getFluid(2000),
-                ELEMENT.getInstance().RUTHENIUM.getFluidStack(288),
-                0,
-                20 * 300,
-                8000);
-        CORE.RA.addBlastSmelterRecipe(
-                new ItemStack[] { ItemUtils.getGregtechCircuit(19),
-                        ItemUtils.getItemStackOfAmountFromOreDict("crushedPurifiedOsmium", 8),
-                        ELEMENT.getInstance().CARBON.getDust(32), },
-                Materials.SulfuricAcid.getFluid(2000),
-                ELEMENT.getInstance().RUTHENIUM.getFluidStack(288),
-                0,
-                20 * 300,
-                8000);
-        CORE.RA.addBlastSmelterRecipe(
-                new ItemStack[] { ItemUtils.getGregtechCircuit(19),
-                        ItemUtils.getItemStackOfAmountFromOreDict("crushedPurifiedPlatinum", 8),
-                        ELEMENT.getInstance().CARBON.getDust(32), },
-                Materials.SulfuricAcid.getFluid(2000),
-                ELEMENT.getInstance().RUTHENIUM.getFluidStack(288),
-                0,
-                20 * 300,
-                8000);
-        CORE.RA.addBlastSmelterRecipe(
-                new ItemStack[] { ItemUtils.getGregtechCircuit(19),
-                        ItemUtils.getItemStackOfAmountFromOreDict("crushedPurifiedCooperite", 8),
-                        ELEMENT.getInstance().CARBON.getDust(32), },
-                Materials.SulfuricAcid.getFluid(8000),
-                ELEMENT.getInstance().RUTHENIUM.getFluidStack(144),
-                0,
-                20 * 300,
-                8000);
-
         // Rhenium Roasting
         CORE.RA.addBlastSmelterRecipe(
                 new ItemStack[] { ItemUtils.getGregtechCircuit(20),


### PR DESCRIPTION
Remove ruthenium roasting recipes as we use platline instead.

They are not even in the game. Currently they are removed at gamestart by BW, but just not having them in the first place is better and gives us more flexiblity for https://github.com/GTNewHorizons/bartworks/pull/368 and https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/14867.