### PR TITLE
Reduce minimum casing requirement for various machines

### DIFF
--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/GregtechMetaTileEntity_IndustrialArcFurnace.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/GregtechMetaTileEntity_IndustrialArcFurnace.java
@@ -76,7 +76,7 @@ public class GregtechMetaTileEntity_IndustrialArcFurnace extends
                 .addInfo("Right-click controller with a Screwdriver to change modes")
                 .addInfo("Max Size required to process Plasma recipes").addPollutionAmount(getPollutionPerSecond(null))
                 .addSeparator().addController("Top center").addStructureInfo("Size: nxnx3 [WxHxL] (Hollow)")
-                .addStructureInfo("n can be 3, 5 or 7").addCasingInfoMin(mCasingName, 10, false)
+                .addStructureInfo("n can be 3, 5 or 7").addCasingInfoMin(mCasingName, 6, false)
                 .addInputBus("Any Casing", 1).addOutputBus("Any Casing", 1).addInputHatch("Any Casing", 1)
                 .addOutputHatch("Any Casing", 1).addEnergyHatch("Any Casing", 1).addMaintenanceHatch("Any Casing", 1)
                 .addMufflerHatch("Any Casing", 1).toolTipFinisher(CORE.GT_Tooltip_Builder.get());
@@ -147,17 +147,17 @@ public class GregtechMetaTileEntity_IndustrialArcFurnace extends
         mSize = 0;
         if (checkPiece(mName + "3", 1, 1, 0)) {
             mSize = 3;
-            return mCasing >= 10 && checkHatch();
+            return mCasing >= 6 && checkHatch();
         }
         mCasing = 0;
         if (checkPiece(mName + "5", 2, 2, 0)) {
             mSize = 5;
-            return mCasing >= 10 && checkHatch();
+            return mCasing >= 6 && checkHatch();
         }
         mCasing = 0;
         if (checkPiece(mName + "7", 3, 3, 0)) {
             mSize = 7;
-            return mCasing >= 10 && checkHatch();
+            return mCasing >= 6 && checkHatch();
         }
         return false;
     }

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/GregtechMetaTileEntity_IndustrialArcFurnace.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/GregtechMetaTileEntity_IndustrialArcFurnace.java
@@ -76,7 +76,7 @@ public class GregtechMetaTileEntity_IndustrialArcFurnace extends
                 .addInfo("Right-click controller with a Screwdriver to change modes")
                 .addInfo("Max Size required to process Plasma recipes").addPollutionAmount(getPollutionPerSecond(null))
                 .addSeparator().addController("Top center").addStructureInfo("Size: nxnx3 [WxHxL] (Hollow)")
-                .addStructureInfo("n can be 3, 5 or 7").addCasingInfoMin(mCasingName, 6, false)
+                .addStructureInfo("n can be 3, 5 or 7").addCasingInfoMin(mCasingName, 10, false)
                 .addInputBus("Any Casing", 1).addOutputBus("Any Casing", 1).addInputHatch("Any Casing", 1)
                 .addOutputHatch("Any Casing", 1).addEnergyHatch("Any Casing", 1).addMaintenanceHatch("Any Casing", 1)
                 .addMufflerHatch("Any Casing", 1).toolTipFinisher(CORE.GT_Tooltip_Builder.get());
@@ -147,17 +147,17 @@ public class GregtechMetaTileEntity_IndustrialArcFurnace extends
         mSize = 0;
         if (checkPiece(mName + "3", 1, 1, 0)) {
             mSize = 3;
-            return mCasing >= 6 && checkHatch();
+            return mCasing >= 10 && checkHatch();
         }
         mCasing = 0;
         if (checkPiece(mName + "5", 2, 2, 0)) {
             mSize = 5;
-            return mCasing >= 6 && checkHatch();
+            return mCasing >= 10 && checkHatch();
         }
         mCasing = 0;
         if (checkPiece(mName + "7", 3, 3, 0)) {
             mSize = 7;
-            return mCasing >= 6 && checkHatch();
+            return mCasing >= 10 && checkHatch();
         }
         return false;
     }

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/GregtechMetaTileEntity_IndustrialCentrifuge.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/GregtechMetaTileEntity_IndustrialCentrifuge.java
@@ -77,7 +77,7 @@ public class GregtechMetaTileEntity_IndustrialCentrifuge extends
                 .addInfo("Disable animations with a screwdriver").addInfo("Only uses 90% of the EU/t normally required")
                 .addInfo("Processes six items per voltage tier").addPollutionAmount(getPollutionPerSecond(null))
                 .addSeparator().beginStructureBlock(3, 3, 3, true).addController("Front Center")
