### PR TITLE
Normalize semifluid gens to match the other fuel gens

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,5 +1,5 @@
 dependencies {
-    api('com.github.GTNewHorizons:GT5-Unofficial:5.09.44.99:dev')
+    api('com.github.GTNewHorizons:GT5-Unofficial:5.09.44.104:dev')
     api("com.github.GTNewHorizons:bartworks:0.8.20:dev")
 
     implementation('curse.maven:cofh-core-69162:2388751')

--- a/repositories.gradle
+++ b/repositories.gradle
@@ -1,5 +1,4 @@
 // Add any additional repositories for your dependencies here
 
 repositories {
-    mavenLocal()
 }

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/generators/GT_MetaTileEntity_SemiFluidGenerator.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/generators/GT_MetaTileEntity_SemiFluidGenerator.java
@@ -46,7 +46,7 @@ public class GT_MetaTileEntity_SemiFluidGenerator extends GT_MetaTileEntity_Basi
 
     @Override
     public int getCapacity() {
-        return 4000 * this.mTier;
+        return 16000;
     }
 
     public void onConfigLoad() {


### PR DESCRIPTION
Closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/15047#issuecomment-1847844416

Someone check that I am right that `mavenlocal` shouldn't be in the default repositories.