### PR TITLE
Enable input separation for the Cutting Factory.

### DIFF
--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/GregtechMetaTileEntity_IndustrialCuttingMachine.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/GregtechMetaTileEntity_IndustrialCuttingMachine.java
@@ -177,6 +177,11 @@ public class GregtechMetaTileEntity_IndustrialCuttingMachine extends
         return false;
     }
 
+    @Override
+    public boolean isInputSeparationEnabled() {
+        return true;
+    }
+
     public Block getCasingBlock() {
         return ModBlocks.blockCasings2Misc;
     }


### PR DESCRIPTION
Closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/15640.

Several materials have multiple different cutting recipes, usually one to make slabs (circuit 1) and one to make plates (circuit 3). This makes it possible to disambiguate between them by using different input buses with the multiblock. It is also future-proof in case more recipes like this get added.

For now separation is forced on; if anybody comes up with any realistic situation where one might explicitly want it *off*, I can make it toggleable.