### PR TITLE
Fix chisel busses

### DIFF
--- a/src/main/java/gtPlusPlus/core/recipe/RECIPES_Machines.java
+++ b/src/main/java/gtPlusPlus/core/recipe/RECIPES_Machines.java
@@ -3029,14 +3029,14 @@ public class RECIPES_Machines {
                 GregtechItemList.GT_MetaTileEntity_ChiselBus_MV.get(1),
                 GregtechItemList.GT_MetaTileEntity_ChiselBus_HV.get(1), };
 
-        for (int i = 1; i < mChiselBuses.length; i++) {
+        for (int tier = 1; tier < mChiselBuses.length + 1; tier++) {
             CORE.RA.addSixSlotAssemblingRecipe(
-                    new ItemStack[] { CI.getNumberedCircuit(17), mSuperBusesInput[i], CI.getSensor(i, 1),
-                            CI.getRobotArm(i, 2), CI.getBolt(i, 16), ItemUtils.getSimpleStack(Blocks.chest) },
-                    CI.getAlternativeTieredFluid(i, 144 * 2),
-                    mChiselBuses[i - 1],
+                    new ItemStack[] { CI.getNumberedCircuit(17), mSuperBusesInput[tier - 1], CI.getSensor(tier, 1),
+                            CI.getRobotArm(tier, 2), CI.getBolt(tier, 16), ItemUtils.getSimpleStack(Blocks.chest) },
+                    CI.getAlternativeTieredFluid(tier, 144 * 2),
+                    mChiselBuses[tier - 1],
                     20 * 30 * 2,
-                    (int) GT_Values.VP[i + 1]);
+                    (int) GT_Values.VP[tier + 1]);
         }
     }
 

--- a/src/main/java/gtPlusPlus/xmod/gregtech/registration/gregtech/GregtechCustomHatches.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/registration/gregtech/GregtechCustomHatches.java
@@ -25,7 +25,7 @@ public class GregtechCustomHatches {
             run2();
         }
         run3();
-        run5(); // Chisel buses
+        run4(); // Chisel buses
     }
 
     private static void run1() {
@@ -241,15 +241,15 @@ public class GregtechCustomHatches {
         return new GT_MetaTileEntity_ChiselBus(id, unlocalizedName, localizedName, tier);
     }
 
-    private static void run5() {
+    private static void run4() {
         int aID = 31778;
 
         GregtechItemList.GT_MetaTileEntity_ChiselBus_LV
-                .set((makeChiselBus(aID++, "hatch.chisel.tier.01", "Chisel Bus II", 1)).getStackForm(1L));
+                .set((makeChiselBus(aID++, "hatch.chisel.tier.01", "Chisel Bus I", 1)).getStackForm(1L));
         GregtechItemList.GT_MetaTileEntity_ChiselBus_MV
-                .set((makeChiselBus(aID++, "hatch.chisel.tier.02", "Chisel Bus III", 2)).getStackForm(1L));
+                .set((makeChiselBus(aID++, "hatch.chisel.tier.02", "Chisel Bus II", 2)).getStackForm(1L));
         GregtechItemList.GT_MetaTileEntity_ChiselBus_HV
-                .set((makeChiselBus(aID++, "hatch.chisel.tier.03", "Chisel Bus IV", 3)).getStackForm(1L));
+                .set((makeChiselBus(aID++, "hatch.chisel.tier.03", "Chisel Bus III", 3)).getStackForm(1L));
 
     }
 }


### PR DESCRIPTION
Fixes https://discord.com/channels/181078474394566657/603348502637969419/1190288184765063198

The ulv one stays removed as we are removing ULV bit by bit. But they are already renamed so that LV is I (and so on). And the HV one has a recipe again.

was caused by https://github.com/GTNewHorizons/GTplusplus/pull/767