### PR TITLE
Fix Thermal Boiler accepting energy hatches.

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,5 +1,5 @@
 dependencies {
-    api('com.github.GTNewHorizons:GT5-Unofficial:5.09.45.153:dev')
+    api('com.github.GTNewHorizons:GT5-Unofficial:5.09.45.155:dev')
     api("com.github.GTNewHorizons:bartworks:0.9.21:dev")
 
     implementation('curse.maven:cofh-core-69162:2388751')

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/GT4Entity_ThermalBoiler.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/GT4Entity_ThermalBoiler.java
@@ -3,7 +3,6 @@ package gtPlusPlus.xmod.gregtech.common.tileentities.machines.multi.production;
 import static com.gtnewhorizon.structurelib.structure.StructureUtility.ofBlock;
 import static com.gtnewhorizon.structurelib.structure.StructureUtility.onElementPass;
 import static com.gtnewhorizon.structurelib.structure.StructureUtility.transpose;
-import static gregtech.api.enums.GT_HatchElement.Energy;
 import static gregtech.api.enums.GT_HatchElement.InputBus;
 import static gregtech.api.enums.GT_HatchElement.InputHatch;
 import static gregtech.api.enums.GT_HatchElement.Maintenance;
@@ -313,7 +312,7 @@ public class GT4Entity_ThermalBoiler extends GregtechMeta_MultiBlockBase<GT4Enti
                     .addElement(
                             'C',
                             buildHatchAdder(GT4Entity_ThermalBoiler.class)
-                                    .atLeast(InputBus, OutputBus, InputHatch, OutputHatch, Maintenance, Energy, Muffler)
+                                    .atLeast(InputBus, OutputBus, InputHatch, OutputHatch, Maintenance, Muffler)
                                     .casingIndex(TAE.getIndexFromPage(0, 1)).dot(1).buildAndChain(
                                             onElementPass(x -> ++x.mCasing, ofBlock(ModBlocks.blockCasings2Misc, 11))))
                     .build();


### PR DESCRIPTION
Makes the Thermal Boiler not form with an energy hatch. It is a boiler, it does not need energy. This subsequently prevents it from trying to overclock and generate incorrect amounts of steam. Mentioned here: https://discord.com/channels/181078474394566657/603348502637969419/1230902328203280435, thanks to @Reflex18 for the report.