### PR TITLE
Fix steam multi bonuses and document them

### DIFF
--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/steam/GregtechMetaTileEntity_SteamCompressor.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/steam/GregtechMetaTileEntity_SteamCompressor.java
@@ -70,7 +70,9 @@ public class GregtechMetaTileEntity_SteamCompressor
     protected GT_Multiblock_Tooltip_Builder createTooltip() {
         GT_Multiblock_Tooltip_Builder tt = new GT_Multiblock_Tooltip_Builder();
         tt.addMachineType(getMachineType()).addInfo("Controller Block for the Steam Compressor")
-                .addInfo("Compresses " + getMaxParallelRecipes() + " things at a time").addSeparator()
+                .addInfo("33.3% faster than using a single block Steam Compressor.")
+                .addInfo("Uses only 66.6% of the steam/s compared to a single block Steam Compressor.")
+                .addInfo("Compresses up to " + getMaxParallelRecipes() + " things at a time").addSeparator()
                 .beginStructureBlock(3, 3, 4, true).addController("Front center")
                 .addCasingInfoMin(mCasingName, 28, false).addOtherStructurePart(TT_steaminputbus, "Any casing", 1)
                 .addOtherStructurePart(TT_steamoutputbus, "Any casing", 1)
@@ -127,6 +129,7 @@ public class GregtechMetaTileEntity_SteamCompressor
         return RecipeMaps.compressorRecipes;
     }
 
+    // note that a basic steam machine has .setEUtDiscount(2F).setSpeedBoost(2F). So these are bonuses.
     @Override
     protected ProcessingLogic createProcessingLogic() {
         return new ProcessingLogic() {
@@ -134,7 +137,7 @@ public class GregtechMetaTileEntity_SteamCompressor
             @Override
             @Nonnull
             protected GT_OverclockCalculator createOverclockCalculator(@NotNull GT_Recipe recipe) {
-                return GT_OverclockCalculator.ofNoOverclock(recipe);
+                return GT_OverclockCalculator.ofNoOverclock(recipe).setEUtDiscount(1.33F).setSpeedBoost(1.5F);
             }
         }.setMaxParallel(getMaxParallelRecipes());
     }

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/steam/GregtechMetaTileEntity_SteamMacerator.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/steam/GregtechMetaTileEntity_SteamMacerator.java
@@ -74,7 +74,9 @@ public class GregtechMetaTileEntity_SteamMacerator
         }
         GT_Multiblock_Tooltip_Builder tt = new GT_Multiblock_Tooltip_Builder();
         tt.addMachineType(getMachineType()).addInfo("Controller Block for the Steam Macerator")
-                .addInfo("Macerates " + getMaxParallelRecipes() + " ores at a time").addSeparator()
+                .addInfo("33.3% faster than using a single block Steam Macerator.")
+                .addInfo("Uses only 66.6% of the steam/s required compared to a single block Steam Macerator.")
+                .addInfo("Macerates up to " + getMaxParallelRecipes() + " things at a time").addSeparator()
                 .beginStructureBlock(3, 3, 3, true).addController("Front center")
                 .addCasingInfoMin(mCasingName, 14, false).addOtherStructurePart(TT_steaminputbus, "Any casing", 1)
                 .addOtherStructurePart(TT_steamoutputbus, "Any casing", 1)
@@ -131,6 +133,7 @@ public class GregtechMetaTileEntity_SteamMacerator
         return RecipeMaps.maceratorRecipes;
     }
 
+    // note that a basic steam machine has .setEUtDiscount(2F).setSpeedBoost(2F). So these are bonuses.
     @Override
     protected ProcessingLogic createProcessingLogic() {
         return new ProcessingLogic() {
@@ -138,7 +141,7 @@ public class GregtechMetaTileEntity_SteamMacerator
             @Override
             @Nonnull
             protected GT_OverclockCalculator createOverclockCalculator(@NotNull GT_Recipe recipe) {
-                return GT_OverclockCalculator.ofNoOverclock(recipe);
+                return GT_OverclockCalculator.ofNoOverclock(recipe).setEUtDiscount(1.33F).setSpeedBoost(1.5F);
             }
 
         }.setMaxParallel(getMaxParallelRecipes());


### PR DESCRIPTION
They were broken by the GPL implementation here https://github.com/GTNewHorizons/GTplusplus/pull/697.

This PR restores the old values and makes them clear in the tooltip.

example calculations:
1 crushed ore in a singleblock (non-HP) steam macerator takes 40 seconds and uses 4L/t steam = 3200 steam total.
The multi macerates 8 crushed ore in 30 seconds for 22L/t steam = 13200 steam total or 1650 steam per ore.
So you get roughly 2x efficiency and more than 10x speed compared to the singleblock.