### PR TITLE
Add alternate recipes for neptunium and fermium plasma

### DIFF
--- a/src/main/java/gtPlusPlus/xmod/gregtech/loaders/recipe/RecipeLoader_ChemicalSkips.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/loaders/recipe/RecipeLoader_ChemicalSkips.java
@@ -342,18 +342,18 @@ public class RecipeLoader_ChemicalSkips {
 
         // MK5 versions
         GT_Values.RA.addFusionReactorRecipe(
-                new FluidStack[] { new FluidStack(ELEMENT.getInstance().XENON.getPlasma(), 144),
-                        Materials.Yttrium.getMolten(144) },
-                new FluidStack[] { new FluidStack(ELEMENT.getInstance().NEPTUNIUM.getPlasma(), 144) },
-                3 * SECONDS + 4 * TICKS,
+                new FluidStack[] { new FluidStack(ELEMENT.getInstance().XENON.getPlasma(), 288),
+                        Materials.Yttrium.getMolten(288) },
+                new FluidStack[] { new FluidStack(ELEMENT.getInstance().NEPTUNIUM.getPlasma(), 288) },
+                1 * SECONDS + 12 * TICKS,
                 (int) TierEU.RECIPE_UEV,
                 1_000_000_000);
 
         GT_Values.RA.addFusionReactorRecipe(
-                new FluidStack[] { new FluidStack(ELEMENT.STANDALONE.FORCE.getPlasma(), 144),
-                        Materials.Rubidium.getMolten(144) },
-                new FluidStack[] { new FluidStack(ELEMENT.getInstance().FERMIUM.getPlasma(), 144) },
-                3 * SECONDS + 4 * TICKS,
+                new FluidStack[] { new FluidStack(ELEMENT.STANDALONE.FORCE.getPlasma(), 288),
+                        Materials.Rubidium.getMolten(288) },
+                new FluidStack[] { new FluidStack(ELEMENT.getInstance().FERMIUM.getPlasma(), 288) },
+                1 * SECONDS + 12 * TICKS,
                 (int) TierEU.RECIPE_UEV,
                 1_000_000_000);
     }

--- a/src/main/java/gtPlusPlus/xmod/gregtech/loaders/recipe/RecipeLoader_ChemicalSkips.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/loaders/recipe/RecipeLoader_ChemicalSkips.java
@@ -8,6 +8,7 @@ import static gregtech.api.enums.Mods.NewHorizonsCoreMod;
 import static gregtech.api.recipe.RecipeMaps.assemblerRecipes;
 import static gregtech.api.util.GT_ModHandler.getModItem;
 import static gregtech.api.util.GT_RecipeBuilder.SECONDS;
+import static gregtech.api.util.GT_RecipeBuilder.TICKS;
 
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.fluids.FluidStack;
@@ -337,6 +338,23 @@ public class RecipeLoader_ChemicalSkips {
                 new FluidStack[] { new FluidStack(ELEMENT.getInstance().FERMIUM.getPlasma(), 100) },
                 30 * 20,
                 (int) TierEU.RECIPE_UHV,
+                1_000_000_000);
+
+        // MK5 versions
+        GT_Values.RA.addFusionReactorRecipe(
+                new FluidStack[] { new FluidStack(ELEMENT.getInstance().XENON.getPlasma(), 144),
+                        Materials.Yttrium.getMolten(144) },
+                new FluidStack[] { new FluidStack(ELEMENT.getInstance().NEPTUNIUM.getPlasma(), 144) },
+                3 * SECONDS + 4 * TICKS,
+                (int) TierEU.RECIPE_UEV,
+                1_000_000_000);
+
+        GT_Values.RA.addFusionReactorRecipe(
+                new FluidStack[] { new FluidStack(ELEMENT.STANDALONE.FORCE.getPlasma(), 144),
+                        Materials.Rubidium.getMolten(144) },
+                new FluidStack[] { new FluidStack(ELEMENT.getInstance().FERMIUM.getPlasma(), 144) },
+                3 * SECONDS + 4 * TICKS,
+                (int) TierEU.RECIPE_UEV,
                 1_000_000_000);
     }
 


### PR DESCRIPTION
Adds alternate higher tier recipes for neptunium and fermium plasma which are faster than their mk4 counterparts but also require part of the fusion chain, adding complexity in return.
These two plasmas are notoriously slow currently and the proposed alternate recipes aim to make their production less of a slog without making them free.

Neptunium:
![image](https://github.com/GTNewHorizons/GTplusplus/assets/93287602/7dcb1a3d-ab72-4d49-9840-a269047e2e53)
Fermium:
![image](https://github.com/GTNewHorizons/GTplusplus/assets/93287602/03339c69-4094-4701-84f3-8b2df393c0c9)
