### PR TITLE
Generate Germanium fully again

### DIFF
--- a/src/main/java/gtPlusPlus/core/item/ModItems.java
+++ b/src/main/java/gtPlusPlus/core/item/ModItems.java
@@ -300,6 +300,7 @@ public final class ModItems {
             MaterialGenerator.generate(ELEMENT.getInstance().RHODIUM);
             MaterialGenerator.generate(ELEMENT.getInstance().RHENIUM);
             MaterialGenerator.generate(ELEMENT.getInstance().THALLIUM);
+            MaterialGenerator.generate(ELEMENT.getInstance().GERMANIUM);
 
             // RADIOACTIVE ELEMENTS
             MaterialGenerator.generateNuclearMaterial(ELEMENT.getInstance().POLONIUM, false);
@@ -865,13 +866,6 @@ public final class ModItems {
                     "Lanthanum",
                     Materials.Lanthanum.mElement.name(),
                     Utils.rgbtoHexValue(106, 127, 163));
-        }
-        if (!ItemUtils.checkForInvalidItems(ItemUtils.getItemStackOfAmountFromOreDictNoBroken("dustGermanium", 1))) {
-            ItemUtils.generateSpecialUseDusts(
-                    "Germanium",
-                    "Germanium",
-                    "Ge",
-                    ELEMENT.getInstance().GERMANIUM.getRgbAsHex());
         }
 
         // Just an unusual plate needed for some black magic.


### PR DESCRIPTION
fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/14644.
But its done directly in gt++ this time and not in tectech by reflecting gt++ like in the past.

works in full pack:
![image](https://github.com/GTNewHorizons/GTplusplus/assets/40274384/3bf42f8a-e865-4ae4-a288-c7821f2daed3)
![image](https://github.com/GTNewHorizons/GTplusplus/assets/40274384/9de35250-161c-41d7-ac6b-c8a9243bb756)
