### PR TITLE
Fixes for overflow valve, wireless charger, and transmission components recipes and ids

### DIFF
--- a/src/main/java/gtPlusPlus/core/recipe/RECIPES_Machines.java
+++ b/src/main/java/gtPlusPlus/core/recipe/RECIPES_Machines.java
@@ -753,14 +753,14 @@ public class RECIPES_Machines {
                 GregtechItemList.Cover_Overflow_MV.get(1L), GregtechItemList.Cover_Overflow_HV.get(1L),
                 GregtechItemList.Cover_Overflow_EV.get(1L), GregtechItemList.Cover_Overflow_IV.get(1L), };
 
-        for (int i = 1; i < aOutputs.length; i++) {
+        for (int tier = 1; tier < aOutputs.length + 1; tier++) {
             CORE.RA.addSixSlotAssemblingRecipe(
-                    new ItemStack[] { CI.getNumberedBioCircuit(19), CI.getElectricPump(i, 2), CI.getElectricMotor(i, 2),
-                            CI.getPlate(i, 4) },
-                    Materials.SolderingAlloy.getFluid(i * (144)),
-                    aOutputs[i].copy(),
+                    new ItemStack[] { CI.getNumberedBioCircuit(19), CI.getElectricPump(tier, 2),
+                            CI.getElectricMotor(tier, 2), CI.getPlate(tier, 4) },
+                    Materials.SolderingAlloy.getFluid(tier * (144)),
+                    aOutputs[tier - 1].copy(),
                     20 * 20,
-                    MaterialUtils.getVoltageForTier(i));
+                    MaterialUtils.getVoltageForTier(tier));
         }
     }
 
@@ -2715,17 +2715,17 @@ public class RECIPES_Machines {
                 GregtechItemList.Charger_LuV.get(1), GregtechItemList.Charger_ZPM.get(1),
                 GregtechItemList.Charger_UV.get(1), GregtechItemList.Charger_UHV.get(1) };
 
-        for (int tier = 1; tier < aChargers.length; tier++) {
+        for (int tier = 1; tier < aChargers.length + 1; tier++) {
 
             ItemStack[] aInputs = new ItemStack[] { CI.getTieredMachineHull(tier, 1),
                     CI.getTransmissionComponent(tier, 2), CI.getFieldGenerator(tier, 1),
-                    CI.getTieredComponent(OrePrefixes.plate, tier, 4),
-                    CI.getTieredComponent(OrePrefixes.circuit, tier, 2), };
+                    CI.getTieredComponent(OrePrefixes.plate, tier + 1, 4),
+                    CI.getTieredComponent(OrePrefixes.circuit, tier + 1, 2), };
             CORE.RA.addSixSlotAssemblingRecipe(
                     aInputs,
-                    CI.getAlternativeTieredFluid(tier, (144 * 2 * tier)), // Input Fluid
-                    aChargers[tier],
-                    45 * 10 * (tier),
+                    CI.getAlternativeTieredFluid(tier, (144 * 2 * (tier + 1))), // Input Fluid
+                    aChargers[tier - 1],
+                    45 * 10 * (tier + 1),
                     MaterialUtils.getVoltageForTier(tier));
         }
     }

--- a/src/main/java/gtPlusPlus/core/recipe/common/CI.java
+++ b/src/main/java/gtPlusPlus/core/recipe/common/CI.java
@@ -881,7 +881,7 @@ public class CI {
 
     public static ItemStack getFieldGenerator(int aTier, int aSize) {
         ItemStack aType;
-        int aLazyTier = 0;
+        int aLazyTier = 1;
         if (aTier == aLazyTier++) {
             aType = CI.fieldGenerator_LV;
         } else if (aTier == aLazyTier++) {
@@ -963,7 +963,7 @@ public class CI {
     }
 
     public static ItemStack getTransmissionComponent(int aTier, int aAmount) {
-        GregtechItemList[] aTransParts = new GregtechItemList[] { GregtechItemList.TransmissionComponent_LV,
+        GregtechItemList[] aTransParts = new GregtechItemList[] { null, GregtechItemList.TransmissionComponent_LV,
                 GregtechItemList.TransmissionComponent_MV, GregtechItemList.TransmissionComponent_HV,
                 GregtechItemList.TransmissionComponent_EV, GregtechItemList.TransmissionComponent_IV,
                 GregtechItemList.TransmissionComponent_LuV, GregtechItemList.TransmissionComponent_ZPM,

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/items/MetaGeneratedGregtechItems.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/items/MetaGeneratedGregtechItems.java
@@ -272,21 +272,22 @@ public class MetaGeneratedGregtechItems extends Gregtech_MetaItem_X32 {
                         "Wood's Glass Lens",
                         "Allows UV & IF to pass through, blocks visible light spectrums"));
 
-        int aStartID = 141;
+        // 141 now unused, was the ulv transmission component
+        int aStartID = 142;
         GregtechItemList[] aTransParts = new GregtechItemList[] { GregtechItemList.TransmissionComponent_LV,
                 GregtechItemList.TransmissionComponent_MV, GregtechItemList.TransmissionComponent_HV,
                 GregtechItemList.TransmissionComponent_EV, GregtechItemList.TransmissionComponent_IV,
                 GregtechItemList.TransmissionComponent_LuV, GregtechItemList.TransmissionComponent_ZPM,
                 GregtechItemList.TransmissionComponent_UV, GregtechItemList.TransmissionComponent_UHV, };
-        for (int aIndex = 0; aIndex < aTransParts.length; aIndex++) {
-            aTransParts[aIndex].set(
+        for (int tier = 1; tier < aTransParts.length + 1; tier++) {
+            aTransParts[tier - 1].set(
                     this.addItem(
                             aStartID++,
-                            "Transmission Component (" + GT_Values.VN[aIndex] + ")",
+                            "Transmission Component (" + GT_Values.VN[tier] + ")",
                             "",
-                            getTcAspectStack(TC_Aspects.ELECTRUM, aIndex),
-                            getTcAspectStack(TC_Aspects.MACHINA, aIndex),
-                            getTcAspectStack(TC_Aspects.MAGNETO, aIndex)));
+                            getTcAspectStack(TC_Aspects.ELECTRUM, tier),
+                            getTcAspectStack(TC_Aspects.MACHINA, tier),
+                            getTcAspectStack(TC_Aspects.MAGNETO, tier)));
         }
 
         // Distillus Chip


### PR DESCRIPTION
- Fixes a number of bugs caused by https://github.com/GTNewHorizons/GTplusplus/pull/767.
- Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/15045
- Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/15045#issuecomment-1847425837
- Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/15045#issuecomment-1847446256

Specifically:
- Fixes incorrect tiers for inputs/outputs/amounts/recipe time for wireless chargers as well as restore missing recipes
- Fixes incorrect tiers for inputs/outputs/amounts/recipe time for overflow valve as well as restore missing recipes
- fix id-shift of transmission components, fix mismatch between internal name and visual item, and restore UHV transmission component to existence while removing the ULV one properly. Also fix the tiers in the gettransmissioncomponent function and thus their tiers in recipes.
- fixed tiers in getFieldGenerator function and thus their tiers in recipes.

I checked in full pack by comparing to 2.4.0 that: the ids are correct now for transmission components, ULV one is properly gone, UHV exists again. wireless charger and overflow valve recipes look the same as 2.4.0 now (and LV one exists).