### PR TITLE
Enable perfect OC on the matter fabrication CPU recycler mode

### DIFF
--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/GregtechMetaTileEntity_MassFabricator.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/GregtechMetaTileEntity_MassFabricator.java
@@ -284,7 +284,7 @@ public class GregtechMetaTileEntity_MassFabricator
     @Override
     protected void setupProcessingLogic(ProcessingLogic logic) {
         super.setupProcessingLogic(logic);
-        logic.setOverclock(mMode == MODE_SCRAP ? 1 : 2, 2);
+        logic.enablePerfectOverclock();
     }
 
     @Override


### PR DESCRIPTION
Enables perfect OC for the recycler mode of the matter fabrication CPU.
Currently this mode is completely unusable on large scale as the recyclers are 1. way too slow and 2. far too power hungry to be worth it.
Enabling perfect OC for this mode fixes both of those issues and makes using UUA viable (granted one can supply the necessary items for scrap production)
![image](https://github.com/GTNewHorizons/GTplusplus/assets/93287602/5b10d6dd-6c8b-4abd-a96d-e4a386aa6913)
https://docs.google.com/spreadsheets/d/1YxpXsn6DdMKQ2Kg9punc7zUSOACXb-F53B6kf6XLwTk/edit?usp=sharing