### PR TITLE
Fix QFT

### DIFF
--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/GregtechMetaTileEntity_QuantumForceTransformer.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/GregtechMetaTileEntity_QuantumForceTransformer.java
@@ -325,34 +325,18 @@ public class GregtechMetaTileEntity_QuantumForceTransformer
     @Override
     public boolean checkMachine(IGregTechTileEntity aBaseMetaTileEntity, ItemStack aStack) {
         this.mCasing = 0;
+        this.mCraftingTier = 0;
+        this.mFocusingTier = 0;
         if (!checkPiece(MAIN_PIECE, 7, 20, 4)) {
             return false;
         }
 
-        if (mMaintenanceHatches.size() != 1 || mOutputBusses.size() < 1
-                || mInputBusses.size() < 1
-                || mInputHatches.size() < 1
-                || mOutputHatches.size() < 1) {
+        if (mMaintenanceHatches.size() != 1 || mOutputBusses.isEmpty()
+                || mOutputHatches.isEmpty()) {
             return false;
         }
 
-        // Makes sure that the multi can accept only 1 TT Energy Hatch OR up to 2 Normal Energy Hatches. Deform if both
-        // present or more than 1 TT Hatch.
-        if (mExoticEnergyHatches.isEmpty() && mEnergyHatches.isEmpty()) {
-            return false;
-        }
-
-        if (mExoticEnergyHatches.size() >= 1) {
-            if (!mEnergyHatches.isEmpty()) {
-                return false;
-            }
-
-            if (mExoticEnergyHatches.size() != 1) {
-                return false;
-            }
-        }
-
-        return mEnergyHatches.size() <= 2;
+        return checkExoticAndNormalEnergyHatches();
     }
 
     @Override

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/GregtechMetaTileEntity_QuantumForceTransformer.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/GregtechMetaTileEntity_QuantumForceTransformer.java
@@ -331,8 +331,7 @@ public class GregtechMetaTileEntity_QuantumForceTransformer
             return false;
         }
 