-                .addCasingInfoMin("Centrifuge Casings", 10, false).addInputBus("Any Casing", 1)
+                .addCasingInfoMin("Centrifuge Casings", 6, false).addInputBus("Any Casing", 1)
                 .addOutputBus("Any Casing", 1).addInputHatch("Any Casing", 1).addOutputHatch("Any Casing", 1)
                 .addEnergyHatch("Any Casing", 1).addMaintenanceHatch("Any Casing", 1).addMufflerHatch("Any Casing", 1)
                 .toolTipFinisher(CORE.GT_Tooltip_Builder.get());
@@ -118,7 +118,7 @@ public class GregtechMetaTileEntity_IndustrialCentrifuge extends
     @Override
     public boolean checkMachine(IGregTechTileEntity aBaseMetaTileEntity, ItemStack aStack) {
         mCasing = 0;
-        return checkPiece(mName, 1, 1, 0) && mCasing >= 10 && checkHatch();
+        return checkPiece(mName, 1, 1, 0) && mCasing >= 6 && checkHatch();
     }
 
     @Override

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/GregtechMetaTileEntity_IndustrialChisel.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/GregtechMetaTileEntity_IndustrialChisel.java
@@ -81,7 +81,7 @@ public class GregtechMetaTileEntity_IndustrialChisel
                 .addInfo("If no target is provided for common buses, the result of the first chisel is used")
                 .addInfo("Speed: +200% | EU Usage: 75% | Parallel: Tier x 16")
                 .addPollutionAmount(getPollutionPerSecond(null)).addSeparator().beginStructureBlock(3, 3, 3, true)
-                .addController("Front center").addCasingInfoMin("Sturdy Printer Casing", 10, false)
+                .addController("Front center").addCasingInfoMin("Sturdy Printer Casing", 6, false)
                 .addInputBus("Any casing", 1).addOutputBus("Any casing", 1).addEnergyHatch("Any casing", 1)
                 .addMaintenanceHatch("Any casing", 1).addMufflerHatch("Any casing", 1)
                 .toolTipFinisher(CORE.GT_Tooltip_Builder.get());
@@ -127,7 +127,7 @@ public class GregtechMetaTileEntity_IndustrialChisel
     @Override
     public boolean checkMachine(IGregTechTileEntity aBaseMetaTileEntity, ItemStack aStack) {
         mCasing = 0;
-        return checkPiece(mName, 1, 1, 0) && mCasing >= 10 && checkHatch();
+        return checkPiece(mName, 1, 1, 0) && mCasing >= 6 && checkHatch();
     }
 
     @Override

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/GregtechMetaTileEntity_IndustrialCuttingMachine.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/GregtechMetaTileEntity_IndustrialCuttingMachine.java
@@ -69,7 +69,7 @@ public class GregtechMetaTileEntity_IndustrialCuttingMachine extends
                 .addInfo("200% faster than using single block machines of the same voltage")
                 .addInfo("Only uses 75% of the EU/t normally required").addInfo("Processes four items per voltage tier")
                 .addPollutionAmount(getPollutionPerSecond(null)).addSeparator().beginStructureBlock(3, 3, 5, true)
