### PR TITLE
Free casings Matter Fabrication CPU

### DIFF
--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/GregtechMetaTileEntity_MassFabricator.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/GregtechMetaTileEntity_MassFabricator.java
@@ -102,7 +102,7 @@ public class GregtechMetaTileEntity_MassFabricator
                 .addInfo("Produces UU-A, UU-M & Scrap").addInfo("Change mode with screwdriver")
                 .addPollutionAmount(getPollutionPerSecond(null)).addSeparator().beginStructureBlock(5, 4, 5, true)
                 .addController("Front Center").addCasingInfoMin(mCasingName3, 9, false)
-                .addCasingInfoMin(mCasingName2, 24, false).addCasingInfoMin(mCasingName1, 40, false)
+                .addCasingInfoMin(mCasingName2, 24, false).addCasingInfoMin(mCasingName1, 36, false)
                 .addInputBus("Any Casing", 1).addOutputBus("Any Casing", 1).addInputHatch("Any Casing", 1)
                 .addOutputHatch("Any Casing", 1).addEnergyHatch("Any Casing", 1).addMaintenanceHatch("Any Casing", 1)
                 .addMufflerHatch("Any Casing", 1).toolTipFinisher(CORE.GT_Tooltip_Builder.get());
@@ -192,7 +192,7 @@ public class GregtechMetaTileEntity_MassFabricator
     @Override
     public boolean checkMachine(IGregTechTileEntity aBaseMetaTileEntity, ItemStack aStack) {
         mCasing = 0;
-        return checkPiece(mName, 2, 3, 0) && mCasing >= 40 && checkHatch();
+        return checkPiece(mName, 2, 3, 0) && mCasing >= 36 && checkHatch();
     }
 
     @Override


### PR DESCRIPTION
now you need 36 casing (36<-40)
we need it for normal fit 8 Energy Hatches with Maintenance Hatch
 befor it you could only put 6 and without the Maintenance Hatch
6 was not enough somtimes so for prewenting random turn -offing utilized Machine Controller Cover , and with it and without Maintenance Hatch after some "Problems"   it went into an on/off cycle.
1)before :
![image](https://github.com/GTNewHorizons/GTplusplus/assets/35747549/e09b3b6a-4b19-45f6-93db-5614ac913316)
2) after :
![image](https://github.com/GTNewHorizons/GTplusplus/assets/35747549/4d1cb3e4-b062-4f0a-89fc-ec0aa3505678)
