### PR TITLE
fix id shift of super busses

### DIFF
--- a/src/main/java/gtPlusPlus/xmod/gregtech/registration/gregtech/GregtechCustomHatches.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/registration/gregtech/GregtechCustomHatches.java
@@ -196,7 +196,7 @@ public class GregtechCustomHatches {
         /*
          * Super Output Busses
          */
-        aStartID = 30031;
+        aStartID = 30032;
         GregtechItemList.Hatch_SuperBus_Output_LV.set(
                 ((IMetaTileEntity) makeOutputBus(aStartID++, "hatch.superbus.output.tier.01", "Super Bus (O) (LV)", 1))
                         .getStackForm(1L));


### PR DESCRIPTION
- Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/15060 (uhv super bus missing)
- fixes all the super busses shifting by one tier when updating.

was caused by https://github.com/GTNewHorizons/GTplusplus/pull/767