-                .addController("Front Center").addCasingInfoMin("Cutting Factory Frames", 26, false)
+                .addController("Front Center").addCasingInfoMin("Cutting Factory Frames", 14, false)
                 .addInputBus("Any Casing", 1).addOutputBus("Any Casing", 1).addInputHatch("Any Casing", 1)
                 .addEnergyHatch("Any Casing", 1).addMaintenanceHatch("Any Casing", 1).addMufflerHatch("Any Casing", 1)
                 .toolTipFinisher(CORE.GT_Tooltip_Builder.get());
@@ -111,7 +111,7 @@ public class GregtechMetaTileEntity_IndustrialCuttingMachine extends
     @Override
     public boolean checkMachine(IGregTechTileEntity aBaseMetaTileEntity, ItemStack aStack) {
         mCasing = 0;
-        return checkPiece(mName, 1, 1, 0) && mCasing >= 26 && checkHatch();
+        return checkPiece(mName, 1, 1, 0) && mCasing >= 14 && checkHatch();
     }
 
     @Override

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/GregtechMetaTileEntity_IndustrialElectrolyzer.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/GregtechMetaTileEntity_IndustrialElectrolyzer.java
@@ -64,7 +64,7 @@ public class GregtechMetaTileEntity_IndustrialElectrolyzer extends
                 .addInfo("180% faster than using single block machines of the same voltage")
                 .addInfo("Only uses 90% of the EU/t normally required").addInfo("Processes two items per voltage tier")
                 .addPollutionAmount(getPollutionPerSecond(null)).addSeparator().beginStructureBlock(3, 3, 3, true)
-                .addController("Front Center").addCasingInfoMin("Electrolyzer Casings", 10, false)
+                .addController("Front Center").addCasingInfoMin("Electrolyzer Casings", 6, false)
                 .addInputBus("Any Casing", 1).addOutputBus("Any Casing", 1).addInputHatch("Any Casing", 1)
                 .addOutputHatch("Any Casing", 1).addEnergyHatch("Any Casing", 1).addMaintenanceHatch("Any Casing", 1)
                 .addMufflerHatch("Any Casing", 1).toolTipFinisher(CORE.GT_Tooltip_Builder.get());
@@ -105,7 +105,7 @@ public class GregtechMetaTileEntity_IndustrialElectrolyzer extends
     @Override
     public boolean checkMachine(IGregTechTileEntity aBaseMetaTileEntity, ItemStack aStack) {
         mCasing = 0;
-        return checkPiece(mName, 1, 1, 0) && mCasing >= 10 && checkHatch();
+        return checkPiece(mName, 1, 1, 0) && mCasing >= 6 && checkHatch();
     }
 
     @Override

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/GregtechMetaTileEntity_IndustrialForgeHammer.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/GregtechMetaTileEntity_IndustrialForgeHammer.java
@@ -92,7 +92,7 @@ public class GregtechMetaTileEntity_IndustrialForgeHammer extends
         }
 
         tt.addPollutionAmount(getPollutionPerSecond(null)).addSeparator().beginStructureBlock(3, 3, 3, true)
-                .addController("Front Center").addCasingInfoMin("Forge Casing", 10, false).addInputBus("Any Casing", 1)
+                .addController("Front Center").addCasingInfoMin("Forge Casing", 6, false).addInputBus("Any Casing", 1)
                 .addOutputBus("Any Casing", 1).addInputHatch("Any Casing", 1).addOutputHatch("Any Casing", 1)
                 .addEnergyHatch("Any Casing", 1).addMaintenanceHatch("Any Casing", 1).addMufflerHatch("Any Casing", 1)
                 .addOtherStructurePart("Anvil", "In the center of 3x3x3 structure", 2)
@@ -167,7 +167,7 @@ public class GregtechMetaTileEntity_IndustrialForgeHammer extends
     @Override
     public boolean checkMachine(IGregTechTileEntity aBaseMetaTileEntity, ItemStack aStack) {
         mCasing = 0;
-        return checkPiece(mName, 1, 1, 0) && mCasing >= 10 && checkHatch();
+        return checkPiece(mName, 1, 1, 0) && mCasing >= 6 && checkHatch();
     }
 
     @Override

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/GregtechMetaTileEntity_IndustrialPlatePress.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/GregtechMetaTileEntity_IndustrialPlatePress.java
@@ -67,7 +67,7 @@ public class GregtechMetaTileEntity_IndustrialPlatePress extends
                 .addInfo("Processes four items per voltage tier").addInfo("Circuit for recipe goes in the Input Bus")
                 .addInfo("Each Input Bus can have a different Circuit/Shape!")
                 .addPollutionAmount(getPollutionPerSecond(null)).addSeparator().beginStructureBlock(3, 3, 3, true)
