### PR TITLE
remove traceback from PlayerCache.dat

### DIFF
--- a/src/main/java/gtPlusPlus/core/util/player/PlayerCache.java
+++ b/src/main/java/gtPlusPlus/core/util/player/PlayerCache.java
@@ -19,17 +19,13 @@ public class PlayerCache {
 
     public static void initCache() {
         if (CORE.PlayerCache == null) {
-            try {
-
-                if (cache != null) {
-                    CORE.PlayerCache = PlayerCache.readPropertiesFileAsMap();
-                    Logger.INFO("Loaded PlayerCache.dat");
-                }
-
-            } catch (final Exception e) {
-                Logger.INFO("Failed to initialise PlayerCache.dat");
+            if (cache.exists()) {
+                CORE.PlayerCache = PlayerCache.readPropertiesFileAsMap();
+                Logger.INFO("Loaded PlayerCache.dat");
+            }
+            if (CORE.PlayerCache == null) {
+                Logger.INFO("Failed to load PlayerCache.dat");
                 PlayerCache.createPropertiesFile("PLAYER_", "DATA");
-                // e.printStackTrace();
             }
         }
     }


### PR DESCRIPTION
This removes a traceback during startup when PlayerCache.dat doesn't exist, and then creates it (apparently what the code was designed to do using `try/catch`)

However, the code runs at a time when I'm not sure it could get a Player UUID anyway (startup? common?) and it then doesn't store anything but "DATA" anyway.

Someone who knows something may recommend I just yeet the whole thing entire.