### PR TITLE
Remove unwanted trivial cbd recipe

### DIFF
--- a/src/main/java/gtPlusPlus/core/item/chemistry/CoalTar.java
+++ b/src/main/java/gtPlusPlus/core/item/chemistry/CoalTar.java
@@ -11,7 +11,6 @@ import net.minecraftforge.fluids.Fluid;
 import net.minecraftforge.fluids.FluidStack;
 
 import gregtech.api.enums.GT_Values;
-import gregtech.api.enums.ItemList;
 import gregtech.api.enums.Materials;
 import gregtech.api.enums.OrePrefixes;
 import gregtech.api.util.GT_OreDictUnificator;
@@ -36,18 +35,6 @@ public class CoalTar extends ItemPackage {
     public static Fluid Coal_Tar_Oil;
     public static Fluid Sulfuric_Coal_Tar_Oil;
     public static Fluid Naphthalene;
-
-    private static void recipeEthylBenzineFuelsIntoHeavyFuel() {
-        GT_Values.RA.stdBuilder().itemInputs(Materials.Fuel.getCells(9))
-                .fluidInputs(FluidUtils.getFluidStack(Ethylbenzene, 2000)).itemOutputs(ItemList.Cell_Empty.get(9L))
-                .fluidOutputs(Materials.NitroFuel.getFluid(7500)).duration(5 * SECONDS).eut(1000).noOptimize()
-                .addTo(UniversalChemical);
-
-        GT_Values.RA.stdBuilder().itemInputs(Materials.BioDiesel.getCells(9))
-                .fluidInputs(FluidUtils.getFluidStack(Ethylbenzene, 4000)).itemOutputs(ItemList.Cell_Empty.get(9L))
-                .fluidOutputs(Materials.NitroFuel.getFluid(6000)).duration(5 * SECONDS).eut(1000).noOptimize()
-                .addTo(UniversalChemical);
-    }
 
     public static void recipeCreateEthylene() {
 
@@ -217,8 +204,6 @@ public class CoalTar extends ItemPackage {
         recipeCoalTarOilToSulfuricOilToNaphthalene();
         recipeNaphthaleneToPhthalicAcid();
         recipePhthalicAcidToPhthalicAnhydride();
-
-        recipeEthylBenzineFuelsIntoHeavyFuel();
 
         // Burn the coal gas!
         GT_Values.RA.addFuel(ItemUtils.getItemStackOfAmountFromOreDict("cellCoalGas", 1), null, 96, 1);


### PR DESCRIPTION
These recipes were disabled in config but that broke due to the changes here https://github.com/GTNewHorizons/GTplusplus/pull/842.

Disabling was done by dream here https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/commit/d0f746771dc9918ef14324e381037b44dc26911f

Better to remove them properly.

Fixes https://discord.com/channels/181078474394566657/603348502637969419/1227399422363697252