-                .addController("Front Center").addCasingInfoMin("Material Press Machine Casings", 10, false)
+                .addController("Front Center").addCasingInfoMin("Material Press Machine Casings", 6, false)
                 .addInputBus("Any Casing", 1).addOutputBus("Any Casing", 1).addEnergyHatch("Any Casing", 1)
                 .addMaintenanceHatch("Any Casing", 1).addMufflerHatch("Any Casing", 1)
                 .toolTipFinisher(CORE.GT_Tooltip_Builder.get());
@@ -108,7 +108,7 @@ public class GregtechMetaTileEntity_IndustrialPlatePress extends
     @Override
     public boolean checkMachine(IGregTechTileEntity aBaseMetaTileEntity, ItemStack aStack) {
         mCasing = 0;
-        return checkPiece(mName, 1, 1, 0) && mCasing >= 10 && checkHatch();
+        return checkPiece(mName, 1, 1, 0) && mCasing >= 6 && checkHatch();
     }
 
     @Override

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/GregtechMetaTileEntity_IndustrialWireMill.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/GregtechMetaTileEntity_IndustrialWireMill.java
@@ -69,7 +69,7 @@ public class GregtechMetaTileEntity_IndustrialWireMill extends
                 .addInfo("200% faster than using single block machines of the same voltage")
                 .addInfo("Only uses 75% of the EU/t normally required").addInfo("Processes four items per voltage tier")
                 .addPollutionAmount(getPollutionPerSecond(null)).addSeparator().beginStructureBlock(3, 3, 5, true)
-                .addController("Front Center").addCasingInfoMin("Wire Factory Casings", 20, false)
+                .addController("Front Center").addCasingInfoMin("Wire Factory Casings", 14, false)
                 .addInputBus("Any Casing", 1).addOutputBus("Any Casing", 1).addEnergyHatch("Any Casing", 1)
                 .addMaintenanceHatch("Any Casing", 1).addMufflerHatch("Any Casing", 1)
                 .toolTipFinisher(CORE.GT_Tooltip_Builder.get());
@@ -111,7 +111,7 @@ public class GregtechMetaTileEntity_IndustrialWireMill extends
     @Override
     public boolean checkMachine(IGregTechTileEntity aBaseMetaTileEntity, ItemStack aStack) {
         mCasing = 0;
-        return checkPiece(mName, 1, 1, 0) && mCasing >= 20 && checkHatch();
+        return checkPiece(mName, 1, 1, 0) && mCasing >= 14 && checkHatch();
     }
 
     @Override


### PR DESCRIPTION
This pull request reduces the min casing amount of various machine to make it consistent with other multiblocks of equal size. As a baseline the multi with the least amount of hatches has been used. 

**3x3x3:**
LPF 6 -> 6 (unchanged and baseline)
Industrial Material Press 10 -> 6
Industrial Sledgehammer 10 -> 6
Industrial Electrolyzer 10 -> 6
Industrial Centrifuge 10 -> 6
Industrial Arc Furnace 10 -> 6

**3x3x5**
Industrial Extrusion machine 14 -> 14 (unchanged and baseline)
Wire Factory 20 -> 14
Cutting Factory 26 -> 14

### Why
With the current amount of different components needed its mostly just an annoyance to have a high requirement of casings as you are limited by how many different hatches you can use (especially relevant with cribs). The casing themselves are also not expensive either. Multis like the Industrial Material Press suffer greatly from that as it is used quite a lot. In my opinion it would make sense that multis that are equal in size (not counting any special blocks or coils) have the same min casing requirement.
