### PR TITLE
Fixes for wireless chargers

### DIFF
--- a/src/main/java/gtPlusPlus/core/util/minecraft/PlayerUtils.java
+++ b/src/main/java/gtPlusPlus/core/util/minecraft/PlayerUtils.java
@@ -1,6 +1,5 @@
 package gtPlusPlus.core.util.minecraft;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -36,6 +35,12 @@ public class PlayerUtils {
         }
     }
 
+    public static List<EntityPlayerMP> getOnlinePlayers() {
+        final List<EntityPlayerMP> onlinePlayers = MinecraftServer.getServer()
+                .getConfigurationManager().playerEntityList;
+        return onlinePlayers;
+    }
+
     public static void messagePlayer(final EntityPlayer P, final String S) {
         gregtech.api.util.GT_Utility.sendChatToPlayer(P, S);
     }
@@ -46,12 +51,7 @@ public class PlayerUtils {
 
     public static EntityPlayer getPlayer(final String name) {
         try {
-            final List<EntityPlayer> i = new ArrayList<>();
-            for (EntityPlayerMP playerMP : (Iterable<EntityPlayerMP>) MinecraftServer.getServer()
-                    .getConfigurationManager().playerEntityList) {
-                i.add(playerMP);
-            }
-            for (final EntityPlayer temp : i) {
+            for (final EntityPlayer temp : getOnlinePlayers()) {
                 if (temp.getDisplayName().toLowerCase().equals(name.toLowerCase())) {
                     return temp;
                 }
@@ -64,8 +64,7 @@ public class PlayerUtils {
         if (parUUID == null) {
             return null;
         }
-        final List<EntityPlayerMP> allPlayers = MinecraftServer.getServer().getConfigurationManager().playerEntityList;
-        for (final EntityPlayerMP player : allPlayers) {
+        for (final EntityPlayerMP player : getOnlinePlayers()) {
             if (player.getUniqueID().equals(parUUID)) {
                 return player;
             }

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/helpers/ChargingHelper.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/helpers/ChargingHelper.java
@@ -137,15 +137,16 @@ public class ChargingHelper {
         }
     }
 
+    public static GregtechMetaWirelessCharger getEntry(BlockPos mPos) {
+        return mChargerMap.get(mPos);
+    }
+
     public static boolean addEntry(BlockPos mPos, GregtechMetaWirelessCharger mEntity) {
         if (mEntity == null) {
             return false;
         }
-        if (!mChargerMap.containsKey(mPos)) {
-            return mChargerMap.put(mPos, mEntity) == null;
-        } else {
-            return true;
-        }
+        mChargerMap.put(mPos, mEntity);
+        return true;
     }
 
     public static boolean removeEntry(BlockPos mPos, GregtechMetaWirelessCharger mEntity) {

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/helpers/ChargingHelper.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/helpers/ChargingHelper.java
@@ -14,12 +14,12 @@ import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.InventoryPlayer;
 import net.minecraft.inventory.IInventory;
 import net.minecraft.item.ItemStack;
-import net.minecraftforge.event.entity.living.LivingEvent.LivingUpdateEvent;
 
 import baubles.api.BaublesApi;
 import cofh.api.energy.IEnergyContainerItem;
 import cpw.mods.fml.common.eventhandler.EventPriority;
 import cpw.mods.fml.common.eventhandler.SubscribeEvent;
+import cpw.mods.fml.common.gameevent.TickEvent.ServerTickEvent;
 import gregtech.api.enums.GT_Values;
 import gregtech.api.util.GT_ModHandler;
 import gregtech.common.items.GT_MetaGenerated_Item_01;
@@ -31,6 +31,7 @@ import gtPlusPlus.api.objects.minecraft.BlockPos;
 import gtPlusPlus.core.util.Utils;
 import gtPlusPlus.core.util.math.MathUtils;
 import gtPlusPlus.core.util.minecraft.NBTUtils;
+import gtPlusPlus.core.util.minecraft.PlayerUtils;
 import gtPlusPlus.xmod.gregtech.common.tileentities.machines.basic.GregtechMetaWirelessCharger;
 import ic2.api.item.ElectricItem;
 import ic2.api.item.IElectricItem;
@@ -42,81 +43,74 @@ public class ChargingHelper {
     private int mTickTimer = 0;
     private static final int mTickMultiplier = 20;
 
-    // Called whenever the player is updated or ticked.
     @SubscribeEvent(priority = EventPriority.HIGHEST)
+    public void onServerTick(ServerTickEvent event) {
+        if (++mTickTimer % mTickMultiplier == 0) {
+            if (Utils.isServer()) {
+                for (EntityPlayer mPlayerMan : PlayerUtils.getOnlinePlayers()) {
+                    doPlayerChargeTick(mPlayerMan);
+                }
+            }
+        }
+    }
+
     @SuppressWarnings("unused")
-    public void onPlayerTick(LivingUpdateEvent event) {
+    private void doPlayerChargeTick(EntityPlayer mPlayerMan) {
         try {
-            if (event.entity != null && event.entityLiving != null) {
-                if (event.entityLiving instanceof EntityPlayer mPlayerMan) {
-                    if (Utils.isServer()) {
-                        mTickTimer++;
-                        if (mTickTimer % mTickMultiplier == 0) {
+            long mVoltage;
+            long mEuStored;
 
-                            long mVoltage;
-                            long mEuStored;
+            if (!mChargerMap.isEmpty() && mValidPlayers.containsKey(mPlayerMan.getDisplayName())) {
+                InventoryPlayer mPlayerInventory = mPlayerMan.inventory;
+                ItemStack[] mArmourContents = mPlayerInventory.armorInventory.clone();
+                ItemStack[] mInventoryContents = mPlayerInventory.mainInventory.clone();
+                ItemStack[] baubleSlots = null;
+                if (Baubles.isModLoaded()) {
+                    IInventory baubleInv = BaublesApi.getBaubles(mPlayerMan);
+                    if (baubleInv != null) {
+                        baubleSlots = new ItemStack[baubleInv.getSizeInventory()];
+                        for (int i = 0; i < baubleInv.getSizeInventory(); i++) {
+                            baubleSlots[i] = baubleInv.getStackInSlot(i);
+                        }
+                    }
+                }
 
-                            if (!mChargerMap.isEmpty() && mValidPlayers.containsKey(mPlayerMan.getDisplayName())) {
-                                InventoryPlayer mPlayerInventory = mPlayerMan.inventory;
-                                ItemStack[] mArmourContents = mPlayerInventory.armorInventory.clone();
-                                ItemStack[] mInventoryContents = mPlayerInventory.mainInventory.clone();
-                                ItemStack[] baubleSlots = null;
-                                if (Baubles.isModLoaded()) {
-                                    IInventory baubleInv = BaublesApi.getBaubles(mPlayerMan);
-                                    if (baubleInv != null) {
-                                        baubleSlots = new ItemStack[baubleInv.getSizeInventory()];
-                                        for (int i = 0; i < baubleInv.getSizeInventory(); i++) {
-                                            baubleSlots[i] = baubleInv.getStackInSlot(i);
-                                        }
-                                    }
+                for (GregtechMetaWirelessCharger mEntityTemp : mChargerMap.values()) {
+                    if (mEntityTemp != null) {
+                        if (mEntityTemp.getBaseMetaTileEntity() == null
+                                || !mEntityTemp.getBaseMetaTileEntity().isAllowedToWork())
+                            continue;
+                        if (mPlayerMan.getEntityWorld().provider.dimensionId == mEntityTemp.getDimensionID()) {
+                            mVoltage = mEntityTemp.maxEUInput();
+                            mEuStored = mEntityTemp.getEUVar();
+                            if (mVoltage > 0 && mEuStored >= mVoltage) {
+                                Map<String, UUID> LR = mEntityTemp.getLongRangeMap();
+                                Map<String, UUID> LO = mEntityTemp.getLocalMap();
+
+                                long mStartingEu = mEntityTemp.getEUVar();
+                                if (canCharge(mEntityTemp, mPlayerMan, LR, LO)) {
+                                    chargeItems(mEntityTemp, mArmourContents);
+                                    chargeItems(mEntityTemp, mInventoryContents);
+                                    chargeItems(mEntityTemp, baubleSlots);
                                 }
 
-                                for (GregtechMetaWirelessCharger mEntityTemp : mChargerMap.values()) {
-                                    if (mEntityTemp != null) {
-                                        if (mEntityTemp.getBaseMetaTileEntity() == null
-                                                || !mEntityTemp.getBaseMetaTileEntity().isAllowedToWork())
-                                            continue;
-                                        if (mPlayerMan.getEntityWorld().provider.dimensionId
-                                                == mEntityTemp.getDimensionID()) {
-                                            mVoltage = mEntityTemp.maxEUInput();
-                                            mEuStored = mEntityTemp.getEUVar();
-                                            if (mVoltage > 0 && mEuStored >= mVoltage) {
+                                if (mStartingEu - mEntityTemp.getEUVar() <= 0) {
+                                    long mMaxDistance;
+                                    if (mEntityTemp.getMode() == 0) {
+                                        mMaxDistance = (4 * GT_Values.V[mEntityTemp.getTier()]);
+                                    } else if (mEntityTemp.getMode() == 1) {
+                                        mMaxDistance = (mEntityTemp.getTier() * 10L);
+                                    } else {
+                                        mMaxDistance = (4 * GT_Values.V[mEntityTemp.getTier()] / 2);
+                                    }
+                                    double mDistance = calculateDistance(mEntityTemp, mPlayerMan);
+                                    long mVoltageCost = MathUtils.findPercentageOfInt(mMaxDistance, (float) mDistance);
 
-                                                Map<String, UUID> LR = mEntityTemp.getLongRangeMap();
-                                                Map<String, UUID> LO = mEntityTemp.getLocalMap();
-
-                                                long mStartingEu = mEntityTemp.getEUVar();
-                                                if (canCharge(mEntityTemp, mPlayerMan, LR, LO)) {
-                                                    chargeItems(mEntityTemp, mArmourContents);
-                                                    chargeItems(mEntityTemp, mInventoryContents);
-                                                    chargeItems(mEntityTemp, baubleSlots);
-                                                }
-
-                                                if (mStartingEu - mEntityTemp.getEUVar() <= 0) {
-                                                    long mMaxDistance;
-                                                    if (mEntityTemp.getMode() == 0) {
-                                                        mMaxDistance = (4 * GT_Values.V[mEntityTemp.getTier()]);
-                                                    } else if (mEntityTemp.getMode() == 1) {
-                                                        mMaxDistance = (mEntityTemp.getTier() * 10L);
-                                                    } else {
-                                                        mMaxDistance = (4 * GT_Values.V[mEntityTemp.getTier()] / 2);
-                                                    }
-                                                    double mDistance = calculateDistance(mEntityTemp, mPlayerMan);
-                                                    long mVoltageCost = MathUtils
-                                                            .findPercentageOfInt(mMaxDistance, (float) mDistance);
-
-                                                    if (mVoltageCost > 0) {
-                                                        if (mVoltageCost > mEntityTemp.maxEUInput()) {
-                                                            mEntityTemp.setEUVar(
-                                                                    (mEntityTemp.getEUVar()
-                                                                            - mEntityTemp.maxEUInput()));
-                                                        } else {
-                                                            mEntityTemp
-                                                                    .setEUVar((mEntityTemp.getEUVar() - mVoltageCost));
-                                                        }
-                                                    }
-                                                }
-                                            }
+                                    if (mVoltageCost > 0) {
+                                        if (mVoltageCost > mEntityTemp.maxEUInput()) {
+                                            mEntityTemp.setEUVar((mEntityTemp.getEUVar() - mEntityTemp.maxEUInput()));
+                                        } else {
+                                            mEntityTemp.setEUVar((mEntityTemp.getEUVar() - mVoltageCost));
                                         }
                                     }
                                 }

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/basic/GregtechMetaWirelessCharger.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/basic/GregtechMetaWirelessCharger.java
@@ -470,13 +470,13 @@ public class GregtechMetaWirelessCharger extends GregtechMetaTileEntity {
                 this.mCurrentDimension = aBaseMetaTileEntity.getWorld().provider.dimensionId;
             }
 
-            boolean mHasBeenMapped = this.equals(ChargingHelper.getEntry(getTileEntityPosition()));
-            if (!mHasBeenMapped && ChargingHelper.addEntry(getTileEntityPosition(), this)) {
-                mHasBeenMapped = true;
-            }
+            if (aTick % 20 == 0) {
+                boolean mHasBeenMapped = this.equals(ChargingHelper.getEntry(getTileEntityPosition()));
+                if (!mHasBeenMapped) {
+                    mHasBeenMapped = ChargingHelper.addEntry(getTileEntityPosition(), this);
+                }
 
-            if (aTick % 20 == 0 && mHasBeenMapped) {
-                if (!aBaseMetaTileEntity.getWorld().playerEntities.isEmpty()) {
+                if (mHasBeenMapped && !aBaseMetaTileEntity.getWorld().playerEntities.isEmpty()) {
                     for (Object mTempPlayer : aBaseMetaTileEntity.getWorld().playerEntities) {
                         if (mTempPlayer instanceof EntityPlayer || mTempPlayer instanceof EntityPlayerMP) {
                             EntityPlayer mTemp = (EntityPlayer) mTempPlayer;

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/basic/GregtechMetaWirelessCharger.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/basic/GregtechMetaWirelessCharger.java
@@ -28,7 +28,6 @@ import gtPlusPlus.xmod.gregtech.common.helpers.ChargingHelper;
 
 public class GregtechMetaWirelessCharger extends GregtechMetaTileEntity {
 
-    private boolean mHasBeenMapped = false;
     private int mCurrentDimension = 0;
     public int mMode = 0;
     public boolean mLocked = true;
@@ -471,6 +470,7 @@ public class GregtechMetaWirelessCharger extends GregtechMetaTileEntity {
                 this.mCurrentDimension = aBaseMetaTileEntity.getWorld().provider.dimensionId;
             }
 
+            boolean mHasBeenMapped = this.equals(ChargingHelper.getEntry(getTileEntityPosition()));
             if (!mHasBeenMapped && ChargingHelper.addEntry(getTileEntityPosition(), this)) {
                 mHasBeenMapped = true;
             }
@@ -654,15 +654,5 @@ public class GregtechMetaWirelessCharger extends GregtechMetaTileEntity {
     public void doExplosion(long aExplosionPower) {
         ChargingHelper.removeEntry(getTileEntityPosition(), this);
         super.doExplosion(aExplosionPower);
-    }
-
-    @Override
-    public void onPreTick(IGregTechTileEntity aBaseMetaTileEntity, long aTick) {
-        if (aBaseMetaTileEntity.isServerSide()) {
-            if (!mHasBeenMapped && ChargingHelper.addEntry(getTileEntityPosition(), this)) {
-                mHasBeenMapped = true;
-            }
-        }
-        super.onPreTick(aBaseMetaTileEntity, aTick);
     }
 }


### PR DESCRIPTION
Addresses Modpack issue [#14596](https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/14596)

The wireless charger stops working in single player when the player saves and quits to the title screen, then reopens the world. Closing and relaunching the client is the only way to fix this.

This happens because while the Wireless Charger object gets destroyed when the chunk is unloaded, that 'ghost' object remains in the static ChargingHelper. When the chunk is reloaded, a new wireless charger object is created, but is not added to the ChargingHelper because the 'ghost' object occupies the same position. This 'ghost' object is drained of energy but doesn't receive any energy so it runs out after a few ticks.

This fix replaces the old 'ghost' charger object with the new instance of the same charger.