### PR TITLE
Let remainingFlow become 125% of realOptFlow, rather than raw optimal…

### DIFF
--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/turbines/GT_MTE_LargeTurbine_Gas.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/turbines/GT_MTE_LargeTurbine_Gas.java
@@ -107,7 +107,7 @@ public class GT_MTE_LargeTurbine_Gas extends GregtechMetaTileEntity_LargerTurbin
     }
 
     @Override
-    int fluidIntoPower(ArrayList<FluidStack> aFluids, long aOptFlow, int aBaseEff, float[] flowMultipliers) {
+    long fluidIntoPower(ArrayList<FluidStack> aFluids, long aOptFlow, int aBaseEff, float[] flowMultipliers) {
         if (aFluids.size() >= 1) {
             int tEU = 0;
             int actualOptimalFlow = 0;

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/turbines/GT_MTE_LargeTurbine_Plasma.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/turbines/GT_MTE_LargeTurbine_Plasma.java
@@ -182,7 +182,7 @@ public class GT_MTE_LargeTurbine_Plasma extends GregtechMetaTileEntity_LargerTur
                 fuelValue = getFuelValue(new FluidStack(tFluids.get(0), 0));
             }
             float magicValue = (fuelValue * 0.005f) * (fuelValue * 0.005f);
-            long efficiencyLoss = (long) Math.min(1.0f, magicValue / euPerTurbine);
+            float efficiencyLoss = Math.min(1.0f, magicValue / euPerTurbine);
             newPower *= efficiencyLoss;
 
             long difference = newPower - this.lEUt; // difference between current output and new output

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/turbines/GT_MTE_LargeTurbine_Plasma.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/turbines/GT_MTE_LargeTurbine_Plasma.java
@@ -172,7 +172,7 @@ public class GT_MTE_LargeTurbine_Plasma extends GregtechMetaTileEntity_LargerTur
             }
 
             // How much the turbine should be producing with this flow
-            int newPower = fluidIntoPower(tFluids, optFlow, baseEff, flowMultipliers);
+            long newPower = fluidIntoPower(tFluids, optFlow, baseEff, flowMultipliers);
 
             // Reduce produced power depending on the ratio between fuel value and turbine EU/t with the following
             // formula:
@@ -182,7 +182,7 @@ public class GT_MTE_LargeTurbine_Plasma extends GregtechMetaTileEntity_LargerTur
                 fuelValue = getFuelValue(new FluidStack(tFluids.get(0), 0));
             }
             float magicValue = (fuelValue * 0.005f) * (fuelValue * 0.005f);
-            float efficiencyLoss = Math.min(1.0f, magicValue / euPerTurbine);
+            long efficiencyLoss = (long) Math.min(1.0f, magicValue / euPerTurbine);
             newPower *= efficiencyLoss;
 
             long difference = newPower - this.lEUt; // difference between current output and new output
@@ -218,7 +218,7 @@ public class GT_MTE_LargeTurbine_Plasma extends GregtechMetaTileEntity_LargerTur
     }
 
     @Override
