### PR TITLE
Fix Multi-Machine Manual Recipe

### DIFF
--- a/src/main/java/gtPlusPlus/core/handler/BookHandler.java
+++ b/src/main/java/gtPlusPlus/core/handler/BookHandler.java
@@ -10,10 +10,10 @@ import net.minecraft.init.Items;
 import net.minecraft.item.ItemStack;
 
 import gregtech.api.enums.GT_Values;
+import gregtech.api.util.GT_ModHandler;
 import gregtech.api.util.GT_OreDictUnificator;
 import gtPlusPlus.api.objects.Logger;
 import gtPlusPlus.core.item.ModItems;
-import gtPlusPlus.core.recipe.common.CI;
 import gtPlusPlus.core.util.minecraft.ItemUtils;
 import gtPlusPlus.core.util.minecraft.RecipeUtils;
 
@@ -431,10 +431,11 @@ public class BookHandler {
                 new ItemStack[] { ItemUtils.getSimpleStack(Items.writable_book),
                         ItemUtils.getSimpleStack(Items.lava_bucket) },
                 ItemBookWritten_ThermalBoiler);
-        RecipeUtils.addShapelessGregtechRecipe(
-                new ItemStack[] { ItemUtils.getSimpleStack(Items.writable_book),
-                        ItemUtils.getItemStackOfAmountFromOreDict(CI.craftingToolWrench, 1) },
-                ItemBookWritten_MultiMachineManual);
+        GT_ModHandler.addCraftingRecipe(
+                ItemBookWritten_MultiMachineManual,
+                GT_ModHandler.RecipeBits.NOT_REMOVABLE | GT_ModHandler.RecipeBits.REVERSIBLE
+                        | GT_ModHandler.RecipeBits.BUFFERED,
+                new Object[] { "Xw", 'X', ItemUtils.getSimpleStack(Items.writable_book) });
         RecipeUtils.addShapelessGregtechRecipe(
                 new ItemStack[] { ItemUtils.getSimpleStack(Items.writable_book),
                         ItemUtils.getItemStackOfAmountFromOreDict("wireGt01Tin", 1) },


### PR DESCRIPTION
Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/15368
Specifically, just switch to the GT api. That is the most logical thing for tool recipes anyway. It is shaped now but that should be good anyway.

![image](https://github.com/GTNewHorizons/GTplusplus/assets/40274384/dc9ca1cb-29c1-49ac-8531-5c630a36a9f9)
