### PR TITLE
Fix Soldering Iron unable to set redstone output strength.

### DIFF
--- a/src/main/java/gtPlusPlus/xmod/gregtech/api/metatileentity/implementations/base/GregtechMeta_MultiBlockBase.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/api/metatileentity/implementations/base/GregtechMeta_MultiBlockBase.java
@@ -1157,7 +1157,7 @@ public abstract class GregtechMeta_MultiBlockBase<T extends GT_MetaTileEntity_Ex
     @Override
     public boolean onSolderingToolRightClick(ForgeDirection side, ForgeDirection wrenchingSide, EntityPlayer aPlayer,
             float aX, float aY, float aZ) {
-        if (supportsVoidProtection()) {
+        if (supportsVoidProtection() && wrenchingSide == getBaseMetaTileEntity().getFrontFacing()) {
             Set<VoidingMode> allowed = getAllowedVoidingModes();
             setVoidingMode(getVoidingMode().nextInCollection(allowed));
             GT_Utility.sendChatToPlayer(


### PR DESCRIPTION
Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/15191 and duplicates (https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/15232, https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/15259).

Right-clicking the front face of the controller changes voiding mode, right-clicking any other face changes redstone output strength.

Related PR fixing the same issue with the EEC in KubaTech: https://github.com/GTNewHorizons/KubaTech/pull/115

Comment: do we really need the voiding mode to be toggleable by a tool, when multis now have a GUI button for it?