### PR TITLE
Fix Waila for steam multis

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,5 +1,5 @@
 dependencies {
-    api('com.github.GTNewHorizons:GT5-Unofficial:5.09.45.155:dev')
+    api('com.github.GTNewHorizons:GT5-Unofficial:5.09.45.159:dev')
     api("com.github.GTNewHorizons:bartworks:0.9.21:dev")
 
     implementation('curse.maven:cofh-core-69162:2388751')

--- a/src/main/java/gtPlusPlus/xmod/gregtech/api/metatileentity/implementations/base/GregtechMeta_SteamMultiBase.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/api/metatileentity/implementations/base/GregtechMeta_SteamMultiBase.java
@@ -364,7 +364,7 @@ public abstract class GregtechMeta_SteamMultiBase<T extends GregtechMeta_SteamMu
             int tAverageTime = tag.getInteger("averageNS");
             currentTip.add("Average CPU load of ~" + formatNumbers(tAverageTime) + " ns");
         }
-        super.getOriginalWailaBody(itemStack, currentTip, accessor, config);
+        super.getMTEWailaBody(itemStack, currentTip, accessor, config);
     }
 
     protected static <T extends GregtechMeta_SteamMultiBase<T>> GT_HatchElementBuilder<T> buildSteamInput(

--- a/src/main/java/gtPlusPlus/xmod/gregtech/api/metatileentity/implementations/base/GregtechMeta_SteamMultiBase.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/api/metatileentity/implementations/base/GregtechMeta_SteamMultiBase.java
@@ -3,6 +3,10 @@ package gtPlusPlus.xmod.gregtech.api.metatileentity.implementations.base;
 import static gregtech.api.enums.GT_Values.V;
 import static gregtech.api.util.GT_StructureUtility.buildHatchAdder;
 import static gregtech.api.util.GT_Utility.filterValidMTEs;
+import static gregtech.api.util.GT_Utility.formatNumbers;
+import static mcp.mobius.waila.api.SpecialChars.GREEN;
+import static mcp.mobius.waila.api.SpecialChars.RED;
+import static mcp.mobius.waila.api.SpecialChars.RESET;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -10,10 +14,12 @@ import java.util.List;
 
 import net.minecraft.inventory.IInventory;
 import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.StatCollector;
 import net.minecraftforge.common.util.ForgeDirection;
 import net.minecraftforge.fluids.FluidStack;
 
+import gregtech.GT_Mod;
 import gregtech.api.enums.Textures;
 import gregtech.api.interfaces.IHatchElement;
 import gregtech.api.interfaces.ITexture;
@@ -26,11 +32,14 @@ import gregtech.api.objects.GT_RenderedTexture;
 import gregtech.api.recipe.RecipeMap;
 import gregtech.api.util.GT_HatchElementBuilder;
 import gregtech.api.util.GT_Utility;
+import gregtech.api.util.GT_Waila;
 import gregtech.api.util.IGT_HatchAdder;
 import gregtech.api.util.shutdown.ShutDownReasonRegistry;
 import gtPlusPlus.core.util.minecraft.FluidUtils;
 import gtPlusPlus.xmod.gregtech.api.metatileentity.implementations.GT_MetaTileEntity_Hatch_Steam_BusInput;
 import gtPlusPlus.xmod.gregtech.api.metatileentity.implementations.GT_MetaTileEntity_Hatch_Steam_BusOutput;
+import mcp.mobius.waila.api.IWailaConfigHandler;
+import mcp.mobius.waila.api.IWailaDataAccessor;
 
 public abstract class GregtechMeta_SteamMultiBase<T extends GregtechMeta_SteamMultiBase<T>>
         extends GregtechMeta_MultiBlockBase<T> {
@@ -323,6 +332,39 @@ public abstract class GregtechMeta_SteamMultiBase<T extends GregtechMeta_SteamMu
             }
         }
         return ret;
+    }
+
+    @Override
+    public void getWailaBody(ItemStack itemStack, List<String> currentTip, IWailaDataAccessor accessor,
+            IWailaConfigHandler config) {
+        final NBTTagCompound tag = accessor.getNBTData();
+
+        if (tag.getBoolean("incompleteStructure")) {
+            currentTip.add(RED + "** INCOMPLETE STRUCTURE **" + RESET);
+        }
+        currentTip.add(
+                (tag.getBoolean("hasProblems") ? (RED + "** HAS PROBLEMS **") : GREEN + "Running Fine") + RESET
+                        + "  Efficiency: "
+                        + tag.getFloat("efficiency")
+                        + "%");
+
+        boolean isActive = tag.getBoolean("isActive");
+        if (isActive) {
+            long actualEnergyUsage = tag.getLong("energyUsage");
+            if (actualEnergyUsage > 0) {
+                currentTip.add(
+                        StatCollector
+                                .translateToLocalFormatted("GTPP.waila.steam.use", formatNumbers(actualEnergyUsage)));
+            }
+        }
+        currentTip.add(
+                GT_Waila.getMachineProgressString(isActive, tag.getInteger("maxProgress"), tag.getInteger("progress")));
+        // Show ns on the tooltip
+        if (GT_Mod.gregtechproxy.wailaAverageNS && tag.hasKey("averageNS")) {
+            int tAverageTime = tag.getInteger("averageNS");
+            currentTip.add("Average CPU load of ~" + formatNumbers(tAverageTime) + " ns");
+        }
+        super.getOriginalWailaBody(itemStack, currentTip, accessor, config);
     }
 
     protected static <T extends GregtechMeta_SteamMultiBase<T>> GT_HatchElementBuilder<T> buildSteamInput(

--- a/src/main/resources/assets/gregtech/lang/en_US.lang
+++ b/src/main/resources/assets/gregtech/lang/en_US.lang
@@ -41,6 +41,9 @@ GTPP.multiblock.multimachine.metal=Metal Mode. Does compressor (circuit 20), lat
 GTPP.multiblock.multimachine.fluid=Fluid Mode. Does fermenter (circuit 20), fluid extractor (circuit 21) and extractor (circuit 22).
 GTPP.multiblock.multimachine.misc=Misc. Mode. Does precision laser engraver (circuit 20), autoclave (circuit 21) and fluid solidifier (circuit 22).
 
+
+GTPP.waila.steam.use=Probably uses: §e%s§r L/t Steam
+
 GTPP.CC.machinetier=Control Core Tier
 GTPP.CC.discount=EU Discount
 GTPP.CC.parallel=Maximum Parallel


### PR DESCRIPTION
Just a visual/documentation fix for this:
![image](https://github.com/GTNewHorizons/GTplusplus/assets/40274384/f9397cd3-5453-49f3-8df1-8d646bd0ef5b)

specifically the eu/t is actually a L/t Steam.

now:
![image](https://github.com/GTNewHorizons/GTplusplus/assets/40274384/fe3d13b1-2ea5-4f54-b1e5-cad9c2ff563e)

requires https://github.com/GTNewHorizons/GT5-Unofficial/pull/2584