### PR TITLE
Advanced Muffler Hatch improvements

### DIFF
--- a/src/main/java/gtPlusPlus/core/item/general/ItemAirFilter.java
+++ b/src/main/java/gtPlusPlus/core/item/general/ItemAirFilter.java
@@ -88,6 +88,10 @@ public class ItemAirFilter extends Item {
         return true;
     }
 
+    public static final long getFilterMaxDamage(final ItemStack aStack) {
+        return aStack.getItemDamage() == 0 ? 50 : 2500;
+    }
+
     public static final long getFilterDamage(final ItemStack aStack) {
         NBTTagCompound aNBT = aStack.getTagCompound();
         if (aNBT != null) {
@@ -119,7 +123,7 @@ public class ItemAirFilter extends Item {
             createNBT(stack);
         }
         double currentDamage = getFilterDamage(stack);
-        double meta = stack.getItemDamage() == 0 ? 50 : 2500;
+        double meta = getFilterMaxDamage(stack);
         double durabilitypercent = currentDamage / meta;
         return durabilitypercent;
     }
@@ -127,7 +131,7 @@ public class ItemAirFilter extends Item {
     @Override
     public void addInformation(ItemStack stack, EntityPlayer player, List list, boolean bool) {
         list.add(EnumChatFormatting.GRAY + "An Air filter for Atmospheric Reconditioning.");
-        int maxDamage = (stack.getItemDamage() == 0 ? 50 : 2500);
+        long maxDamage = getFilterMaxDamage(stack);
         list.add(EnumChatFormatting.GRAY + "" + (maxDamage - getFilterDamage(stack)) + "/" + maxDamage + " uses left.");
         super.addInformation(stack, player, list, bool);
     }

--- a/src/main/java/gtPlusPlus/xmod/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_Hatch_Muffler_Adv.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_Hatch_Muffler_Adv.java
@@ -2,6 +2,7 @@ package gtPlusPlus.xmod.gregtech.api.metatileentity.implementations;
 
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
+import net.minecraft.util.EnumChatFormatting;
 import net.minecraft.world.World;
 import net.minecraftforge.common.util.ForgeDirection;
 
@@ -10,7 +11,6 @@ import com.gtnewhorizons.modularui.api.screen.UIBuildContext;
 import com.gtnewhorizons.modularui.common.widget.SlotWidget;
 
 import gregtech.GT_Mod;
-import gregtech.api.enums.GT_Values;
 import gregtech.api.gui.modularui.GT_UIInfos;
 import gregtech.api.gui.modularui.GUITextureSet;
 import gregtech.api.interfaces.ITexture;
@@ -18,9 +18,9 @@ import gregtech.api.interfaces.modularui.IAddGregtechLogo;
 import gregtech.api.interfaces.tileentity.IGregTechTileEntity;
 import gregtech.api.metatileentity.MetaTileEntity;
 import gregtech.api.metatileentity.implementations.GT_MetaTileEntity_Hatch_Muffler;
+import gregtech.api.metatileentity.implementations.GT_MetaTileEntity_MultiBlockBase;
 import gregtech.api.objects.GT_RenderedTexture;
 import gregtech.api.util.GT_Config;
-import gtPlusPlus.api.objects.Logger;
 import gtPlusPlus.core.item.general.ItemAirFilter;
 import gtPlusPlus.core.lib.CORE;
 import gtPlusPlus.core.util.minecraft.gregtech.PollutionUtils;
@@ -55,20 +55,20 @@ public class GT_MetaTileEntity_Hatch_Muffler_Adv extends GT_MetaTileEntity_Hatch
         super(aName, aTier, 1, aDescription, aTextures);
     }
 
+    final String[] mDescription = new String[] { "Outputs pollution from a multiblock", "DO NOT OBSTRUCT THE OUTPUT!",
+            "Requires 3 Air Blocks in front of the exhaust face",
+            mTier < 5 ? "Requires an Air Filter to function"
+                    : "Requires an Air Filter " + EnumChatFormatting.WHITE
+                            + "[Tier 2]"
+                            + EnumChatFormatting.GRAY
+                            + " to function",
+            "Can take Air Filters from an input bus of the multiblock",
+            "Reduces Pollution to " + calculatePollutionReduction(100, true) + "%",
+            "Recovers " + (100 - calculatePollutionReduction(100, true)) + "% of CO2/CO/SO2", CORE.GT_Tooltip.get() };
+
     @Override
     public String[] getDescription() {
-        String[] desc = new String[mDescriptionArray.length + 7];
-        System.arraycopy(mDescriptionArray, 0, desc, 0, mDescriptionArray.length);
-        desc[mDescriptionArray.length] = "DO NOT OBSTRUCT THE OUTPUT!";
-        desc[mDescriptionArray.length + 1] = "Requires 3 Air on the exhaust face";
-        desc[mDescriptionArray.length + 2] = "Requires Air Filters";
-        desc[mDescriptionArray.length + 3] = "Mufflers require T2 Filters from IV-" + GT_Values.VN[9];
-        desc[mDescriptionArray.length + 4] = "Reduces Pollution to " + this.calculatePollutionReductionForTooltip(100)
-                + "%";
-        desc[mDescriptionArray.length + 5] = "Recovers " + (105 - this.calculatePollutionReductionForTooltip(100))
-                + "% of CO2/CO/SO2";
-        desc[mDescriptionArray.length + 6] = CORE.GT_Tooltip.get();
-        return desc;
+        return mDescription;
     }
 
     @Override
@@ -87,6 +87,12 @@ public class GT_MetaTileEntity_Hatch_Muffler_Adv extends GT_MetaTileEntity_Hatch
     }
 
     @Override
