### PR TITLE
Allow emptying of fluid tanks by placing them anywhere in the crafting grid.

### DIFF
--- a/src/main/java/gtPlusPlus/core/recipe/RECIPES_Machines.java
+++ b/src/main/java/gtPlusPlus/core/recipe/RECIPES_Machines.java
@@ -1276,17 +1276,7 @@ public class RECIPES_Machines {
                     GregtechItemList.GT_FluidTank_LV, GregtechItemList.GT_FluidTank_MV,
                     GregtechItemList.GT_FluidTank_HV };
             for (GregtechItemList aTank : aTanks) {
-                RecipeUtils.addShapedGregtechRecipe(
-                        aTank.get(1),
-                        null,
-                        null,
-                        null,
-                        null,
-                        null,
-                        null,
-                        null,
-                        null,
-                        aTank.get(1));
+                RecipeUtils.addShapelessGregtechRecipe(new Object[] { aTank.get(1) }, aTank.get(1));
             }
 
             RecipeUtils.addShapedGregtechRecipe(


### PR DESCRIPTION
Previously, a fluid tank containing some fluid could be emptied by placing it in the top left corner of the crafting grid. (Shaped crafting recipe.) This PR changes this recipe to be shapeless; so a tank can be emptied by placing it anywhere in the grid, not only in the top left slot.

This also makes the behavior consistent with super and quantum tanks, and super and quantum chests, all of which can be emptied anywhere in the crafting grid.

This resolves https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/15107.

&nbsp;

**NOTE:** the recipe does not work in game *specifically for the HV tank*. All other tiers of tanks (ULV -- MV) work correctly. However, this is also the case in the current stable release, and at least as far back as 2.4.1: the HV tank can simply not be emptied in the crafting grid anywhere, even in the top left slot. The HV tank recipe is correctly defined in GT++ along with the other tiers, but it is getting removed somewhere else later. I tried investigating why this happens, but I couldn't find the cause.

Unless this exception is for some reason intended, then I would suggest fixing this removal before or along with merging this PR.