### PR TITLE
Stocking input busses don't update texture on TGS

### DIFF
--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/GregtechMetaTileEntityTreeFarm.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/GregtechMetaTileEntityTreeFarm.java
@@ -111,10 +111,10 @@ public class GregtechMetaTileEntityTreeFarm extends GregtechMeta_MultiBlockBase<
                 .addInfo("Work time is fixed at 5 seconds").addInfo("Energy input tier multiplies output further")
                 .addInfo("Output multiplier is equal to: 2*tier^2 - 2*tier + 5")
                 .addPollutionAmount(getPollutionPerSecond(null)).addSeparator().beginStructureBlock(3, 3, 3, true)
+                .addController("Front center").addCasingInfoMin(mCasingName, 8, false).addInputBus("Any casing", 1)
                 .addStructureInfo(
                         EnumChatFormatting.YELLOW
                                 + "Stocking Input Busses and Crafting Input Busses/Buffers are not allowed!")
-                .addController("Front center").addCasingInfoMin(mCasingName, 8, false).addInputBus("Any casing", 1)
                 .addOutputBus("Any casing", 1).addEnergyHatch("Any casing", 1).addMaintenanceHatch("Any casing", 1)
                 .addMufflerHatch("Any casing", 1).toolTipFinisher(CORE.GT_Tooltip_Builder.get());
         return tt;

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/GregtechMetaTileEntityTreeFarm.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/GregtechMetaTileEntityTreeFarm.java
@@ -25,6 +25,7 @@ import net.minecraft.init.Items;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemShears;
 import net.minecraft.item.ItemStack;
+import net.minecraft.util.EnumChatFormatting;
 import net.minecraftforge.fluids.FluidStack;
 
 import com.gtnewhorizon.structurelib.alignment.constructable.ISurvivalConstructable;
@@ -110,6 +111,9 @@ public class GregtechMetaTileEntityTreeFarm extends GregtechMeta_MultiBlockBase<
                 .addInfo("Work time is fixed at 5 seconds").addInfo("Energy input tier multiplies output further")
                 .addInfo("Output multiplier is equal to: 2*tier^2 - 2*tier + 5")
                 .addPollutionAmount(getPollutionPerSecond(null)).addSeparator().beginStructureBlock(3, 3, 3, true)
+                .addStructureInfo(
+                        EnumChatFormatting.YELLOW
+                                + "Stocking Input Busses and Crafting Input Busses/Buffers are not allowed!")
                 .addController("Front center").addCasingInfoMin(mCasingName, 8, false).addInputBus("Any casing", 1)
                 .addOutputBus("Any casing", 1).addEnergyHatch("Any casing", 1).addMaintenanceHatch("Any casing", 1)
                 .addMufflerHatch("Any casing", 1).toolTipFinisher(CORE.GT_Tooltip_Builder.get());
@@ -138,16 +142,14 @@ public class GregtechMetaTileEntityTreeFarm extends GregtechMeta_MultiBlockBase<
     }
 
     @Override
-    public boolean checkHatch() {
+    public boolean addInputBusToMachineList(IGregTechTileEntity aTileEntity, int aBaseCasingIndex) {
         // Tools from a stocking inout bus can not be damaged, this would cause an infinite durability exploit.
         // Therefore disallow ME input bus.
-        if (!super.checkHatch()) return false;
-        for (GT_MetaTileEntity_Hatch_InputBus inputBus : mInputBusses) {
-            if (inputBus instanceof GT_MetaTileEntity_Hatch_InputBus_ME) {
-                return false;
-            }
-        }
-        return true;
+        if (aTileEntity == null) return false;
+        IMetaTileEntity aMetaTileEntity = aTileEntity.getMetaTileEntity();
+        if (aMetaTileEntity == null) return false;
+        if (aMetaTileEntity instanceof GT_MetaTileEntity_Hatch_InputBus_ME) return false;
+        return super.addInputBusToMachineList(aTileEntity, aBaseCasingIndex);
     }
 
     @Override


### PR DESCRIPTION
After https://github.com/GTNewHorizons/GTplusplus/pull/839 Stocking Input Busses will update their textures on TGS though TGS will not form. This pr fixes it and adds a warning text.