+    public boolean allowPutStack(IGregTechTileEntity aBaseMetaTileEntity, int aIndex, ForgeDirection side,
+            ItemStack aStack) {
+        return (aIndex == this.SLOT_FILTER && isAirFilter(aStack));
+    }
+
+    @Override
     public MetaTileEntity newMetaEntity(IGregTechTileEntity aTileEntity) {
         return new GT_MetaTileEntity_Hatch_Muffler_Adv(this.mName, this.mTier, mDescriptionArray, this.mTextures);
     }
@@ -97,151 +103,158 @@ public class GT_MetaTileEntity_Hatch_Muffler_Adv extends GT_MetaTileEntity_Hatch
         return true;
     }
 
-    private boolean airCheck() {
-        if (this.getBaseMetaTileEntity().getAirAtSide(this.getBaseMetaTileEntity().getFrontFacing())
-                && this.getBaseMetaTileEntity()
-                        .getAirAtSideAndDistance(this.getBaseMetaTileEntity().getFrontFacing(), 1)
-                && this.getBaseMetaTileEntity()
-                        .getAirAtSideAndDistance(this.getBaseMetaTileEntity().getFrontFacing(), 2)) {
-            return true;
-        }
-        return false;
-    }
-
     @Override
-    public boolean polluteEnvironment(MetaTileEntity unused) {
-        if (airCheck() && damageAirFilter()) {
-            int aEmission = this.calculatePollutionReduction(10000);
-            PollutionUtils.addPollution(this.getBaseMetaTileEntity(), aEmission);
-            // Logger.INFO("Outputting "+aEmission+"gbl");
-            return true;
-        } else {
-            // Logger.INFO("Failed to output pollution");
-            return false;
-        }
-    }
+    public boolean polluteEnvironment(MetaTileEntity parentTileEntity) {
+        if (!airCheck()) return false; // Muffler obstructed.
 
-    public int calculatePollutionReductionForTooltip(int aPollution) {
-        return (int) (aPollution * Math.pow(0.64D, (double) (this.mTier - 1)));
+        int emission = 10000;
+        if (damageAirFilter(parentTileEntity)) {
+            emission = calculatePollutionReduction(emission, false);
+        }
+
+        PollutionUtils.addPollution(this.getBaseMetaTileEntity(), emission);
+        return true;
     }
 
     @Override
     public int calculatePollutionReduction(int aPollution) {
-        double aVal1 = aPollution * Math.pow(0.64D, (double) (this.mTier - 1));
-        int aVal2 = (int) aVal1;
-        if (!hasValidFilter()) {
-            aVal2 = (int) ((double) aPollution * Math.pow(0.7D, (double) (this.mTier - 1)));;
-        }
-        return aVal2;
+        // This is called by EBF to calculate exhaust gas amounts, we need to check the filter.
+        return calculatePollutionReduction(aPollution, false);
     }
 
-    @Override
-    public boolean allowPutStack(IGregTechTileEntity aBaseMetaTileEntity, int aIndex, ForgeDirection side,
-            ItemStack aStack) {
-        if (aIndex == this.SLOT_FILTER) {
-            if (isAirFilter(aStack)) {
-                return true;
+    /**
+     * Calculates pollution reduction.
+     *
+     * @param aPollution   Amount of pollution to be reduced.
+     * @param ignoreFilter If this is true, assumes that a valid filter is present without checking (for example, to
+     *                     build tooltips).
+     * @return Amount of pollution after reduction.
+     */
+    protected int calculatePollutionReduction(int aPollution, boolean ignoreFilter) {
+        if (!ignoreFilter && !hasAirFilter()) return aPollution; // Do not reduce pollution without a filter.
+
+        // Special case to be always better than a basic muffler.
+        if (mTier < 2) return (int) (aPollution * 0.95);
+        if (mTier > 8) return 0;
+
+        return (int) (aPollution * Math.pow(0.64D, mTier - 1));
+    }
+
+    /**
+     *
+     * @return True if enough blocks in front of the muffler are air.
+     */
+    private boolean airCheck() {
+        IGregTechTileEntity bmte = getBaseMetaTileEntity();
+        ForgeDirection facing = bmte.getFrontFacing();
+        return bmte.getAirAtSide(facing) && bmte.getAirAtSideAndDistance(facing, 1)
+                && bmte.getAirAtSideAndDistance(facing, 2);
+    }
+
+    /**
+     * Try to damage an air filter. Will first try to find a valid filter in the hatch's own inventory, then in the
+     * input buses of the parent multiblock. If the filter is destroyed, will try to replace it from the parent
+     * multiblock's input buses again.
+     *
+     * @param parentTileEntity Which multiblock this hatch is a part of. If this is null, only checks inventory of the
+     *                         muffler.
+     * @return True if the filter has been successfully damaged.
+     */
+    private boolean damageAirFilter(MetaTileEntity parentTileEntity) {
+        if (!findAirFilter(parentTileEntity)) return false; // No filter available.
+
+        ItemStack filter = mInventory[SLOT_FILTER];
+        if (filter == null) return false; // This should never happen if findAirFilter() above succeeded.
+
+        long currentDamage = ItemAirFilter.getFilterDamage(filter);
+        if (currentDamage < ItemAirFilter.getFilterMaxDamage(filter) - 1) {
+            // Damage filter by one step.
+            ItemAirFilter.setFilterDamage(filter, currentDamage + 1);
+            return true;
+        } else {
+            // Destroy the filter.
+            mInventory[SLOT_FILTER] = null;
+
+            // Try to find a new one.
+            findAirFilter(parentTileEntity);
+
+            // Regardless of whether we have a new filter or not, *this* operation succeeded.
+            return true;
+        }
+    }
+
+    /**
+     * Try to find a valid air filter in the input buses of the parent multiblock.
+     *
+     * @param parentTileEntity Which multiblock this hatch is a part of. If this is null, only checks inventory of the
+     *                         muffler.
+     * @return True if the inventory of the muffler already contains an air filter, or if one was retrieved from the
+     *         parent multiblock.
+     */
+    private boolean findAirFilter(MetaTileEntity parentTileEntity) {
+        if (hasAirFilter()) return true; // Has a filter in inventory.
+        if (mInventory[SLOT_FILTER] != null) return false; // Has a non-filter item in inventory.
+        if (parentTileEntity == null) return false; // Unknown parent multiblock.
+
+        if (parentTileEntity instanceof GT_MetaTileEntity_MultiBlockBase GTMultiBase) {
+            for (var inputBus : GTMultiBase.mInputBusses) {
+                for (ItemStack stack : inputBus.mInventory) {
+                    if (isAirFilter(stack)) {
+                        ItemStack stackCopy = stack.copy();
+                        if (GTMultiBase.depleteInput(stack)) {
+                            mInventory[SLOT_FILTER] = stackCopy;
+                            return true;
+                        }
+                    }
+                }
             }
         }
+
         return false;
     }
 
-    private ItemStack getInventoryStack() {
-        if (this.mInventory != null && this.mInventory.length > 0) {
-            if (this.mInventory.length - 1 >= this.SLOT_FILTER) {
-                return this.mInventory[this.SLOT_FILTER];
-            }
-        }
-        return null;
+    /**
+     *
+     * @return True if the item currently in the inventory is an air filter valid for this tier of muffler hatch.
+     */
+    private boolean hasAirFilter() {
+        return isAirFilter(mInventory[SLOT_FILTER]);
     }
 
-    private void breakAirFilter() {
-        if (this.mInventory != null && this.mInventory.length > 0) {
-            if (this.mInventory.length - 1 >= this.SLOT_FILTER) {
-                Logger.INFO("Breaking Filter");
-                this.mInventory[this.SLOT_FILTER] = null;
+    /**
+     *
+     * @param filter
+     * @return True if the argument is an air filter valid for this tier of muffler hatch.
+     */
+    public boolean isAirFilter(ItemStack filter) {
+        if (filter == null) return false;
+        if (filter.getItem() instanceof ItemAirFilter) {
+            if (mTier < 5) {
+                // Accept any filter.
+                return true;
+            } else {
+                // Accept only T2 filter.
+                return filter.getItemDamage() == 1;
             }
         }
-    }
-
-    public boolean hasValidFilter() {
-        return isAirFilter(getInventoryStack());
+        return false;
     }
 
     @Override
     public void onPostTick(IGregTechTileEntity aBaseMetaTileEntity, long aTick) {
-
-        // Logger.INFO("A1");
-
         super.onPostTick(aBaseMetaTileEntity, aTick);
 
-        // Logger.INFO("A2");
-
-        String aParticleName;
-        if ((aTick % 2) == 0) {
-            aParticleName = "cloud";
-        } else {
-            aParticleName = "smoke";
-        }
-
-        // Logger.INFO("A3");
-
         if (aBaseMetaTileEntity.isClientSide()) {
-            // Logger.INFO("B1");
             if (this.getBaseMetaTileEntity().isActive()) {
-                // Logger.INFO("C1");
+                String aParticleName;
+                if ((aTick % 2) == 0) {
+                    aParticleName = "cloud";
+                } else {
+                    aParticleName = "smoke";
+                }
                 this.pollutionParticles(this.getBaseMetaTileEntity().getWorld(), aParticleName);
             }
-            // return;
-        } else {
-            // Logger.INFO("B2");
-            if (this.getInventoryStack() == null) {} else {
-                // Logger.INFO("D2");
-            }
         }
-        // Logger.INFO("A4");
-
-    }
-
-    public boolean isAirFilter(ItemStack filter) {
-        if (filter == null) {
-            return false;
-        }
-        if (filter.getItem() instanceof ItemAirFilter) {
-
-            if (this.mTier < 5) {
-                return true;
-            } else {
-                if (filter.getItemDamage() == 1) {
-                    return true;
-                }
-            }
-        }
-        return false;
-    }
-
-    public boolean damageAirFilter() {
-        ItemStack filter = getInventoryStack();
-        if (filter == null) {
-            return false;
-        }
-
-        if (isAirFilter(filter)) {
-            long currentUse = ItemAirFilter.getFilterDamage(filter);
-            Logger.INFO("Filter Damage: " + currentUse);
-            // Remove broken Filter
-            if ((filter.getItemDamage() == 0 && currentUse >= 50 - 1)
-                    || (filter.getItemDamage() == 1 && currentUse >= 2500 - 1)) {
-                breakAirFilter();
-                return true;
-            } else {
-                // Do Damage
-                ItemAirFilter.setFilterDamage(filter, currentUse + 1);
-                Logger.INFO("Filter Damage now: " + currentUse);
-                return true;
-            }
-        }
-        return false;
     }
 
     @Override

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/GregtechMetaTileEntity_LargeRocketEngine.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/GregtechMetaTileEntity_LargeRocketEngine.java
@@ -48,7 +48,6 @@ import gtPlusPlus.core.lib.CORE;
 import gtPlusPlus.core.material.MISC_MATERIALS;
 import gtPlusPlus.core.util.minecraft.FluidUtils;
 import gtPlusPlus.xmod.gregtech.api.metatileentity.implementations.GT_MetaTileEntity_Hatch_AirIntake;
-import gtPlusPlus.xmod.gregtech.api.metatileentity.implementations.GT_MetaTileEntity_Hatch_Muffler_Adv;
 import gtPlusPlus.xmod.gregtech.api.metatileentity.implementations.base.GregtechMeta_MultiBlockBase;
 import gtPlusPlus.xmod.gregtech.common.blocks.textures.TexturesGtBlock;
 
@@ -426,28 +425,6 @@ public class GregtechMetaTileEntity_LargeRocketEngine extends
             }
         }
         return injected > 0;
-    }
-
-    @Override
-    public boolean onRunningTick(ItemStack aStack) {
-        if (this.mRuntime % 20 == 0) {
-            if (this.mMufflerHatches.size() == 1
-                    && this.mMufflerHatches.get(0) instanceof GT_MetaTileEntity_Hatch_Muffler_Adv tMuffler) {
-                if (!tMuffler.hasValidFilter()) {
-                    ArrayList<ItemStack> tInputs = getStoredInputs();
-                    for (ItemStack tItem : tInputs) {
-                        if (tMuffler.isAirFilter(tItem)) {
-                            tMuffler.mInventory[0] = tItem.copy();
-                            depleteInput(tItem);
-                            updateSlots();
-                            break;
-                        }
-                    }
-                }
-            }
-        }
-        super.onRunningTick(aStack);
-        return true;
     }
 
     public Block getCasingBlock() {


### PR DESCRIPTION
This PR contains several improvements to Advanced Muffler Hatches:

* As of 2.5.x, if the advanced muffler has no filter or the filter is depleted, the multiblock will immediately halt operation and void. Now, an advanced muffler can continue operating even without an air filter, but it will only reduce pollution by as much as a basic muffler of the same tier would.

* When the air filter is depleted, the advanced muffler will now try to pull a new filter from an input bus of the multiblock. This simplifies automation, especially for multiblocks which force the muffler to be in a position where none of its sides are accessible (for example, EBF, Pyrolyze Oven, Large Combustion Generator, ...)

* Pollution output is now fixed at 95% for LV, and 0% for UHV advanced mufflers. (Previously, 100% and 2.81% respectively.) This means that the advanced muffler is now always better (or at least not worse) than a basic muffler. The formula for other tiers is not changed.

* The tooltip no longer mentions an exhaust gas recovery amount that is different from the pollution filtering amount. This never worked in the first place; and is in fact fundamentally impossible to do with the way the EBF calculates exhaust amounts. (I couldn't find a github issue for this, but I remember somebody mentioning it in discord.)

* Cleaned up some obsolete/unreachable code.

There is currently one small inconvenience, that is if you build a multiblock with an advanced muffler, and place the air filter in an input bus, the filter will only be retrieved the first time the multiblock vents pollution. This means that specifically for the EBF, the amount of exhaust gas will be calculated as if using a basic muffler before the first pollution cycle. I don't believe this is possible to fix without changing base multiblock code. If you really care about a few % worth of exhaust gas, place a filter in the muffler hatch manually; it will be replaced correctly from that point on.

The removed code in `LargeRocketEngine.java` performed the same function that the mufflers now do by themselves (replacing a depleted filter), and thus is now redundant.