### PR TITLE
Align fish centrifuge recipes with GT

### DIFF
--- a/src/main/java/gtPlusPlus/xmod/pamsharvest/fishtrap/FishTrapHandler.java
+++ b/src/main/java/gtPlusPlus/xmod/pamsharvest/fishtrap/FishTrapHandler.java
@@ -29,7 +29,7 @@ public class FishTrapHandler {
                                 ItemUtils.getItemStackOfAmountFromOreDict("dustTinyBone", 1))
                         .outputChances(10000, 1000).duration(20 * SECONDS).eut(2).addTo(maceratorRecipes);
                 GT_Values.RA.stdBuilder().itemInputs(ItemUtils.getItemStackOfAmountFromOreDict(itemName, 1))
-                        .fluidOutputs(FluidUtils.getFluidStack("methane", 96)).duration(19 * SECONDS).eut(5)
+                        .fluidOutputs(FluidUtils.getFluidStack("methane", 48)).duration(19 * SECONDS + 4 * TICKS).eut(5)
                         .addTo(centrifugeRecipes);
                 GT_Values.RA.stdBuilder().itemInputs(ItemUtils.getItemStackOfAmountFromOreDict(itemName, 1))
                         .fluidOutputs(FluidUtils.getFluidStack("fishoil", 50)).duration(16 * TICKS).eut(4)
@@ -43,7 +43,7 @@ public class FishTrapHandler {
                             ItemUtils.getItemStackOfAmountFromOreDict("dustTinyBone", 1))
                     .outputChances(10000, 1000).duration(20 * SECONDS).eut(2).addTo(maceratorRecipes);
             GT_Values.RA.stdBuilder().itemInputs(ItemUtils.getItemStackOfAmountFromOreDict(greenheartFish, 1))
-                    .fluidOutputs(FluidUtils.getFluidStack("methane", 96)).duration(19 * SECONDS).eut(5)
+                    .fluidOutputs(FluidUtils.getFluidStack("methane", 48)).duration(19 * SECONDS + 4 * TICKS).eut(5)
                     .addTo(centrifugeRecipes);
             GT_Values.RA.stdBuilder().itemInputs(ItemUtils.getItemStackOfAmountFromOreDict(greenheartFish, 1))
                     .fluidOutputs(FluidUtils.getFluidStack("fishoil", 50)).duration(16 * TICKS).eut(4)


### PR DESCRIPTION
Brings the fish centrifuge recipes in GT++ in line with the GT ones for fish/meat/etc.

closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/15567