### PR TITLE
add back coke oven recipes again

### DIFF
--- a/src/main/java/gtPlusPlus/xmod/gregtech/HANDLER_GT.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/HANDLER_GT.java
@@ -79,6 +79,9 @@ public class HANDLER_GT {
         new ProcessingAngleGrinder().run();
         new ProcessingElectricSnips().run();
 
+        // Add recipes
+        CokeAndPyrolyseOven.postInit();
+
         // Register custom singles to the PA
         AddCustomMachineToPA.register();
 


### PR DESCRIPTION
fix https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/14934

*someone* moved the code off where it was, but unfortunately forget to call the new initializer