### PR TITLE
Fix recipe loop.

### DIFF
--- a/src/main/java/gtPlusPlus/xmod/gregtech/loaders/recipe/RecipeLoader_Nuclear.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/loaders/recipe/RecipeLoader_Nuclear.java
@@ -205,14 +205,6 @@ public class RecipeLoader_Nuclear {
                 600 * 20);
 
         GT_Values.RA.addChemicalRecipe(
-                ItemUtils.getItemStackOfAmountFromOreDict("dustLithium7", 1),
-                null,
-                FluidUtils.getFluidStack("sulfuricacid", 144 * 8),
-                FluidUtils.getFluidStack("sulfuriclithium", 144 * 2),
-                ItemUtils.getItemStackOfAmountFromOreDict("dustSmallLithium7", 1),
-                20 * 20);
-
-        GT_Values.RA.addChemicalRecipe(
                 ItemUtils.getItemStackOfAmountFromOreDict("cellOxygen", 1),
                 ItemUtils.getItemStackOfAmountFromOreDict("dustLithium7", 16),
                 FluidUtils.getFluidStack("water", 1000),


### PR DESCRIPTION
Fixes https://github.com/GTNewHorizons/Dupes-Exploits-GTNH/issues/114 by removing the chemical reactor/LCR recipe.

As far as I can tell, the only use of Sulfuric Lithium is as a byproduct of some ore processing recipes. Therefore it does not make sense for it to be synthesizable. But if anybody knows of other uses that are not in NEI, that this change breaks, please comment so the recipe quantities can be adjusted instead.