### PR TITLE
Fix broken gas in 2 recipes

### DIFF
--- a/src/main/java/gtPlusPlus/core/recipe/RECIPES_GREGTECH.java
+++ b/src/main/java/gtPlusPlus/core/recipe/RECIPES_GREGTECH.java
@@ -135,7 +135,7 @@ public class RECIPES_GREGTECH {
         // Advanced method for Nitric Acid Production
         CORE.RA.addChemicalPlantRecipe(
                 new ItemStack[] { CI.getNumberedAdvancedCircuit(17), CI.getPinkCatalyst(0), },
-                new FluidStack[] { Materials.NitrogenDioxide.getFluid(4000L), FluidUtils.getAir(4000),
+                new FluidStack[] { Materials.NitrogenDioxide.getGas(4000L), FluidUtils.getAir(4000),
                         FluidUtils.getWater(2000), },
                 new ItemStack[] {},
                 new FluidStack[] { FluidUtils.getFluidStack("nitricacid", 4000), },
@@ -173,10 +173,10 @@ public class RECIPES_GREGTECH {
         // 3NO2 + H2O = 2HNO3 + NO
         CORE.RA.addChemicalPlantRecipe(
                 new ItemStack[] { CI.getNumberedAdvancedCircuit(16), CI.getPinkCatalyst(0), },
-                new FluidStack[] { Materials.NitrogenDioxide.getFluid(3000L), FluidUtils.getDistilledWater(1000) },
+                new FluidStack[] { Materials.NitrogenDioxide.getGas(3000L), FluidUtils.getDistilledWater(1000) },
                 new ItemStack[] {},
                 new FluidStack[] { FluidUtils.getFluidStack("nitricacid", 2000),
-                        Materials.NitricOxide.getFluid(1000L), },
+                        Materials.NitricOxide.getGas(1000L), },
                 10 * 20,
                 480,
                 2);

--- a/src/main/java/gtPlusPlus/core/recipe/RECIPES_GREGTECH.java
+++ b/src/main/java/gtPlusPlus/core/recipe/RECIPES_GREGTECH.java
@@ -175,8 +175,7 @@ public class RECIPES_GREGTECH {
                 new ItemStack[] { CI.getNumberedAdvancedCircuit(16), CI.getPinkCatalyst(0), },
                 new FluidStack[] { Materials.NitrogenDioxide.getGas(3000L), FluidUtils.getDistilledWater(1000) },
                 new ItemStack[] {},
-                new FluidStack[] { FluidUtils.getFluidStack("nitricacid", 2000),
-                        Materials.NitricOxide.getGas(1000L), },
+                new FluidStack[] { FluidUtils.getFluidStack("nitricacid", 2000), Materials.NitricOxide.getGas(1000L), },
                 10 * 20,
                 480,
                 2);


### PR DESCRIPTION
Just a fix for a bug from https://github.com/GTNewHorizons/GTplusplus/pull/739.

These two materials are gasses, fluids.

fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/15393.