-        if (mMaintenanceHatches.size() != 1 || mOutputBusses.isEmpty()
-                || mOutputHatches.isEmpty()) {
+        if (mMaintenanceHatches.size() != 1 || mOutputBusses.isEmpty() || mOutputHatches.isEmpty()) {
             return false;
         }
 

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/GregtechMetaTileEntity_QuantumForceTransformer.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/GregtechMetaTileEntity_QuantumForceTransformer.java
@@ -280,11 +280,35 @@ public class GregtechMetaTileEntity_QuantumForceTransformer
                 .addCasingInfoMin("Quantum Force Conductor", 177, false)
                 .addCasingInfoMin("Force Field Glass", 224, false)
                 .addCasingInfoMin("Neutron Pulse Manipulators", 233, false)
-                .addCasingInfoMin("Neutron Shielding Cores", 142, false).addInputBus("Bottom Layer", 4)
-                .addInputHatch("Bottom Layer", 4).addOutputHatch("Top Layer", 5).addOutputBus("Top Layer", 5)
-                .addEnergyHatch("Bottom Layer", 4).addMaintenanceHatch("Bottom Layer", 4)
-                .addStructureInfo("Neptunium Plasma Hatch: Left side of Controller")
-                .addStructureInfo("Fermium Plasma Hatch: Right side of Controller").toolTipFinisher(
+                .addCasingInfoMin("Neutron Shielding Cores", 142, false)
+                .addInputBus(EnumChatFormatting.BLUE + "Bottom" + EnumChatFormatting.GRAY + " Layer", 4)
+                .addInputHatch(EnumChatFormatting.BLUE + "Bottom" + EnumChatFormatting.GRAY + " Layer", 4)
+                .addOutputHatch(EnumChatFormatting.AQUA + "Top" + EnumChatFormatting.GRAY + " Layer", 5)
+                .addOutputBus(EnumChatFormatting.AQUA + "Top" + EnumChatFormatting.GRAY + " Layer", 5)
+                .addEnergyHatch(EnumChatFormatting.BLUE + "Bottom" + EnumChatFormatting.GRAY + " Layer", 4)
+                .addMaintenanceHatch(
+                        EnumChatFormatting.BLUE + "Bottom"
+                                + EnumChatFormatting.GRAY
+                                + " or "
+                                + EnumChatFormatting.AQUA
+                                + "Top"
+                                + EnumChatFormatting.GRAY
+                                + " Layer",
+                        4,
+                        5)
+                .addStructureInfo(
+                        EnumChatFormatting.WHITE + "Neptunium Plasma Hatch: "
+                                + EnumChatFormatting.GREEN
+                                + "Left"
+                                + EnumChatFormatting.GRAY
+                                + " side of Controller")
+                .addStructureInfo(
+                        EnumChatFormatting.WHITE + "Fermium Plasma Hatch: "
+                                + EnumChatFormatting.DARK_GREEN
+                                + "Right"
+                                + EnumChatFormatting.GRAY
+                                + " side of Controller")
+                .toolTipFinisher(
                         GT_Values.AuthorBlueWeabo + EnumChatFormatting.RESET
                                 + EnumChatFormatting.GREEN
                                 + " + Steelux"

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/GregtechMetaTileEntity_QuantumForceTransformer.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/GregtechMetaTileEntity_QuantumForceTransformer.java
@@ -570,7 +570,7 @@ public class GregtechMetaTileEntity_QuantumForceTransformer
             private int findProgrammedCircuitNumber() {
                 if (isInputSeparationEnabled()) {
                     for (ItemStack stack : inputItems) {
-                        if (ItemList.Circuit_Integrated.isStackEqual(stack)) {
+                        if (ItemList.Circuit_Integrated.isStackEqual(stack, true, false)) {
                             return stack.getItemDamage() - 1;
                         }
                     }

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/GregtechMetaTileEntity_QuantumForceTransformer.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/GregtechMetaTileEntity_QuantumForceTransformer.java
@@ -742,11 +742,6 @@ public class GregtechMetaTileEntity_QuantumForceTransformer
     }
 
     @Override
-    public boolean supportsBatchMode() {
-        return true;
-    }
-
-    @Override
     public void saveNBTData(NBTTagCompound aNBT) {
         aNBT.setBoolean("mFluidMode", mFluidMode);
         aNBT.setBoolean("doFermium", doFermium);
@@ -921,6 +916,11 @@ public class GregtechMetaTileEntity_QuantumForceTransformer
 
     @Override
     public boolean supportsInputSeparation() {
+        return true;
+    }
+
+    @Override
+    public boolean supportsBatchMode() {
         return true;
     }
 }

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/GregtechMetaTileEntity_QuantumForceTransformer.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/GregtechMetaTileEntity_QuantumForceTransformer.java
@@ -623,6 +623,16 @@ public class GregtechMetaTileEntity_QuantumForceTransformer
     }
 
     @Override
+    public void onPostTick(IGregTechTileEntity aBaseMetaTileEntity, long aTick) {
+        super.onPostTick(aBaseMetaTileEntity, aTick);
+        if (aBaseMetaTileEntity.isServerSide()) {
+            // TODO: Look for proper fix
+            // Updates every 30 sec
+            if (mUpdate <= -550) mUpdate = 50;
+        }
+    }
+
+    @Override
     public int getMaxEfficiency(final ItemStack aStack) {
         return 10000;
     }

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/GregtechMetaTileEntity_QuantumForceTransformer.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/GregtechMetaTileEntity_QuantumForceTransformer.java
@@ -89,6 +89,7 @@ public class GregtechMetaTileEntity_QuantumForceTransformer
     private int mCasing;
     protected int mCraftingTier = 0;
     protected int mFocusingTier = 0;
+    protected int mMaxParallel = 0;
     private boolean mFluidMode = false, doFermium = false, doNeptunium = false;
     private static final Fluid mNeptunium = ELEMENT.getInstance().NEPTUNIUM.getPlasma();
     private static final Fluid mFermium = ELEMENT.getInstance().FERMIUM.getPlasma();
@@ -483,6 +484,7 @@ public class GregtechMetaTileEntity_QuantumForceTransformer
                     }
                 }
 
+                mMaxParallel = maxParallel;
                 doFermium = false;
                 doNeptunium = false;
 
@@ -597,7 +599,8 @@ public class GregtechMetaTileEntity_QuantumForceTransformer
         }
 
         if (runningTick % 20 == 0) {
-            int amount = (int) (getFocusingTier() * 4 * Math.sqrt(processingLogic.getCurrentParallels()));
+            int amount = (int) (getFocusingTier() * 4
+                    * Math.sqrt(Math.min(mMaxParallel, processingLogic.getCurrentParallels())));
             if (doFermium) {
                 if (!drain(mFermiumHatch, new FluidStack(mFermium, amount), true)) {
                     doFermium = false;
@@ -756,6 +759,7 @@ public class GregtechMetaTileEntity_QuantumForceTransformer
         aNBT.setBoolean("mFluidMode", mFluidMode);
         aNBT.setBoolean("doFermium", doFermium);
         aNBT.setBoolean("doNeptunium", doNeptunium);
+        aNBT.setInteger("mMaxParallel", mMaxParallel);
         super.saveNBTData(aNBT);
     }
 
@@ -771,6 +775,7 @@ public class GregtechMetaTileEntity_QuantumForceTransformer
         mFluidMode = aNBT.getBoolean("mFluidMode");
         doFermium = aNBT.getBoolean("doFermium");
         doNeptunium = aNBT.getBoolean("doNeptunium");
+        mMaxParallel = aNBT.getInteger("mMaxParallel");
     }
 
     @Override

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/GregtechMetaTileEntity_QuantumForceTransformer.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/GregtechMetaTileEntity_QuantumForceTransformer.java
@@ -487,14 +487,10 @@ public class GregtechMetaTileEntity_QuantumForceTransformer
                 doNeptunium = false;
 
                 if (recipe.mSpecialValue <= getFocusingTier()) {
-                    if (mFermiumHatch != null && mFermiumHatch.getFluid() != null
-                            && mFermiumHatch.getFluid().getFluid() != null
-                            && mFermiumHatch.getFluid().getFluid().equals(mFermium)) {
+                    if (drain(mFermiumHatch, new FluidStack(mFermium, 1), false)) {
                         doFermium = true;
                     }
-                    if (mNeptuniumHatch != null && mNeptuniumHatch.getFluid() != null
-                            && mNeptuniumHatch.getFluid().getFluid() != null
-                            && mNeptuniumHatch.getFluid().getFluid().equals(mNeptunium)) {
+                    if (drain(mNeptuniumHatch, new FluidStack(mNeptunium, 1), false)) {
                         doNeptunium = true;
                     }
                 }
@@ -603,8 +599,7 @@ public class GregtechMetaTileEntity_QuantumForceTransformer
         if (runningTick % 20 == 0) {
             int amount = (int) (getFocusingTier() * 4 * Math.sqrt(processingLogic.getCurrentParallels()));
             if (doFermium) {
-                FluidStack tLiquid = mFermiumHatch.drain(amount, true);
-                if (tLiquid == null || tLiquid.amount < amount) {
+                if (!drain(mFermiumHatch, new FluidStack(mFermium, amount), true)) {
                     doFermium = false;
                     criticalStopMachine();
                     return false;
@@ -612,8 +607,7 @@ public class GregtechMetaTileEntity_QuantumForceTransformer
             }
 
             if (doNeptunium) {
-                FluidStack tLiquid = mNeptuniumHatch.drain(amount, true);
-                if (tLiquid == null || tLiquid.amount < amount) {
+                if (!drain(mNeptuniumHatch, new FluidStack(mNeptunium, amount), true)) {
                     doNeptunium = false;
                     criticalStopMachine();
                     return false;


### PR DESCRIPTION
- Finds programmed circuit in input bus correctly. Close [#15224](https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/15224)
- Updates machine tier without breaking controller. Close [#13975](https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/13975)
- No longer requires 1+ input busses and 1+ input hatches. Fix the similar issue to [#14739](https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/14739)
- Checks structure every 30 sec. Partial fix for [#15392](https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/15392)
- Plasma hatches support ME input hatches
- Avoids integer overflow when calculating outputs
- Plasma consumption will only be affected by original parallel
- Better structure info 