### PR TITLE
Downtier dehydrator multiblock from ZPM to LuV

### DIFF
--- a/src/main/java/gtPlusPlus/core/recipe/RECIPES_Machines.java
+++ b/src/main/java/gtPlusPlus/core/recipe/RECIPES_Machines.java
@@ -2760,7 +2760,7 @@ public class RECIPES_Machines {
 
         CORE.RA.addSixSlotAssemblingRecipe(
                 new ItemStack[] { GregtechItemList.Casing_Vacuum_Furnace.get(1),
-                        CI.getTieredComponent(OrePrefixes.wireGt16, 6, 4), CI.getEnergyCore(6, 1), CI.getRobotArm(4, 4),
+                        CI.getTieredComponent(OrePrefixes.wireGt16, 6, 4), CI.getEnergyCore(5, 1), CI.getRobotArm(4, 4),
                         CI.getTieredComponent(OrePrefixes.plate, 6, 8),
                         CI.getTieredComponent(OrePrefixes.circuit, 6, 8), },
                 CI.getTieredFluid(6, (144 * 4 * 5)), // Input Fluid

--- a/src/main/java/gtPlusPlus/core/recipe/RECIPES_Machines.java
+++ b/src/main/java/gtPlusPlus/core/recipe/RECIPES_Machines.java
@@ -2760,7 +2760,7 @@ public class RECIPES_Machines {
 
         CORE.RA.addSixSlotAssemblingRecipe(
                 new ItemStack[] { GregtechItemList.Casing_Vacuum_Furnace.get(1),
-                        CI.getTieredComponent(OrePrefixes.wireGt16, 6, 4), CI.getEnergyCore(5, 1), CI.getRobotArm(4, 4),
+                        CI.getTieredComponent(OrePrefixes.wireGt16, 7, 4), CI.getEnergyCore(5, 1), CI.getRobotArm(4, 4),
                         CI.getTieredComponent(OrePrefixes.plate, 6, 8),
                         CI.getTieredComponent(OrePrefixes.circuit, 6, 8), },
                 CI.getTieredFluid(6, (144 * 4 * 5)), // Input Fluid

--- a/src/main/java/gtPlusPlus/core/recipe/RECIPES_Machines.java
+++ b/src/main/java/gtPlusPlus/core/recipe/RECIPES_Machines.java
@@ -2760,13 +2760,13 @@ public class RECIPES_Machines {
 
         CORE.RA.addSixSlotAssemblingRecipe(
                 new ItemStack[] { GregtechItemList.Casing_Vacuum_Furnace.get(1),
-                        CI.getTieredComponent(OrePrefixes.wireGt16, 7, 4), CI.getEnergyCore(6, 1), CI.getRobotArm(4, 4),
-                        CI.getTieredComponent(OrePrefixes.plate, 7, 8),
+                        CI.getTieredComponent(OrePrefixes.wireGt16, 6, 4), CI.getEnergyCore(6, 1), CI.getRobotArm(4, 4),
+                        CI.getTieredComponent(OrePrefixes.plate, 6, 8),
                         CI.getTieredComponent(OrePrefixes.circuit, 6, 8), },
-                CI.getTieredFluid(7, (144 * 4 * 5)), // Input Fluid
+                CI.getTieredFluid(6, (144 * 4 * 5)), // Input Fluid
                 GregtechItemList.Controller_Vacuum_Furnace.get(1),
                 60 * 20 * 12,
-                MaterialUtils.getVoltageForTier(7));
+                MaterialUtils.getVoltageForTier(6));
     }
 
     private static void milling() {


### PR DESCRIPTION
The dehydrator multiblock is currently available in ZPM, forcing you to use singleblocks for your rare earth needs in LuV (samarium, yttrium). Processing arrays are not an option since the singleblock is blacklisted. As discussed briefly in discord, this PR adjusts the recipe so it is instead available in LuV.

Concretely:

- Replaces pikyonium (ZPM ABS alloy) in the controller recipe with zeron-100, consistent with the other GT++ "Tiered" alloys.
- Replaces LuV energy core (requires pikyonium) with IV energy core in controller recipe.

This change gates the multiblock dehydrator behind the LuV energy hatch and LuV assembler.

Attached recipe screenshots (only the top was changed)

![Controller](https://github.com/GTNewHorizons/GTplusplus/assets/26485755/6e66f0c5-c3ab-4507-87ec-e4d81023593f)
![Zeron-100](https://github.com/GTNewHorizons/GTplusplus/assets/26485755/a48d2601-ec3f-475d-8221-14c20c2c21c1)
![Energy core IV](https://github.com/GTNewHorizons/GTplusplus/assets/26485755/b4232f2e-90c6-43a5-a149-c2f35a58d12c)

