### PR TITLE
Fix Volcanus and cryo freezer not having pyrotheum and cryotheum hatch in their tooltip

### DIFF
--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/GregtechMetaTileEntity_IndustrialVacuumFreezer.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/GregtechMetaTileEntity_IndustrialVacuumFreezer.java
@@ -85,8 +85,8 @@ public class GregtechMetaTileEntity_IndustrialVacuumFreezer extends
                 .addPollutionAmount(getPollutionPerSecond(null)).addSeparator().beginStructureBlock(3, 3, 3, true)
                 .addController("Front Center").addCasingInfoMin(mCasingName, 10, false)
                 .addInputBus("Any Casing", 1).addOutputBus("Any Casing", 1).addInputHatch("Any Casing", 1)
-                .addOutputHatch("Any Casing", 1).addEnergyHatch("Any Casing", 1).addMaintenanceHatch("Any Casing", 1)
-                .addMufflerHatch("Any Casing", 1).addOtherStructurePart(mHatchName, "Any Casing", 1).toolTipFinisher(CORE.GT_Tooltip_Builder.get());
+                .addOutputHatch("Any Casing", 1).addEnergyHatch("Any Casing", 1).addMufflerHatch("Any Casing", 1).addMaintenanceHatch("Any Casing", 1)
+                .addOtherStructurePart(mHatchName, "Any Casing", 1).toolTipFinisher(CORE.GT_Tooltip_Builder.get());
         return tt;
     }
 

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/GregtechMetaTileEntity_IndustrialVacuumFreezer.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/GregtechMetaTileEntity_IndustrialVacuumFreezer.java
@@ -83,9 +83,9 @@ public class GregtechMetaTileEntity_IndustrialVacuumFreezer extends
                 .addInfo("Consumes 1L of " + mCryoFuelName + "/t during operation")
                 .addInfo("Constructed exactly the same as a normal Vacuum Freezer")
                 .addPollutionAmount(getPollutionPerSecond(null)).addSeparator().beginStructureBlock(3, 3, 3, true)
-                .addController("Front Center").addCasingInfoMin(mCasingName, 10, false)
-                .addInputBus("Any Casing", 1).addOutputBus("Any Casing", 1).addInputHatch("Any Casing", 1)
-                .addOutputHatch("Any Casing", 1).addEnergyHatch("Any Casing", 1).addMufflerHatch("Any Casing", 1).addMaintenanceHatch("Any Casing", 1)
+                .addController("Front Center").addCasingInfoMin(mCasingName, 10, false).addInputBus("Any Casing", 1)
+                .addOutputBus("Any Casing", 1).addInputHatch("Any Casing", 1).addOutputHatch("Any Casing", 1)
+                .addEnergyHatch("Any Casing", 1).addMufflerHatch("Any Casing", 1).addMaintenanceHatch("Any Casing", 1)
                 .addOtherStructurePart(mHatchName, "Any Casing", 1).toolTipFinisher(CORE.GT_Tooltip_Builder.get());
         return tt;
     }

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/GregtechMetaTileEntity_IndustrialVacuumFreezer.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/GregtechMetaTileEntity_IndustrialVacuumFreezer.java
@@ -83,10 +83,10 @@ public class GregtechMetaTileEntity_IndustrialVacuumFreezer extends
                 .addInfo("Consumes 1L of " + mCryoFuelName + "/t during operation")
                 .addInfo("Constructed exactly the same as a normal Vacuum Freezer")
                 .addPollutionAmount(getPollutionPerSecond(null)).addSeparator().beginStructureBlock(3, 3, 3, true)
-                .addController("Front Center").addCasingInfoMin(mCasingName, 10, false).addStructureHint(mHatchName, 1)
+                .addController("Front Center").addCasingInfoMin(mCasingName, 10, false)
                 .addInputBus("Any Casing", 1).addOutputBus("Any Casing", 1).addInputHatch("Any Casing", 1)
                 .addOutputHatch("Any Casing", 1).addEnergyHatch("Any Casing", 1).addMaintenanceHatch("Any Casing", 1)
-                .addMufflerHatch("Any Casing", 1).toolTipFinisher(CORE.GT_Tooltip_Builder.get());
+                .addMufflerHatch("Any Casing", 1).addOtherStructurePart(mHatchName, "Any Casing", 1).toolTipFinisher(CORE.GT_Tooltip_Builder.get());
         return tt;
     }
 

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/advanced/GregtechMetaTileEntity_Adv_EBF.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/advanced/GregtechMetaTileEntity_Adv_EBF.java
@@ -94,9 +94,9 @@ public class GregtechMetaTileEntity_Adv_EBF extends GregtechMeta_MultiBlockBase<
                 .addInfo("Constructed exactly the same as a normal EBF").addPollutionAmount(getPollutionPerSecond(null))
                 .addSeparator().addController("Bottom center").addCasingInfoMin(mCasingName, 8, false)
                 .addInputHatch("Any Casing", 1).addInputBus("Any Casing", 1).addOutputBus("Any Casing", 1)
-                .addOutputHatch("Any Casing", 1).addStructureHint(mHatchName, 1).addEnergyHatch("Any Casing", 1)
-                .addMufflerHatch("Any Casing", 1).addMaintenanceHatch("Any Casing", 1)
-                .addOtherStructurePart(mHatchName, "Any Casing", 1).toolTipFinisher(CORE.GT_Tooltip_Builder.get());
+                .addOutputHatch("Any Casing", 1).addEnergyHatch("Any Casing", 1).addMufflerHatch("Any Casing", 1)
+                .addMaintenanceHatch("Any Casing", 1).addOtherStructurePart(mHatchName, "Any Casing", 1)
+                .toolTipFinisher(CORE.GT_Tooltip_Builder.get());
         return tt;
     }
 

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/advanced/GregtechMetaTileEntity_Adv_EBF.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/advanced/GregtechMetaTileEntity_Adv_EBF.java
@@ -96,7 +96,7 @@ public class GregtechMetaTileEntity_Adv_EBF extends GregtechMeta_MultiBlockBase<
                 .addInputHatch("Any Casing", 1).addInputBus("Any Casing", 1).addOutputBus("Any Casing", 1)
                 .addOutputHatch("Any Casing", 1).addStructureHint(mHatchName, 1).addEnergyHatch("Any Casing", 1)
                 .addMufflerHatch("Any Casing", 1).addMaintenanceHatch("Any Casing", 1)
-                .toolTipFinisher(CORE.GT_Tooltip_Builder.get());
+                .addOtherStructurePart(mHatchName, "Any Casing", 1).toolTipFinisher(CORE.GT_Tooltip_Builder.get());
         return tt;
     }
 


### PR DESCRIPTION
before: (image taken from guy that reported it on stable ig)
![image](https://github.com/GTNewHorizons/GTplusplus/assets/39595617/3e2feef4-e200-42d4-b4b2-48b67fbb1416)
after: (taken from dev instance)
![image](https://github.com/GTNewHorizons/GTplusplus/assets/39595617/8ee026de-af0f-4969-836b-d7441cb04f44)

it was showing those hatches in NEI preview and hologram, but not in actual tooltip

I also changed the order in which muffler and maintenance are ordered to be same as volcanus(estetic purposes ig)