-    int fluidIntoPower(ArrayList<FluidStack> aFluids, long aOptFlow, int aBaseEff, float[] flowMultipliers) {
+    long fluidIntoPower(ArrayList<FluidStack> aFluids, long aOptFlow, int aBaseEff, float[] flowMultipliers) {
         if (aFluids.size() >= 1) {
             aOptFlow *= 800; // CHANGED THINGS HERE, check recipe runs once per 20 ticks
             int tEU = 0;

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/turbines/GT_MTE_LargeTurbine_SCSteam.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/turbines/GT_MTE_LargeTurbine_SCSteam.java
@@ -61,7 +61,9 @@ public class GT_MTE_LargeTurbine_SCSteam extends GregtechMetaTileEntity_LargerTu
         int flow = 0;
         // Variable required outside of loop for
         // multi-hatch scenarios.
-        this.realOptFlow = (double) aOptFlow * (double) flowMultipliers[0];
+        this.realOptFlow = aOptFlow;
+        // this.realOptFlow = (double) aOptFlow * (double) flowMultipliers[0];
+        // Will there be an multiplier for SC?
         int remainingFlow = MathUtils.safeInt((long) (realOptFlow * 1.25f)); // Allowed to use up to
         // 125% of optimal flow.
 

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/turbines/GT_MTE_LargeTurbine_SCSteam.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/turbines/GT_MTE_LargeTurbine_SCSteam.java
@@ -59,8 +59,9 @@ public class GT_MTE_LargeTurbine_SCSteam extends GregtechMetaTileEntity_LargerTu
         int tEU = 0;
         int totalFlow = 0; // Byproducts are based on actual flow
         int flow = 0;
-        int remainingFlow = MathUtils.safeInt((long) (aOptFlow * 1.25f)); // Allowed to use up to 125% of optimal flow.
-                                                                          // Variable required outside of loop for
+        int remainingFlow = MathUtils.safeInt((long) (aOptFlow * 1.25f * flowMultipliers[0])); // Allowed to use up to
+                                                                                               // 125% of optimal flow.
+        // Variable required outside of loop for
         // multi-hatch scenarios.
         this.realOptFlow = (double) aOptFlow * (double) flowMultipliers[0];
 
@@ -78,8 +79,8 @@ public class GT_MTE_LargeTurbine_SCSteam extends GregtechMetaTileEntity_LargerTu
         if (totalFlow <= 0) return 0;
         tEU = totalFlow;
         addOutput(GT_ModHandler.getSteam(totalFlow));
-        if (totalFlow != aOptFlow) {
-            float efficiency = 1.0f - Math.abs((totalFlow - aOptFlow) / (float) aOptFlow);
+        if (totalFlow != realOptFlow) {
+            float efficiency = 1.0f - Math.abs((totalFlow - (float) realOptFlow) / (float) realOptFlow);
             // if(totalFlow>aOptFlow){efficiency = 1.0f;}
             tEU *= efficiency;
             tEU = Math.max(1, MathUtils.safeInt((long) tEU * (long) aBaseEff / 10000L));

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/turbines/GT_MTE_LargeTurbine_SCSteam.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/turbines/GT_MTE_LargeTurbine_SCSteam.java
@@ -55,15 +55,15 @@ public class GT_MTE_LargeTurbine_SCSteam extends GregtechMetaTileEntity_LargerTu
     }
 
     @Override
-    int fluidIntoPower(ArrayList<FluidStack> aFluids, long aOptFlow, int aBaseEff, float[] flowMultipliers) {
+    long fluidIntoPower(ArrayList<FluidStack> aFluids, long aOptFlow, int aBaseEff, float[] flowMultipliers) {
         int tEU = 0;
         int totalFlow = 0; // Byproducts are based on actual flow
         int flow = 0;
-        int remainingFlow = MathUtils.safeInt((long) (aOptFlow * 1.25f * flowMultipliers[0])); // Allowed to use up to
-                                                                                               // 125% of optimal flow.
         // Variable required outside of loop for
         // multi-hatch scenarios.
         this.realOptFlow = (double) aOptFlow * (double) flowMultipliers[0];
+        int remainingFlow = MathUtils.safeInt((long) (realOptFlow * 1.25f)); // Allowed to use up to
+        // 125% of optimal flow.
 
         storedFluid = 0;
         FluidStack tSCSteam = FluidRegistry.getFluidStack("supercriticalsteam", 1);
@@ -88,7 +88,7 @@ public class GT_MTE_LargeTurbine_SCSteam extends GregtechMetaTileEntity_LargerTu
             tEU = MathUtils.safeInt((long) tEU * (long) aBaseEff / 10000L);
         }
 
-        return (int) Math.min(tEU * 100L, Integer.MAX_VALUE);
+        return tEU * 100L;
     }
 
     @Override

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/turbines/GT_MTE_LargeTurbine_SHSteam.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/turbines/GT_MTE_LargeTurbine_SHSteam.java
@@ -77,13 +77,14 @@ public class GT_MTE_LargeTurbine_SHSteam extends GregtechMetaTileEntity_LargerTu
                 aBaseEff *= 0.75f;
             }
         }
-        int tEU = 0;
+        // prevent overflow like that in SC Steam
+        long tEU = 0;
         int totalFlow = 0; // Byproducts are based on actual flow
         int flow = 0;
 
         // Variable required outside of loop for
         // multi-hatch scenarios.
-        this.realOptFlow = (double) aOptFlow * (double) flowMultipliers[0];
+        this.realOptFlow = aOptFlow * flowMultipliers[0];
 
         int remainingFlow = MathUtils.safeInt((long) (realOptFlow * 1.25f)); // Allowed to use up to
         // 125% of optimal flow.
@@ -118,9 +119,9 @@ public class GT_MTE_LargeTurbine_SHSteam extends GregtechMetaTileEntity_LargerTu
             float efficiency = 1.0f - Math.abs((totalFlow - (float) realOptFlow) / (float) realOptFlow);
             // if(totalFlow>aOptFlow){efficiency = 1.0f;}
             tEU *= efficiency;
-            tEU = Math.max(1, MathUtils.safeInt((long) tEU * (long) aBaseEff / 10000L));
+            tEU = Math.max(1, tEU * aBaseEff / 10000L);
         } else {
-            tEU = MathUtils.safeInt((long) tEU * (long) aBaseEff / 10000L);
+            tEU = tEU * aBaseEff / 10000L;
         }
 
         return tEU;

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/turbines/GT_MTE_LargeTurbine_SHSteam.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/turbines/GT_MTE_LargeTurbine_SHSteam.java
@@ -112,7 +112,7 @@ public class GT_MTE_LargeTurbine_SHSteam extends GregtechMetaTileEntity_LargerTu
         if (totalFlow <= 0) return 0;
         tEU = totalFlow;
         addOutput(GT_ModHandler.getSteam(totalFlow));
-        if (totalFlow != aOptFlow) {
+        if (totalFlow != realOptFlow) {
             float efficiency = 1.0f - Math.abs((totalFlow - (float) realOptFlow) / (float) realOptFlow);
             // if(totalFlow>aOptFlow){efficiency = 1.0f;}
             tEU *= efficiency;

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/turbines/GT_MTE_LargeTurbine_SHSteam.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/turbines/GT_MTE_LargeTurbine_SHSteam.java
@@ -64,7 +64,7 @@ public class GT_MTE_LargeTurbine_SHSteam extends GregtechMetaTileEntity_LargerTu
     }
 
     @Override
-    int fluidIntoPower(ArrayList<FluidStack> aFluids, long aOptFlow, int aBaseEff, float[] flowMultipliers) {
+    long fluidIntoPower(ArrayList<FluidStack> aFluids, long aOptFlow, int aBaseEff, float[] flowMultipliers) {
         if (looseFit) {
             aOptFlow *= 4;
             if (aBaseEff > 10000) {
@@ -80,11 +80,13 @@ public class GT_MTE_LargeTurbine_SHSteam extends GregtechMetaTileEntity_LargerTu
         int tEU = 0;
         int totalFlow = 0; // Byproducts are based on actual flow
         int flow = 0;
-        int remainingFlow = MathUtils.safeInt((long) (aOptFlow * flowMultipliers[0] * 1.25f)); // Allowed to use up to
-                                                                                               // 125% of optimal flow.
+
         // Variable required outside of loop for
         // multi-hatch scenarios.
         this.realOptFlow = (double) aOptFlow * (double) flowMultipliers[0];
+
+        int remainingFlow = MathUtils.safeInt((long) (realOptFlow * 1.25f)); // Allowed to use up to
+        // 125% of optimal flow.
 
         storedFluid = 0;
         for (int i = 0; i < aFluids.size() && remainingFlow > 0; i++) {

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/turbines/GT_MTE_LargeTurbine_SHSteam.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/turbines/GT_MTE_LargeTurbine_SHSteam.java
@@ -119,7 +119,7 @@ public class GT_MTE_LargeTurbine_SHSteam extends GregtechMetaTileEntity_LargerTu
             float efficiency = 1.0f - Math.abs((totalFlow - (float) realOptFlow) / (float) realOptFlow);
             // if(totalFlow>aOptFlow){efficiency = 1.0f;}
             tEU *= efficiency;
-            tEU = Math.max(1, tEU * aBaseEff / 10000L);
+            tEU = Math.max(1L, tEU * aBaseEff / 10000L);
         } else {
             tEU = tEU * aBaseEff / 10000L;
         }

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/turbines/GT_MTE_LargeTurbine_SHSteam.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/turbines/GT_MTE_LargeTurbine_SHSteam.java
@@ -80,8 +80,9 @@ public class GT_MTE_LargeTurbine_SHSteam extends GregtechMetaTileEntity_LargerTu
         int tEU = 0;
         int totalFlow = 0; // Byproducts are based on actual flow
         int flow = 0;
-        int remainingFlow = MathUtils.safeInt((long) (aOptFlow * 1.25f)); // Allowed to use up to 125% of optimal flow.
-                                                                          // Variable required outside of loop for
+        int remainingFlow = MathUtils.safeInt((long) (aOptFlow * flowMultipliers[0] * 1.25f)); // Allowed to use up to
+                                                                                               // 125% of optimal flow.
+        // Variable required outside of loop for
         // multi-hatch scenarios.
         this.realOptFlow = (double) aOptFlow * (double) flowMultipliers[0];
 
@@ -112,7 +113,7 @@ public class GT_MTE_LargeTurbine_SHSteam extends GregtechMetaTileEntity_LargerTu
         tEU = totalFlow;
         addOutput(GT_ModHandler.getSteam(totalFlow));
         if (totalFlow != aOptFlow) {
-            float efficiency = 1.0f - Math.abs((totalFlow - aOptFlow) / (float) aOptFlow);
+            float efficiency = 1.0f - Math.abs((totalFlow - (float) realOptFlow) / (float) realOptFlow);
             // if(totalFlow>aOptFlow){efficiency = 1.0f;}
             tEU *= efficiency;
             tEU = Math.max(1, MathUtils.safeInt((long) tEU * (long) aBaseEff / 10000L));

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/turbines/GT_MTE_LargeTurbine_Steam.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/turbines/GT_MTE_LargeTurbine_Steam.java
@@ -86,13 +86,14 @@ public class GT_MTE_LargeTurbine_Steam extends GregtechMetaTileEntity_LargerTurb
                 aBaseEff *= 0.75f;
             }
         }
-        int tEU = 0;
+        // prevent overflow like that in SC Steam
+        long tEU = 0;
         int totalFlow = 0; // Byproducts are based on actual flow
         int flow = 0;
 
         // Variable required outside of loop for
         // multi-hatch scenarios.
-        this.realOptFlow = (double) aOptFlow * (double) flowMultipliers[0];
+        this.realOptFlow = aOptFlow * flowMultipliers[0];
 
         int remainingFlow = MathUtils.safeInt((long) (realOptFlow * 1.25f)); // Allowed to
         // use up to
@@ -129,9 +130,9 @@ public class GT_MTE_LargeTurbine_Steam extends GregtechMetaTileEntity_LargerTurb
             float efficiency = 1.0f - Math.abs((totalFlow - (float) realOptFlow) / (float) realOptFlow);
             // if(totalFlow>aOptFlow){efficiency = 1.0f;}
             tEU *= efficiency;
-            tEU = Math.max(1, MathUtils.safeInt((long) tEU * (long) aBaseEff / 20000L));
+            tEU = Math.max(1, tEU * aBaseEff / 20000L);
         } else {
-            tEU = MathUtils.safeInt((long) tEU * (long) aBaseEff / 20000L);
+            tEU = tEU * aBaseEff / 20000L;
         }
 
         return tEU;

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/turbines/GT_MTE_LargeTurbine_Steam.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/turbines/GT_MTE_LargeTurbine_Steam.java
@@ -123,7 +123,7 @@ public class GT_MTE_LargeTurbine_Steam extends GregtechMetaTileEntity_LargerTurb
         tEU = totalFlow;
         int waterToOutput = useWater(totalFlow / 160.0f);
         addOutput(GT_ModHandler.getDistilledWater(waterToOutput));
-        if (totalFlow != aOptFlow) {
+        if (totalFlow != realOptFlow) {
             float efficiency = 1.0f - Math.abs((totalFlow - (float) realOptFlow) / (float) realOptFlow);
             // if(totalFlow>aOptFlow){efficiency = 1.0f;}
             tEU *= efficiency;

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/turbines/GT_MTE_LargeTurbine_Steam.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/turbines/GT_MTE_LargeTurbine_Steam.java
@@ -89,8 +89,11 @@ public class GT_MTE_LargeTurbine_Steam extends GregtechMetaTileEntity_LargerTurb
         int tEU = 0;
         int totalFlow = 0; // Byproducts are based on actual flow
         int flow = 0;
-        int remainingFlow = MathUtils.safeInt((long) (aOptFlow * 1.25f)); // Allowed to use up to 125% of optimal flow.
-                                                                          // Variable required outside of loop for
+        int remainingFlow = MathUtils.safeInt((long) (aOptFlow * (double) flowMultipliers[0] * 1.25f)); // Allowed to
+                                                                                                        // use up to
+                                                                                                        // 125% of
+                                                                                                        // optimal flow.
+        // Variable required outside of loop for
         // multi-hatch scenarios.
         this.realOptFlow = (double) aOptFlow * (double) flowMultipliers[0];
 
@@ -121,7 +124,7 @@ public class GT_MTE_LargeTurbine_Steam extends GregtechMetaTileEntity_LargerTurb
         int waterToOutput = useWater(totalFlow / 160.0f);
         addOutput(GT_ModHandler.getDistilledWater(waterToOutput));
         if (totalFlow != aOptFlow) {
-            float efficiency = 1.0f - Math.abs((totalFlow - aOptFlow) / (float) aOptFlow);
+            float efficiency = 1.0f - Math.abs((totalFlow - (float) realOptFlow) / (float) realOptFlow);
             // if(totalFlow>aOptFlow){efficiency = 1.0f;}
             tEU *= efficiency;
             tEU = Math.max(1, MathUtils.safeInt((long) tEU * (long) aBaseEff / 20000L));

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/turbines/GT_MTE_LargeTurbine_Steam.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/turbines/GT_MTE_LargeTurbine_Steam.java
@@ -130,7 +130,7 @@ public class GT_MTE_LargeTurbine_Steam extends GregtechMetaTileEntity_LargerTurb
             float efficiency = 1.0f - Math.abs((totalFlow - (float) realOptFlow) / (float) realOptFlow);
             // if(totalFlow>aOptFlow){efficiency = 1.0f;}
             tEU *= efficiency;
-            tEU = Math.max(1, tEU * aBaseEff / 20000L);
+            tEU = Math.max(1L, tEU * aBaseEff / 20000L);
         } else {
             tEU = tEU * aBaseEff / 20000L;
         }

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/turbines/GT_MTE_LargeTurbine_Steam.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/turbines/GT_MTE_LargeTurbine_Steam.java
@@ -73,7 +73,7 @@ public class GT_MTE_LargeTurbine_Steam extends GregtechMetaTileEntity_LargerTurb
     }
 
     @Override
-    int fluidIntoPower(ArrayList<FluidStack> aFluids, long aOptFlow, int aBaseEff, float[] flowMultipliers) {
+    long fluidIntoPower(ArrayList<FluidStack> aFluids, long aOptFlow, int aBaseEff, float[] flowMultipliers) {
         if (looseFit) {
             aOptFlow *= 4;
             if (aBaseEff > 10000) {
@@ -89,13 +89,15 @@ public class GT_MTE_LargeTurbine_Steam extends GregtechMetaTileEntity_LargerTurb
         int tEU = 0;
         int totalFlow = 0; // Byproducts are based on actual flow
         int flow = 0;
-        int remainingFlow = MathUtils.safeInt((long) (aOptFlow * (double) flowMultipliers[0] * 1.25f)); // Allowed to
-                                                                                                        // use up to
-                                                                                                        // 125% of
-                                                                                                        // optimal flow.
+
         // Variable required outside of loop for
         // multi-hatch scenarios.
         this.realOptFlow = (double) aOptFlow * (double) flowMultipliers[0];
+
+        int remainingFlow = MathUtils.safeInt((long) (realOptFlow * 1.25f)); // Allowed to
+        // use up to
+        // 125% of
+        // optimal flow.
 
         storedFluid = 0;
         for (int i = 0; i < aFluids.size() && remainingFlow > 0; i++) { // loop through each hatch; extract inputs and

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/turbines/GregtechMetaTileEntity_LargerTurbineBase.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/turbines/GregtechMetaTileEntity_LargerTurbineBase.java
@@ -483,7 +483,7 @@ public abstract class GregtechMetaTileEntity_LargerTurbineBase extends
             }
 
             // How much the turbine should be producing with this flow
-            int newPower = fluidIntoPower(tFluids, optFlow, baseEff, flowMultipliers);
+            long newPower = fluidIntoPower(tFluids, optFlow, baseEff, flowMultipliers);
             long difference = newPower - this.lEUt; // difference between current output and new output
 
             // Magic numbers: can always change by at least 10 eu/t, but otherwise by at most 1 percent of the
@@ -553,7 +553,7 @@ public abstract class GregtechMetaTileEntity_LargerTurbineBase extends
         return (getFullTurbineAssemblies().size());
     }
 
-    abstract int fluidIntoPower(ArrayList<FluidStack> aFluids, long aOptFlow, int aBaseEff, float[] flowMultipliers);
+    abstract long fluidIntoPower(ArrayList<FluidStack> aFluids, long aOptFlow, int aBaseEff, float[] flowMultipliers);
 
     @Override
     public int getDamageToComponent(ItemStack aStack) {


### PR DESCRIPTION
… flow.

This can fix the inconsistance between optimal flow in tooltip and that in turbine.

When I try to use duranium huge turbine on my XL SC Turbine, I found that the actual output and steam consumption is far less than the calculation.
![93449a920eca9b8cf737b1ae74245a13](https://github.com/GTNewHorizons/GTplusplus/assets/57739338/e78e61a0-e678-47d6-9a32-6d5c41ac097f)
XL SC turbine outputs 6768000EU/t on server, but according to calculation, output is parallelism * optimal flow * efficiency%  * fuel value of SC steam. The optimal flow in XL SC turbine with duranium huge turbine inserted and fast mode enabled is 48 * single optimal flow = 4915200mb/t. The turbine efficiency is 235%, and fuel value of SC steam is 100EU/mb. So final output should be 4915200 * 2.35 * 100 = 115507200 EU/t.  Obviously it doesn't work as the description on turbine tooltip.

Through reading the code I found that 6768000 = 6400 * 1.25 * 2.35 * 100 * 48 * 0.75 (effiency when flow over optimal).
While 6400 is the original optimal flow of the turbine, and has different multipliers when used in different type of machine.
I found that the  variable realOptFlow uses that multiplier but remainingFlow doesn't, so the optimal flow is limited to original flow, rather than actual flow. Through this change I let the steam/HP/SC turbine behave as tooltip on turbine describes.

Output of SC turbine with duranium huge turbine after fix:
![de5c7bcfb085963fdbf7739c8ed4bc16](https://github.com/GTNewHorizons/GTplusplus/assets/57739338/8e565fbf-f9e2-4345-9ccb-e0c45bc06dd6)

